### PR TITLE
Record Package

### DIFF
--- a/api.go
+++ b/api.go
@@ -5,6 +5,8 @@ package simplex
 
 import (
 	"context"
+	"sniplex/record"
+
 	"go.uber.org/zap"
 )
 
@@ -56,8 +58,8 @@ type Communication interface {
 }
 
 type WriteAheadLog interface {
-	Append(*Record)
-	ReadAll() []Record
+	Append(*record.Record)
+	ReadAll() []record.Record
 }
 
 type Block interface {

--- a/memwal.go
+++ b/memwal.go
@@ -6,17 +6,18 @@ package simplex
 import (
 	"bytes"
 	"fmt"
+	"sniplex/record"
 )
 
 type InMemWAL bytes.Buffer
 
-func (wal *InMemWAL) Append(record *Record) {
+func (wal *InMemWAL) Append(record *record.Record) {
 	w := (*bytes.Buffer)(wal)
 	w.Write(record.Bytes())
 }
 
-func (wal *InMemWAL) ReadAll() []Record {
-	res := make([]Record, 0, 100)
+func (wal *InMemWAL) ReadAll() []record.Record {
+	res := make([]record.Record, 0, 100)
 
 	r := (*bytes.Buffer)(wal)
 	var bytesRead int
@@ -24,7 +25,7 @@ func (wal *InMemWAL) ReadAll() []Record {
 	total := r.Len()
 
 	for bytesRead < total {
-		var record Record
+		var record record.Record
 		n, err := record.FromBytes(r)
 		if err != nil {
 			panic(fmt.Sprintf("failed reading record: %v", err))

--- a/memwal_test.go
+++ b/memwal_test.go
@@ -4,19 +4,21 @@
 package simplex
 
 import (
-	"github.com/stretchr/testify/require"
+	"sniplex/record"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestInMemWAL(t *testing.T) {
-	r1 := Record{
+	r1 := record.Record{
 		Version: 1,
 		Type:    2,
 		Size:    3,
 		Payload: []byte{4, 5, 6},
 	}
 
-	r2 := Record{
+	r2 := record.Record{
 		Version: 7,
 		Type:    8,
 		Size:    3,
@@ -27,5 +29,5 @@ func TestInMemWAL(t *testing.T) {
 	wal.Append(&r1)
 	wal.Append(&r2)
 
-	require.Equal(t, []Record{r1, r2}, wal.ReadAll())
+	require.Equal(t, []record.Record{r1, r2}, wal.ReadAll())
 }

--- a/record/record.go
+++ b/record/record.go
@@ -1,11 +1,12 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package simplex
+package record
 
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"hash/crc64"
 	"io"
@@ -17,9 +18,11 @@ const (
 	recordVersionLen  = 1
 	recordTypeLen     = 2
 
-	errInvalidCRC = "invalid CRC checksum"
-
 	maxBlockSize = 100_000_000 // ~ 100MB
+)
+
+var (
+	ErrInvalidCRC = errors.New("invalid CRC checksum")
 )
 
 type Record struct {
@@ -107,7 +110,7 @@ func (r *Record) FromBytes(in io.Reader) (int, error) {
 	expectedChecksum := crc.Sum(nil)
 
 	if !bytes.Equal(checksum, expectedChecksum) {
-		return 0, fmt.Errorf(errInvalidCRC)
+		return 0, ErrInvalidCRC
 	}
 
 	r.Version = version

--- a/record/record_test.go
+++ b/record/record_test.go
@@ -1,13 +1,14 @@
 // Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package simplex
+package record
 
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecord(t *testing.T) {
@@ -28,7 +29,7 @@ func TestRecord(t *testing.T) {
 	// Corrupt the CRC of the buffer
 	copy(buff[len(buff)-8:], []byte{0, 1, 2, 3, 4, 5, 6, 7})
 	_, err = r2.FromBytes(bytes.NewBuffer(buff))
-	require.EqualError(t, err, errInvalidCRC)
+	require.ErrorIs(t, err, ErrInvalidCRC)
 }
 
 func FuzzRecord(f *testing.F) {
@@ -63,6 +64,6 @@ func FuzzRecord(f *testing.F) {
 		copy(buff[len(buff)-8:], crc)
 
 		_, err = r2.FromBytes(bytes.NewBuffer(buff))
-		require.EqualError(t, err, errInvalidCRC)
+		require.ErrorIs(t, err, ErrInvalidCRC)
 	})
 }


### PR DESCRIPTION
Separates the record package to avoid cyclical dependencies with the WAL. 

Also fixes a nit i noticed while doing so. 