### PR TITLE
Separate Notarization/Finalization

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -1036,11 +1036,11 @@ func (e *Epoch) doNotarized(r uint64) error {
 	md := block.BlockHeader()
 
 	f := ToBeSignedFinalization{BlockHeader: md}
-	e.Logger.Info("Signing finalization", zap.Stringer("digest", md.Digest), zap.Stringer("signer", e.ID))
 	signature, err := f.Sign(e.Signer)
 	if err != nil {
 		return fmt.Errorf("failed signing vote %w", err)
 	}
+
 	sf := Finalization{
 		Signature: Signature{
 			Signer: e.ID,

--- a/epoch.go
+++ b/epoch.go
@@ -495,28 +495,6 @@ func (e *Epoch) maybeCollectFinalizationCertificate(round *Round) error {
 	return e.assembleFinalizationCertificate(round)
 }
 
-func (e *Epoch) NewFinalizationCertificate(finalizations []*Finalization) (FinalizationCertificate, error) {
-	voteCount := len(finalizations)
-
-	signatures := make([]Signature, 0, voteCount)
-	e.Logger.Info("Collected Quorum of votes", zap.Uint64("round", e.round), zap.Int("votes", voteCount))
-	for _, vote := range finalizations {
-		// TODO: ensure all finalizations agree on the same metadata!
-		e.Logger.Debug("Collected finalization from node", zap.Stringer("NodeID", vote.Signature.Signer))
-		signatures = append(signatures, vote.Signature)
-	}
-
-	var fCert FinalizationCertificate
-	var err error
-	fCert.Finalization = finalizations[0].Finalization
-	fCert.QC, err = e.SignatureAggregator.Aggregate(signatures)
-	if err != nil {
-		return FinalizationCertificate{}, fmt.Errorf("could not aggregate signatures for finalization certificate: %w", err)
-	}
-
-	return fCert, nil
-}
-
 func (e *Epoch) assembleFinalizationCertificate(round *Round) error {
 	// Divide finalizations into sets that agree on the same metadata
 	finalizationsByMD := make(map[string][]*Finalization)
@@ -540,7 +518,7 @@ func (e *Epoch) assembleFinalizationCertificate(round *Round) error {
 		return nil
 	}
 
-	fCert, err := e.NewFinalizationCertificate(finalizations)
+	fCert, err := NewFinalizationCertificate(e.Logger, e.SignatureAggregator, finalizations)
 	if err != nil {
 		return err
 	}
@@ -623,43 +601,12 @@ func (e *Epoch) maybeCollectNotarization() error {
 		return nil
 	}
 
-	notarization, err := e.NewNotarization(votesForCurrentRound, expectedDigest)
+	notarization, err := NewNotarization(e.Logger, e.SignatureAggregator, votesForCurrentRound, block.BlockHeader())
 	if err != nil {
 		return err
 	}
 
 	return e.persistNotarization(notarization)
-}
-
-func (e *Epoch) NewNotarization(votesForCurrentRound map[string]*Vote, digest [metadataDigestLen]byte) (Notarization, error) {
-	vote := ToBeSignedVote{
-		BlockHeader{
-			ProtocolMetadata: ProtocolMetadata{
-				Epoch: e.Epoch,
-				Round: e.round,
-			},
-			Digest: digest,
-		},
-	}
-
-	voteCount := len(votesForCurrentRound)
-
-	signatures := make([]Signature, 0, voteCount)
-	e.Logger.Info("Collected Quorum of votes", zap.Uint64("round", e.round), zap.Int("votes", voteCount))
-	for _, vote := range votesForCurrentRound {
-		e.Logger.Debug("Collected vote from node", zap.Stringer("NodeID", vote.Signature.Signer))
-		signatures = append(signatures, vote.Signature)
-	}
-
-	var notarization Notarization
-	var err error
-	notarization.Vote = vote
-	notarization.QC, err = e.SignatureAggregator.Aggregate(signatures)
-	if err != nil {
-		return Notarization{}, fmt.Errorf("could not aggregate signatures for notarization: %w", err)
-	}
-
-	return notarization, nil
 }
 
 func (e *Epoch) persistNotarization(notarization Notarization) error {
@@ -1089,11 +1036,11 @@ func (e *Epoch) doNotarized(r uint64) error {
 	md := block.BlockHeader()
 
 	f := ToBeSignedFinalization{BlockHeader: md}
+	e.Logger.Info("Signing finalization", zap.Stringer("digest", md.Digest), zap.Stringer("signer", e.ID))
 	signature, err := f.Sign(e.Signer)
 	if err != nil {
 		return fmt.Errorf("failed signing vote %w", err)
 	}
-
 	sf := Finalization{
 		Signature: Signature{
 			Signer: e.ID,

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -123,7 +123,7 @@ func injectTestVote(t *testing.T, e *Epoch, block Block, id NodeID, signer Signe
 	require.NoError(t, err)
 }
 
-func newTestFinalization(t *testing.T, block *testBlock, id NodeID, signer Signer) *Finalization {
+func newTestFinalization(t *testing.T, block Block, id NodeID, signer Signer) *Finalization {
 	f := ToBeSignedFinalization{BlockHeader: block.BlockHeader()}
 	sig, err := f.Sign(signer)
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func newTestFinalization(t *testing.T, block *testBlock, id NodeID, signer Signe
 	}
 }
 
-func injectTestFinalization(t *testing.T, e *Epoch, block *testBlock, id NodeID, signer Signer) {
+func injectTestFinalization(t *testing.T, e *Epoch, block Block, id NodeID, signer Signer) {
 	err := e.HandleMessage(&Message{
 		Finalization: newTestFinalization(t, block, id, signer),
 	}, id)

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -169,10 +169,11 @@ func (t *testQCDeserializer) DeserializeQuorumCertificate(bytes []byte) (QuorumC
 }
 
 type testSignatureAggregator struct {
+	err error
 }
 
 func (t *testSignatureAggregator) Aggregate(signatures []Signature) (QuorumCertificate, error) {
-	return testQC(signatures), nil
+	return testQC(signatures), t.err
 }
 
 type testQC []Signature

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -79,7 +79,6 @@ func TestEpochSimpleFlow(t *testing.T) {
 
 		for i := 1; i < quorum; i++ {
 			injectTestFinalization(t, e, block, nodes[i], conf.Signer)
-
 		}
 
 		committedData := storage.data[i].Block.Bytes()

--- a/notarization.go
+++ b/notarization.go
@@ -1,0 +1,80 @@
+package simplex
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"slices"
+
+	"go.uber.org/zap"
+)
+
+var ErrorInvalidFinalizationDigest = errors.New("finalization digests do not match")
+
+// NewNotarization builds a Notarization for a block described by [blockHeader] from [votesForCurrentRound].
+func NewNotarization(logger Logger, signatureAggregator SignatureAggregator, votesForCurrentRound map[string]*Vote, blockHeader BlockHeader) (Notarization, error) {
+	vote := ToBeSignedVote{
+		BlockHeader{
+			ProtocolMetadata: ProtocolMetadata{
+				Epoch: blockHeader.Epoch,
+				Round: blockHeader.Round,
+			},
+			Digest: blockHeader.Digest,
+		},
+	}
+
+	voteCount := len(votesForCurrentRound)
+
+	signatures := make([]Signature, 0, voteCount)
+	logger.Info("Collected Quorum of votes", zap.Uint64("round", blockHeader.Round), zap.Int("votes", voteCount))
+	for _, vote := range votesForCurrentRound {
+		logger.Debug("Collected vote from node", zap.Stringer("NodeID", vote.Signature.Signer))
+		signatures = append(signatures, vote.Signature)
+	}
+
+	// sort the signatures by Signer to ensure consistent ordering
+	slices.SortFunc(signatures, compareSignatures)
+
+	var notarization Notarization
+	var err error
+	notarization.Vote = vote
+	notarization.QC, err = signatureAggregator.Aggregate(signatures)
+	if err != nil {
+		return Notarization{}, fmt.Errorf("could not aggregate signatures for notarization: %w", err)
+	}
+
+	return notarization, nil
+}
+
+// NewFinalizationCertificate builds a FinalizationCertificate from [finalizations].
+func NewFinalizationCertificate(logger Logger, signatureAggregator SignatureAggregator, finalizations []*Finalization) (FinalizationCertificate, error) {
+	voteCount := len(finalizations)
+
+	signatures := make([]Signature, 0, voteCount)
+	expectedDigest := finalizations[0].Finalization.Digest
+	for _, vote := range finalizations {
+		if vote.Finalization.Digest != expectedDigest {
+			return FinalizationCertificate{}, ErrorInvalidFinalizationDigest
+		}
+		logger.Debug("Collected finalization from node", zap.Stringer("NodeID", vote.Signature.Signer))
+		signatures = append(signatures, vote.Signature)
+	}
+
+	// sort the signatures, as they are not guaranteed to be in the same order
+	slices.SortFunc(signatures, compareSignatures)
+
+	var fCert FinalizationCertificate
+	var err error
+	fCert.Finalization = finalizations[0].Finalization
+	fCert.QC, err = signatureAggregator.Aggregate(signatures)
+	if err != nil {
+		return FinalizationCertificate{}, fmt.Errorf("could not aggregate signatures for finalization certificate: %w", err)
+	}
+
+	return fCert, nil
+}
+
+// compareSignatures compares two signatures by their Signer field returning -1, 0, 1 if i is less than, equal to, or greater than j.
+func compareSignatures(i, j Signature) int {
+	return bytes.Compare(i.Signer, j.Signer)
+}

--- a/notarization.go
+++ b/notarization.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package simplex
 
 import (

--- a/notarization_test.go
+++ b/notarization_test.go
@@ -42,6 +42,13 @@ func TestNewNotarization(t *testing.T) {
 			expectError:         nil,
 		},
 		{
+			name:                 "no votes",
+			votesForCurrentRound: map[string]*simplex.Vote{},
+			block:                testBlock,
+			signatureAggregator:  &testSignatureAggregator{},
+			expectError:          simplex.ErrorNoVotes,
+		},
+		{
 			name: "error aggregating",
 			votesForCurrentRound: func() map[string]*simplex.Vote {
 				votes := make(map[string]*simplex.Vote)
@@ -54,7 +61,7 @@ func TestNewNotarization(t *testing.T) {
 				return votes
 			}(),
 			block:               testBlock,
-			signatureAggregator: &alwaysErrorSignatureAggregator{},
+			signatureAggregator: &testSignatureAggregator{err: errorSigAggregation},
 			expectError:         errorSigAggregation,
 		},
 	}
@@ -125,8 +132,14 @@ func TestNewFinalizationCertificate(t *testing.T) {
 			finalizations: []*simplex.Finalization{
 				newTestFinalization(t, &testBlock{}, []byte{1}, signer),
 			},
-			signatureAggregator: &alwaysErrorSignatureAggregator{},
+			signatureAggregator: &testSignatureAggregator{err: errorSigAggregation},
 			expectError:         errorSigAggregation,
+		},
+		{
+			name:                "no votes",
+			finalizations:       []*simplex.Finalization{},
+			signatureAggregator: &testSignatureAggregator{},
+			expectError:         simplex.ErrorNoVotes,
 		},
 	}
 
@@ -148,10 +161,4 @@ func TestNewFinalizationCertificate(t *testing.T) {
 			}
 		})
 	}
-}
-
-type alwaysErrorSignatureAggregator struct{}
-
-func (t *alwaysErrorSignatureAggregator) Aggregate(signatures []simplex.Signature) (simplex.QuorumCertificate, error) {
-	return nil, errorSigAggregation
 }

--- a/notarization_test.go
+++ b/notarization_test.go
@@ -147,8 +147,7 @@ func TestNewFinalizationCertificate(t *testing.T) {
 	}
 }
 
-type alwaysErrorSignatureAggregator struct {
-}
+type alwaysErrorSignatureAggregator struct{}
 
 func (t *alwaysErrorSignatureAggregator) Aggregate(signatures []simplex.Signature) (simplex.QuorumCertificate, error) {
 	return nil, errorSigAggregation

--- a/notarization_test.go
+++ b/notarization_test.go
@@ -1,0 +1,155 @@
+package simplex_test
+
+import (
+	"bytes"
+	"errors"
+	"simplex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var errorSigAggregation = errors.New("signature error")
+
+func TestNewNotarization(t *testing.T) {
+	l := makeLogger(t, 1)
+	testBlock := &testBlock{}
+	testSigner := &testSigner{}
+	tests := []struct {
+		name                 string
+		votesForCurrentRound map[string]*simplex.Vote
+		block                simplex.Block
+		expectError          error
+		signatureAggregator  simplex.SignatureAggregator
+	}{
+		{
+			name: "valid notarization",
+			votesForCurrentRound: func() map[string]*simplex.Vote {
+				votes := make(map[string]*simplex.Vote)
+				nodeIds := [][]byte{{1}, {2}, {3}, {4}, {5}}
+				for _, nodeId := range nodeIds {
+					vote, err := newVote(testBlock, nodeId, testSigner)
+					require.NoError(t, err)
+					votes[string(nodeId)] = vote
+				}
+				return votes
+			}(),
+			block:               testBlock,
+			signatureAggregator: &testSignatureAggregator{},
+			expectError:         nil,
+		},
+		{
+			name: "error aggregating",
+			votesForCurrentRound: func() map[string]*simplex.Vote {
+				votes := make(map[string]*simplex.Vote)
+				nodeIds := [][]byte{{1}, {2}, {3}, {4}, {5}}
+				for _, nodeId := range nodeIds {
+					vote, err := newVote(testBlock, nodeId, testSigner)
+					require.NoError(t, err)
+					votes[string(nodeId)] = vote
+				}
+				return votes
+			}(),
+			block:               testBlock,
+			signatureAggregator: &alwaysErrorSignatureAggregator{},
+			expectError:         errorSigAggregation,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notarization, err := simplex.NewNotarization(l, tt.signatureAggregator, tt.votesForCurrentRound, tt.block.BlockHeader())
+			require.ErrorIs(t, err, tt.expectError, "expected error, got nil")
+
+			if tt.expectError == nil {
+				signers := notarization.QC.Signers()
+				require.Equal(t, len(signers), len(tt.votesForCurrentRound), "incorrect amount of signers")
+
+				for i, signer := range signers[1:] {
+					require.Negative(t, bytes.Compare(signers[i], signer), "signers not in order")
+				}
+			}
+		})
+	}
+
+}
+
+func TestNewFinalizationCertificate(t *testing.T) {
+	l := makeLogger(t, 1)
+	signer := &testSigner{}
+	tests := []struct {
+		name                 string
+		finalizations        []*simplex.Finalization
+		signatureAggregator  simplex.SignatureAggregator
+		expectedFinalization *simplex.ToBeSignedFinalization
+		expectedQC           *simplex.QuorumCertificate
+		expectError          error
+	}{
+		{
+			name: "valid finalizations in order",
+			finalizations: []*simplex.Finalization{
+				newFinalization(t, &testBlock{}, []byte{1}, signer),
+				newFinalization(t, &testBlock{}, []byte{2}, signer),
+				newFinalization(t, &testBlock{}, []byte{3}, signer),
+			},
+			signatureAggregator:  &testSignatureAggregator{},
+			expectedFinalization: &newFinalization(t, &testBlock{}, []byte{1}, signer).Finalization,
+			expectError:          nil,
+		},
+		{
+			name: "unsorted finalizations",
+			finalizations: []*simplex.Finalization{
+				newFinalization(t, &testBlock{}, []byte{3}, signer),
+				newFinalization(t, &testBlock{}, []byte{1}, signer),
+				newFinalization(t, &testBlock{}, []byte{2}, signer),
+			},
+			signatureAggregator:  &testSignatureAggregator{},
+			expectedFinalization: &newFinalization(t, &testBlock{}, []byte{1}, signer).Finalization,
+			expectError:          nil,
+		},
+		{
+			name: "finalizations with different digests",
+			finalizations: []*simplex.Finalization{
+				newFinalization(t, &testBlock{digest: [32]byte{1}}, []byte{1}, signer),
+				newFinalization(t, &testBlock{digest: [32]byte{2}}, []byte{2}, signer),
+				newFinalization(t, &testBlock{digest: [32]byte{3}}, []byte{3}, signer),
+			},
+			signatureAggregator: &testSignatureAggregator{},
+			expectError:         simplex.ErrorInvalidFinalizationDigest,
+		},
+		{
+			name: "signature aggregator errors",
+			finalizations: []*simplex.Finalization{
+				newFinalization(t, &testBlock{}, []byte{1}, signer),
+			},
+			signatureAggregator: &alwaysErrorSignatureAggregator{},
+			expectError:         errorSigAggregation,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fCert, err := simplex.NewFinalizationCertificate(l, tt.signatureAggregator, tt.finalizations)
+			require.ErrorIs(t, err, tt.expectError, "expected error, got nil")
+
+			if tt.expectError == nil {
+				require.Equal(t, fCert.Finalization.Digest, tt.expectedFinalization.Digest, "digests not correct")
+
+				signers := fCert.QC.Signers()
+				require.Equal(t, len(signers), len(tt.finalizations), "unexpected amount of signers")
+
+				// ensure the qc signers are in order
+				for i, signer := range signers[1:] {
+					require.Negative(t, bytes.Compare(signers[i], signer), "signers not in order")
+				}
+			}
+		})
+	}
+}
+
+type alwaysErrorSignatureAggregator struct {
+}
+
+func (t *alwaysErrorSignatureAggregator) Aggregate(signatures []simplex.Signature) (simplex.QuorumCertificate, error) {
+	return nil, errorSigAggregation
+}

--- a/notarization_test.go
+++ b/notarization_test.go
@@ -28,7 +28,7 @@ func TestNewNotarization(t *testing.T) {
 				votes := make(map[string]*simplex.Vote)
 				nodeIds := [][]byte{{1}, {2}, {3}, {4}, {5}}
 				for _, nodeId := range nodeIds {
-					vote, err := newVote(testBlock, nodeId, testSigner)
+					vote, err := newTestVote(testBlock, nodeId, testSigner)
 					require.NoError(t, err)
 					votes[string(nodeId)] = vote
 				}
@@ -44,7 +44,7 @@ func TestNewNotarization(t *testing.T) {
 				votes := make(map[string]*simplex.Vote)
 				nodeIds := [][]byte{{1}, {2}, {3}, {4}, {5}}
 				for _, nodeId := range nodeIds {
-					vote, err := newVote(testBlock, nodeId, testSigner)
+					vote, err := newTestVote(testBlock, nodeId, testSigner)
 					require.NoError(t, err)
 					votes[string(nodeId)] = vote
 				}
@@ -88,31 +88,31 @@ func TestNewFinalizationCertificate(t *testing.T) {
 		{
 			name: "valid finalizations in order",
 			finalizations: []*simplex.Finalization{
-				newFinalization(t, &testBlock{}, []byte{1}, signer),
-				newFinalization(t, &testBlock{}, []byte{2}, signer),
-				newFinalization(t, &testBlock{}, []byte{3}, signer),
+				newTestFinalization(t, &testBlock{}, []byte{1}, signer),
+				newTestFinalization(t, &testBlock{}, []byte{2}, signer),
+				newTestFinalization(t, &testBlock{}, []byte{3}, signer),
 			},
 			signatureAggregator:  &testSignatureAggregator{},
-			expectedFinalization: &newFinalization(t, &testBlock{}, []byte{1}, signer).Finalization,
+			expectedFinalization: &newTestFinalization(t, &testBlock{}, []byte{1}, signer).Finalization,
 			expectError:          nil,
 		},
 		{
 			name: "unsorted finalizations",
 			finalizations: []*simplex.Finalization{
-				newFinalization(t, &testBlock{}, []byte{3}, signer),
-				newFinalization(t, &testBlock{}, []byte{1}, signer),
-				newFinalization(t, &testBlock{}, []byte{2}, signer),
+				newTestFinalization(t, &testBlock{}, []byte{3}, signer),
+				newTestFinalization(t, &testBlock{}, []byte{1}, signer),
+				newTestFinalization(t, &testBlock{}, []byte{2}, signer),
 			},
 			signatureAggregator:  &testSignatureAggregator{},
-			expectedFinalization: &newFinalization(t, &testBlock{}, []byte{1}, signer).Finalization,
+			expectedFinalization: &newTestFinalization(t, &testBlock{}, []byte{1}, signer).Finalization,
 			expectError:          nil,
 		},
 		{
 			name: "finalizations with different digests",
 			finalizations: []*simplex.Finalization{
-				newFinalization(t, &testBlock{digest: [32]byte{1}}, []byte{1}, signer),
-				newFinalization(t, &testBlock{digest: [32]byte{2}}, []byte{2}, signer),
-				newFinalization(t, &testBlock{digest: [32]byte{3}}, []byte{3}, signer),
+				newTestFinalization(t, &testBlock{digest: [32]byte{1}}, []byte{1}, signer),
+				newTestFinalization(t, &testBlock{digest: [32]byte{2}}, []byte{2}, signer),
+				newTestFinalization(t, &testBlock{digest: [32]byte{3}}, []byte{3}, signer),
 			},
 			signatureAggregator: &testSignatureAggregator{},
 			expectError:         simplex.ErrorInvalidFinalizationDigest,
@@ -120,7 +120,7 @@ func TestNewFinalizationCertificate(t *testing.T) {
 		{
 			name: "signature aggregator errors",
 			finalizations: []*simplex.Finalization{
-				newFinalization(t, &testBlock{}, []byte{1}, signer),
+				newTestFinalization(t, &testBlock{}, []byte{1}, signer),
 			},
 			signatureAggregator: &alwaysErrorSignatureAggregator{},
 			expectError:         errorSigAggregation,

--- a/notarization_test.go
+++ b/notarization_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package simplex_test
 
 import (

--- a/record_test.go
+++ b/record_test.go
@@ -4,12 +4,14 @@
 package simplex_test
 
 import (
-	"fmt"
 	"simplex"
 	"simplex/record"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
-func newNotarizationRecord(signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID, signer simplex.Signer) ([]byte, error) {
+func newNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID, signer simplex.Signer) ([]byte, error) {
 	votesForCurrentRound := make(map[string]*simplex.Vote)
 	for _, id := range ids {
 		testBlock := block.(*testBlock)
@@ -20,7 +22,7 @@ func newNotarizationRecord(signatureAggregator simplex.SignatureAggregator, bloc
 		votesForCurrentRound[string(id)] = vote
 	}
 
-	notarization, err := newNotarization(signatureAggregator, votesForCurrentRound, block)
+	notarization, err := simplex.NewNotarization(logger, signatureAggregator, votesForCurrentRound, block.BlockHeader())
 	if err != nil {
 		return nil, err
 	}
@@ -30,69 +32,17 @@ func newNotarizationRecord(signatureAggregator simplex.SignatureAggregator, bloc
 	return record, nil
 }
 
-func newNotarization(signatureAggregator simplex.SignatureAggregator, votesForCurrentRound map[string]*simplex.Vote, block simplex.Block) (simplex.Notarization, error) {
-	vote := simplex.ToBeSignedVote{
-		simplex.BlockHeader{
-			ProtocolMetadata: simplex.ProtocolMetadata{
-				Epoch: block.BlockHeader().Epoch,
-				Round: block.BlockHeader().Round,
-			},
-			Digest: block.BlockHeader().Digest,
-		},
-	}
-
-	voteCount := len(votesForCurrentRound)
-
-	signatures := make([]simplex.Signature, 0, voteCount)
-	for _, vote := range votesForCurrentRound {
-		signatures = append(signatures, vote.Signature)
-	}
-
-	var notarization simplex.Notarization
-	var err error
-	notarization.Vote = vote
-	notarization.QC, err = signatureAggregator.Aggregate(signatures)
-	if err != nil {
-		return simplex.Notarization{}, fmt.Errorf("could not aggregate signatures for notarization: %w", err)
-	}
-
-	return notarization, nil
-}
-
 // creates a new finalization certificate
-func newFinalizationRecord(signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID) (simplex.FinalizationCertificate, []byte, error) {
+func newFinalizationRecord(t *testing.T, logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID, signer simplex.Signer) (simplex.FinalizationCertificate, []byte) {
 	finalizations := make([]*simplex.Finalization, len(ids))
 	for i, id := range ids {
 		testBlock := block.(*testBlock)
-		finalizations[i] = newFinalization(testBlock, id)
+		finalizations[i] = newFinalization(t, testBlock, id, signer)
 	}
-
-	fCert, err := newFinalizationCertificate(signatureAggregator, finalizations)
-	if err != nil {
-		return simplex.FinalizationCertificate{}, nil, err
-	}
+	fCert, err := simplex.NewFinalizationCertificate(logger, signatureAggregator, finalizations)
+	require.NoError(t, err)
 
 	record := simplex.NewQuorumRecord(fCert.QC.Bytes(), fCert.Finalization.Bytes(), record.FinalizationRecordType)
 
-	return fCert, record, nil
-}
-
-func newFinalizationCertificate(signatureAggregator simplex.SignatureAggregator, finalizations []*simplex.Finalization) (simplex.FinalizationCertificate, error) {
-	voteCount := len(finalizations)
-
-	signatures := make([]simplex.Signature, 0, voteCount)
-	for _, vote := range finalizations {
-		// TODO: ensure all finalizations agree on the same metadata!
-		signatures = append(signatures, vote.Signature)
-	}
-
-	var fCert simplex.FinalizationCertificate
-	var err error
-	fCert.Finalization = finalizations[0].Finalization
-	fCert.QC, err = signatureAggregator.Aggregate(signatures)
-	if err != nil {
-		return simplex.FinalizationCertificate{}, fmt.Errorf("could not aggregate signatures for finalization certificate: %w", err)
-	}
-
-	return fCert, nil
+	return fCert, record
 }

--- a/record_test.go
+++ b/record_test.go
@@ -37,7 +37,7 @@ func newFinalizationRecord(t *testing.T, logger simplex.Logger, signatureAggrega
 	for i, id := range ids {
 		testBlock := block.(*testBlock)
 		finalizations[i] = newTestFinalization(t, testBlock, id, signer)
-  }
+	}
 
 	fCert, err := simplex.NewFinalizationCertificate(logger, signatureAggregator, finalizations)
 	require.NoError(t, err)

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -158,9 +158,8 @@ func TestRecoverFromNotarization(t *testing.T) {
 
 	// require the round was incremented(notarization increases round)
 	require.Equal(t, uint64(1), e.Metadata().Round)
-
 	for i := 1; i < quorum; i++ {
-		injectTestFinalization(t, e, testBlock, nodes[i], conf.Signer)
+		injectTestFinalization(t, e, block, nodes[i], conf.Signer)
 	}
 
 	committedData := storage.data[0].Block.Bytes()
@@ -229,7 +228,7 @@ func TestRecoverFromWalWithStorage(t *testing.T) {
 
 	for i := 1; i < quorum; i++ {
 		// type assert block to testBlock
-		injectTestFinalization(t, e, testBlock, nodes[i], conf.Signer)
+		injectTestFinalization(t, e, block, nodes[i], conf.Signer)
 	}
 
 	committedData := storage.data[1].Block.Bytes()


### PR DESCRIPTION
Decouple NewNotarization and NewFinalization from epoch and create tests for both. Also updates the methods sort the signers by NodeID to ensure `FinalizationCertificates` & `Notarizations` are consistent between nodes.