### PR TITLE
Fix UT flake

### DIFF
--- a/epoch_multinode_test.go
+++ b/epoch_multinode_test.go
@@ -29,7 +29,7 @@ func TestSimplexMultiNodeSimple(t *testing.T) {
 
 	bb.triggerNewBlock()
 
-	instances := []*testInstance{n1, n2, n3, n4}
+	instances := []*testInstance{n4, n3, n2, n1}
 
 	for _, n := range instances {
 		n.start()


### PR DESCRIPTION
The test TestSimplexMultiNodeSimple spins up 4 Simplex instances by creating them and then triggerring a new block to be created.

Unfortunately, part of starting a new Simplex node is having it realize it's the leader of the first ever round, and proposing a block.

In our unit tests, triggers for block creations are controlled via a golang channel.

When starting a new Simplex instance that is the leader of the current round, it will block until the trigger for block creation is fed into the aforementioned golang channel.

Therefore, it is mandatory to load the block creation trigger before starting the instances.

Unfortunately, this has a nasty side-effect: The first block proposal sent from the leader of the first round, may get lost.

The reason is that Simplex protects itself from receiving messages before it has finished starting by dropping all messages until it has done starting.

Since the leader of the first round starts first, it may send a block to a node that hasn't finished starting.

A trivial fix for this, is to start the nodes in reverse order, which ensures all nodes that are not the leader of the first round finish starting before the leader is started.