### PR TITLE
Leader failover

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -166,3 +166,73 @@ func ParseBlockRecord(buff []byte) (BlockHeader, []byte, error) {
 
 	return bh, payload, nil
 }
+
+func NewEmptyNotarizationRecord(emptyNotarization *EmptyNotarization) []byte {
+	return NewQuorumRecord(emptyNotarization.QC.Bytes(), emptyNotarization.Vote.Bytes(), record.EmptyNotarizationRecordType)
+}
+
+func EmptyNotarizationFromRecord(record []byte, qd QCDeserializer) (EmptyNotarization, error) {
+	qcBytes, emptyVote, err := ParseemptyNotarizationRecord(record)
+	if err != nil {
+		return EmptyNotarization{}, err
+	}
+
+	qc, err := qd.DeserializeQuorumCertificate(qcBytes)
+	if err != nil {
+		return EmptyNotarization{}, err
+	}
+
+	return EmptyNotarization{
+		Vote: emptyVote,
+		QC:   qc,
+	}, nil
+}
+
+func ParseemptyNotarizationRecord(buff []byte) ([]byte, ToBeSignedEmptyVote, error) {
+	recordType := binary.BigEndian.Uint16(buff[:2])
+	if recordType != record.EmptyNotarizationRecordType {
+		return nil, ToBeSignedEmptyVote{}, fmt.Errorf("expected record type %d, got %d", record.NotarizationRecordType, recordType)
+	}
+
+	record := buff[2:]
+	var nr QuorumRecord
+	_, err := asn1.Unmarshal(record, &nr)
+	if err != nil {
+		return nil, ToBeSignedEmptyVote{}, err
+	}
+
+	var vote ToBeSignedEmptyVote
+	if err := vote.FromBytes(nr.Vote); err != nil {
+		return nil, ToBeSignedEmptyVote{}, err
+	}
+
+	return nr.QC, vote, nil
+}
+
+func NewEmptyVoteRecord(emptyVote ToBeSignedEmptyVote) []byte {
+	payload := emptyVote.Bytes()
+	buff := make([]byte, len(payload)+2)
+	binary.BigEndian.PutUint16(buff, record.EmptyVoteRecordType)
+	copy(buff[2:], payload)
+
+	return buff
+}
+
+func ParseEmptyVoteRecord(rawEmptyVote []byte) (ToBeSignedEmptyVote, error) {
+	if len(rawEmptyVote) < 2 {
+		return ToBeSignedEmptyVote{}, errors.New("expected at least two bytes")
+	}
+
+	recordType := binary.BigEndian.Uint16(rawEmptyVote[:2])
+
+	if recordType != record.EmptyVoteRecordType {
+		return ToBeSignedEmptyVote{}, fmt.Errorf("expected record type %d, got %d", record.EmptyVoteRecordType, recordType)
+	}
+
+	var emptyVote ToBeSignedEmptyVote
+	if err := emptyVote.FromBytes(rawEmptyVote[2:]); err != nil {
+		return ToBeSignedEmptyVote{}, err
+	}
+
+	return emptyVote, nil
+}

--- a/encoding.go
+++ b/encoding.go
@@ -167,28 +167,7 @@ func ParseBlockRecord(buff []byte) (BlockHeader, []byte, error) {
 	return bh, payload, nil
 }
 
-func NewEmptyNotarizationRecord(emptyNotarization *EmptyNotarization) []byte {
-	return NewQuorumRecord(emptyNotarization.QC.Bytes(), emptyNotarization.Vote.Bytes(), record.EmptyNotarizationRecordType)
-}
-
-func EmptyNotarizationFromRecord(record []byte, qd QCDeserializer) (EmptyNotarization, error) {
-	qcBytes, emptyVote, err := ParseemptyNotarizationRecord(record)
-	if err != nil {
-		return EmptyNotarization{}, err
-	}
-
-	qc, err := qd.DeserializeQuorumCertificate(qcBytes)
-	if err != nil {
-		return EmptyNotarization{}, err
-	}
-
-	return EmptyNotarization{
-		Vote: emptyVote,
-		QC:   qc,
-	}, nil
-}
-
-func ParseemptyNotarizationRecord(buff []byte) ([]byte, ToBeSignedEmptyVote, error) {
+func ParseEmptyNotarizationRecord(buff []byte) ([]byte, ToBeSignedEmptyVote, error) {
 	recordType := binary.BigEndian.Uint16(buff[:2])
 	if recordType != record.EmptyNotarizationRecordType {
 		return nil, ToBeSignedEmptyVote{}, fmt.Errorf("expected record type %d, got %d", record.NotarizationRecordType, recordType)

--- a/epoch.go
+++ b/epoch.go
@@ -696,7 +696,7 @@ func (e *Epoch) deleteFutureVote(from NodeID, round uint64) {
 	msgsForRound.vote = nil
 }
 
-func (e *Epoch) deleteFutureemptyNotarization(from NodeID, round uint64) {
+func (e *Epoch) deleteFutureEmptyNotarization(from NodeID, round uint64) {
 	msgsForRound, exists := e.futureMessages[string(from)][round]
 	if !exists {
 		return

--- a/epoch.go
+++ b/epoch.go
@@ -907,7 +907,7 @@ func (e *Epoch) maybeAssembleEmptyNotarization() error {
 
 	emptyNotarization := &EmptyNotarization{QC: qc, Vote: popularEmptyVote.Vote}
 
-	return e.persistemptyNotarization(emptyNotarization)
+	return e.persistEmptyNotarization(emptyNotarization)
 }
 
 func findMostPopularEmptyVote(votes map[string]*EmptyVote, quorumSize int) (*EmptyVote, bool) {
@@ -933,7 +933,7 @@ func findMostPopularEmptyVote(votes map[string]*EmptyVote, quorumSize int) (*Emp
 	return popularEmptyVotes[0], true
 }
 
-func (e *Epoch) persistemptyNotarization(emptyNotarization *EmptyNotarization) error {
+func (e *Epoch) persistEmptyNotarization(emptyNotarization *EmptyNotarization) error {
 	emptyNotarizationRecord := NewEmptyNotarizationRecord(emptyNotarization)
 	if err := e.WAL.Append(emptyNotarizationRecord); err != nil {
 		e.Logger.Error("Failed to append empty block record to WAL", zap.Error(err))

--- a/epoch.go
+++ b/epoch.go
@@ -589,7 +589,7 @@ func (e *Epoch) handleEmptyVoteMessage(message *EmptyVote, from NodeID) error {
 
 	emptyVotes.votes[string(from)] = message
 
-	return e.maybeAssembleemptyNotarization()
+	return e.maybeAssembleEmptyNotarization()
 }
 
 func (e *Epoch) getOrCreateEmptyVoteSetForRound(round uint64) *EmptyVoteSet {
@@ -879,7 +879,7 @@ func (e *Epoch) persistFinalizationCertificate(fCert FinalizationCertificate) er
 	return nil
 }
 
-func (e *Epoch) maybeAssembleemptyNotarization() error {
+func (e *Epoch) maybeAssembleEmptyNotarization() error {
 	emptyVotes, exists := e.emptyVotes[e.round]
 
 	// This should never happen, but done for sanity

--- a/epoch.go
+++ b/epoch.go
@@ -676,10 +676,7 @@ func (e *Epoch) handleVoteMessage(message *Vote, from NodeID) error {
 
 func (e *Epoch) haveWeAlreadyTimedOutOnThisRound(round uint64) bool {
 	emptyVotes, exists := e.emptyVotes[round]
-	if exists && emptyVotes.timedOut {
-		return true
-	}
-	return false
+	return exists && emptyVotes.timedOut
 }
 
 func (e *Epoch) storeFutureVote(message *Vote, from NodeID, round uint64) {

--- a/epoch.go
+++ b/epoch.go
@@ -911,15 +911,15 @@ func (e *Epoch) maybeAssembleEmptyNotarization() error {
 }
 
 func findMostPopularEmptyVote(votes map[string]*EmptyVote, quorumSize int) (*EmptyVote, bool) {
-	votesBySender := make(map[string][]*EmptyVote)
+	votesByBytes := make(map[string][]*EmptyVote)
 	for _, vote := range votes {
 		key := string(vote.Vote.Bytes())
-		votesBySender[key] = append(votesBySender[key], vote)
+		votesByBytes[key] = append(votesByBytes[key], vote)
 	}
 
 	var popularEmptyVotes []*EmptyVote
 
-	for _, votes := range votesBySender {
+	for _, votes := range votesByBytes {
 		if len(votes) >= quorumSize {
 			popularEmptyVotes = votes
 			break

--- a/epoch_failover_test.go
+++ b/epoch_failover_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	. "simplex"
 	"simplex/testutil"
-	"simplex/wal"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -35,13 +34,15 @@ func TestEpochLeaderFailover(t *testing.T) {
 
 	start := time.Now()
 
+	wal := newTestWAL(t)
+
 	conf := EpochConfig{
 		MaxProposalWait:     DefaultMaxProposalWaitTime,
 		StartTime:           start,
 		Logger:              l,
 		ID:                  nodes[0],
 		Signer:              &testSigner{},
-		WAL:                 wal.NewMemWAL(t),
+		WAL:                 wal,
 		Verifier:            &testVerifier{},
 		Storage:             storage,
 		Comm:                noopComm(nodes),
@@ -60,17 +61,323 @@ func TestEpochLeaderFailover(t *testing.T) {
 	// Then, don't do anything and wait for our node
 	// to start complaining about a block not being notarized
 
-	// TODO: in future PRs we will expand this test to also do the actual agreement on the empty block
-
-	rounds := uint64(3)
-
-	for round := uint64(0); round < rounds; round++ {
-		notarizeAndFinalizeRound(t, nodes, round, e, bb, quorum, storage, false)
+	for _, round := range []uint64{0, 1, 2} {
+		notarizeAndFinalizeRound(t, nodes, round, round, e, bb, quorum, storage, false)
 	}
 
 	bb.blockShouldBeBuilt <- struct{}{}
 
 	waitForEvent(start, e, timeoutDetected)
+
+	lastBlock, _, ok := storage.Retrieve(storage.Height() - 1)
+	require.True(t, ok)
+
+	prev := lastBlock.BlockHeader().Digest
+
+	md := ProtocolMetadata{
+		Round: 3,
+		Seq:   2,
+		Prev:  prev,
+	}
+
+	nextBlockSeqToCommit := uint64(3)
+	nextRoundToCommit := uint64(4)
+
+	emptyVoteFrom1 := createEmptyVote(md, nodes[1])
+	emptyVoteFrom2 := createEmptyVote(md, nodes[2])
+
+	e.HandleMessage(&Message{
+		EmptyVoteMessage: emptyVoteFrom1,
+	}, nodes[1])
+	e.HandleMessage(&Message{
+		EmptyVoteMessage: emptyVoteFrom2,
+	}, nodes[2])
+
+	// Ensure our node proposes block with sequence 3 for round 4
+	notarizeAndFinalizeRound(t, nodes, nextRoundToCommit, nextBlockSeqToCommit, e, bb, quorum, storage, false)
+
+	// WAL must contain an empty vote and an empty block.
+	walContent, err := wal.ReadAll()
+	require.NoError(t, err)
+
+	// WAL should be: [..., <empty vote>, <empty block>, <notarization for 4>, <block3>]
+	rawEmptyVote, rawEmptyNotarization := walContent[len(walContent)-4], walContent[len(walContent)-3]
+
+	emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
+	require.NoError(t, err)
+	require.Equal(t, createEmptyVote(md, nodes[0]).Vote, emptyVote)
+
+	emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
+	require.NoError(t, err)
+	require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
+	require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
+}
+
+func TestEpochLeaderFailoverAfterProposal(t *testing.T) {
+	timeoutDetected := make(chan struct{})
+	alreadyTimedOut := make(chan struct{})
+
+	l := testutil.MakeLogger(t, 1)
+	l.Intercept(func(entry zapcore.Entry) error {
+		if entry.Message == `Timed out on block agreement` {
+			close(timeoutDetected)
+		}
+		if entry.Message == `Received a vote but already timed out in that round` {
+			select {
+			case <-alreadyTimedOut:
+				return nil
+			default:
+				close(alreadyTimedOut)
+			}
+		}
+		return nil
+	})
+
+	bb := &testBlockBuilder{out: make(chan *testBlock, 1), blockShouldBeBuilt: make(chan struct{}, 1)}
+	storage := newInMemStorage()
+
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+	quorum := Quorum(len(nodes))
+
+	start := time.Now()
+
+	wal := newTestWAL(t)
+
+	conf := EpochConfig{
+		MaxProposalWait:     DefaultMaxProposalWaitTime,
+		StartTime:           start,
+		Logger:              l,
+		ID:                  nodes[0],
+		Signer:              &testSigner{},
+		WAL:                 wal,
+		Verifier:            &testVerifier{},
+		Storage:             storage,
+		Comm:                noopComm(nodes),
+		BlockBuilder:        bb,
+		SignatureAggregator: &testSignatureAggregator{},
+	}
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+
+	require.NoError(t, e.Start())
+
+	// Run through 3 blocks, to make the block proposals be:
+	// 1 --> 2 --> 3 --> 4
+	// Node 4 proposes a block, but node 1 cannot collect votes until the timeout.
+	// After the timeout expires, node 1 is sent all the votes, but it should ignore them.
+
+	for _, round := range []uint64{0, 1, 2} {
+		notarizeAndFinalizeRound(t, nodes, round, round, e, bb, quorum, storage, false)
+	}
+
+	// leader is the proposer of the new block for the given round
+	leader := LeaderForRound(nodes, 3)
+	md := e.Metadata()
+	_, ok := bb.BuildBlock(context.Background(), md)
+	require.True(t, ok)
+	require.Equal(t, md.Round, md.Seq)
+
+	block := <-bb.out
+
+	vote, err := newTestVote(block, leader)
+	require.NoError(t, err)
+	err = e.HandleMessage(&Message{
+		BlockMessage: &BlockMessage{
+			Vote:  *vote,
+			Block: block,
+		},
+	}, leader)
+	require.NoError(t, err)
+
+	bb.blockShouldBeBuilt <- struct{}{}
+
+	waitForEvent(start, e, timeoutDetected)
+
+	for i := 1; i < quorum; i++ {
+		// Skip the vote of the block proposer
+		if leader.Equals(nodes[i]) {
+			continue
+		}
+		injectTestVote(t, e, block, nodes[i])
+	}
+
+	waitForEvent(start, e, alreadyTimedOut)
+
+	lastBlock, _, ok := storage.Retrieve(storage.Height() - 1)
+	require.True(t, ok)
+
+	prev := lastBlock.BlockHeader().Digest
+
+	md = ProtocolMetadata{
+		Round: 3,
+		Seq:   2,
+		Prev:  prev,
+	}
+
+	nextBlockSeqToCommit := uint64(3)
+	nextRoundToCommit := uint64(4)
+
+	emptyVoteFrom1 := createEmptyVote(md, nodes[1])
+	emptyVoteFrom2 := createEmptyVote(md, nodes[2])
+
+	e.HandleMessage(&Message{
+		EmptyVoteMessage: emptyVoteFrom1,
+	}, nodes[1])
+	e.HandleMessage(&Message{
+		EmptyVoteMessage: emptyVoteFrom2,
+	}, nodes[2])
+
+	// Ensure our node proposes block with sequence 3 for round 4
+	notarizeAndFinalizeRound(t, nodes, nextRoundToCommit, nextBlockSeqToCommit, e, bb, quorum, storage, false)
+
+	// WAL must contain an empty vote and an empty block.
+	walContent, err := wal.ReadAll()
+	require.NoError(t, err)
+
+	// WAL should be: [..., <empty vote>, <empty block>, <notarization for 4>, <block3>]
+	rawEmptyVote, rawEmptyNotarization := walContent[len(walContent)-4], walContent[len(walContent)-3]
+
+	emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
+	require.NoError(t, err)
+	require.Equal(t, createEmptyVote(md, nodes[0]).Vote, emptyVote)
+
+	emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
+	require.NoError(t, err)
+	require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
+	require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
+}
+
+func TestEpochLeaderFailoverTwice(t *testing.T) {
+	timeoutDetected := make(chan struct{})
+
+	l := testutil.MakeLogger(t, 1)
+	l.Intercept(func(entry zapcore.Entry) error {
+		if entry.Message == `Timed out on block agreement` {
+			close(timeoutDetected)
+			timeoutDetected = make(chan struct{})
+		}
+		return nil
+	})
+
+	bb := &testBlockBuilder{out: make(chan *testBlock, 1), blockShouldBeBuilt: make(chan struct{}, 1)}
+	storage := newInMemStorage()
+
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+	quorum := Quorum(len(nodes))
+
+	start := time.Now()
+
+	wal := newTestWAL(t)
+
+	conf := EpochConfig{
+		MaxProposalWait:     DefaultMaxProposalWaitTime,
+		StartTime:           start,
+		Logger:              l,
+		ID:                  nodes[0],
+		Signer:              &testSigner{},
+		WAL:                 wal,
+		Verifier:            &testVerifier{},
+		Storage:             storage,
+		Comm:                noopComm(nodes),
+		BlockBuilder:        bb,
+		SignatureAggregator: &testSignatureAggregator{},
+	}
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+
+	require.NoError(t, e.Start())
+
+	for _, round := range []uint64{0, 1} {
+		notarizeAndFinalizeRound(t, nodes, round, round, e, bb, quorum, storage, false)
+	}
+
+	t.Log("Node 2 crashes, leader failover to node 3")
+
+	bb.blockShouldBeBuilt <- struct{}{}
+
+	waitForEvent(start, e, timeoutDetected)
+
+	lastBlock, _, ok := storage.Retrieve(storage.Height() - 1)
+	require.True(t, ok)
+
+	prev := lastBlock.BlockHeader().Digest
+
+	md := ProtocolMetadata{
+		Round: 2,
+		Seq:   1,
+		Prev:  prev,
+	}
+
+	emptyVoteFrom2 := createEmptyVote(md, nodes[2])
+	emptyVoteFrom3 := createEmptyVote(md, nodes[3])
+
+	e.HandleMessage(&Message{
+		EmptyVoteMessage: emptyVoteFrom2,
+	}, nodes[2])
+	e.HandleMessage(&Message{
+		EmptyVoteMessage: emptyVoteFrom3,
+	}, nodes[3])
+
+	wal.assertNotarization(2)
+
+	t.Log("Node 3 crashes and node 2 comes back up (just in time)")
+
+	bb.blockShouldBeBuilt <- struct{}{}
+
+	waitForEvent(start, e, timeoutDetected)
+
+	md = ProtocolMetadata{
+		Round: 3,
+		Seq:   1,
+		Prev:  prev,
+	}
+
+	emptyVoteFrom1 := createEmptyVote(md, nodes[1])
+	emptyVoteFrom3 = createEmptyVote(md, nodes[3])
+
+	e.HandleMessage(&Message{
+		EmptyVoteMessage: emptyVoteFrom1,
+	}, nodes[1])
+	e.HandleMessage(&Message{
+		EmptyVoteMessage: emptyVoteFrom3,
+	}, nodes[3])
+
+	wal.assertNotarization(3)
+
+	// Ensure our node proposes block with sequence 2 for round 4
+	nextRoundToCommit := uint64(4)
+	nextBlockSeqToCommit := uint64(2)
+	notarizeAndFinalizeRound(t, nodes, nextRoundToCommit, nextBlockSeqToCommit, e, bb, quorum, storage, false)
+
+	// WAL must contain an empty vote and an empty block.
+	walContent, err := wal.ReadAll()
+	require.NoError(t, err)
+
+	// WAL should be: [..., <empty vote>, <empty block>, <notarization for 4>, <block2>]
+	rawEmptyVote, rawEmptyNotarization := walContent[len(walContent)-4], walContent[len(walContent)-3]
+
+	emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
+	require.NoError(t, err)
+	require.Equal(t, createEmptyVote(md, nodes[0]).Vote, emptyVote)
+
+	emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
+	require.NoError(t, err)
+	require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
+	require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
+}
+
+func createEmptyVote(md ProtocolMetadata, signer NodeID) *EmptyVote {
+	emptyVoteFrom2 := &EmptyVote{
+		Signature: Signature{
+			Signer: signer,
+		},
+		Vote: ToBeSignedEmptyVote{
+			ProtocolMetadata: md,
+		},
+	}
+	return emptyVoteFrom2
 }
 
 func waitForEvent(start time.Time, e *Epoch, events chan struct{}) {
@@ -133,7 +440,7 @@ func TestEpochLeaderFailoverNotNeeded(t *testing.T) {
 	rounds := uint64(3)
 
 	for round := uint64(0); round < rounds; round++ {
-		notarizeAndFinalizeRound(t, nodes, round, e, bb, quorum, storage, false)
+		notarizeAndFinalizeRound(t, nodes, round, round, e, bb, quorum, storage, false)
 	}
 	bb.blockShouldBeBuilt <- struct{}{}
 	e.AdvanceTime(start.Add(conf.MaxProposalWait / 2))

--- a/epoch_failover_test.go
+++ b/epoch_failover_test.go
@@ -111,6 +111,8 @@ func TestEpochLeaderFailover(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
 	require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
+	require.Equal(t, uint64(2), emptyNotarization.Vote.Seq)
+	require.Equal(t, uint64(4), storage.Height())
 }
 
 func TestEpochLeaderFailoverAfterProposal(t *testing.T) {
@@ -246,6 +248,9 @@ func TestEpochLeaderFailoverAfterProposal(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
 	require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
+	require.Equal(t, uint64(2), emptyNotarization.Vote.Seq)
+	require.Equal(t, uint64(4), storage.Height())
+
 }
 
 func TestEpochLeaderFailoverTwice(t *testing.T) {
@@ -366,6 +371,8 @@ func TestEpochLeaderFailoverTwice(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
 	require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
+	require.Equal(t, uint64(1), emptyNotarization.Vote.Seq)
+	require.Equal(t, uint64(3), storage.Height())
 }
 
 func createEmptyVote(md ProtocolMetadata, signer NodeID) *EmptyVote {

--- a/epoch_multinode_test.go
+++ b/epoch_multinode_test.go
@@ -176,7 +176,7 @@ func (tw *testWAL) assertNotarization(round uint64) {
 				}
 			}
 			if binary.BigEndian.Uint16(rawRecord[:2]) == record.EmptyNotarizationRecordType {
-				_, vote, err := ParseemptyNotarizationRecord(rawRecord)
+				_, vote, err := ParseEmptyNotarizationRecord(rawRecord)
 				require.NoError(tw.t, err)
 
 				if vote.Round == round {

--- a/epoch_multinode_test.go
+++ b/epoch_multinode_test.go
@@ -175,6 +175,14 @@ func (tw *testWAL) assertNotarization(round uint64) {
 					return
 				}
 			}
+			if binary.BigEndian.Uint16(rawRecord[:2]) == record.EmptyNotarizationRecordType {
+				_, vote, err := ParseemptyNotarizationRecord(rawRecord)
+				require.NoError(tw.t, err)
+
+				if vote.Round == round {
+					return
+				}
+			}
 		}
 
 		tw.signal.Wait()

--- a/metadata.go
+++ b/metadata.go
@@ -17,7 +17,8 @@ const (
 	metadataPrevLen    = 32
 	metadataDigestLen  = 32
 
-	metadataLen = metadataVersionLen + metadataDigestLen + metadataEpochLen + metadataRoundLen + metadataSeqLen + metadataPrevLen
+	protocolMetadataLen = metadataVersionLen + metadataEpochLen + metadataRoundLen + metadataSeqLen + metadataPrevLen
+	metadataLen         = protocolMetadataLen + metadataDigestLen
 )
 
 const (

--- a/record/consts.go
+++ b/record/consts.go
@@ -7,5 +7,7 @@ const (
 	UndefinedRecordType uint16 = iota
 	BlockRecordType
 	NotarizationRecordType
+	EmptyVoteRecordType
+	EmptyNotarizationRecordType
 	FinalizationRecordType
 )


### PR DESCRIPTION
This commit adds agreement on empty blocks when a leader times out.

We write to WAL when:
- We time out on a round, so that when we recover we won't accept a proposal.
- We receive an empty notarization before we received a notarization.

Basic unit test where a node played by the test doesn't act in a timely manner,
and the node instantiated in the test then lobbies for an empty block notarization.