### PR TITLE
Instantiate test signer on demand in tests

### DIFF
--- a/notarization_test.go
+++ b/notarization_test.go
@@ -17,7 +17,6 @@ var errorSigAggregation = errors.New("signature error")
 func TestNewNotarization(t *testing.T) {
 	l := makeLogger(t, 1)
 	testBlock := &testBlock{}
-	testSigner := &testSigner{}
 	tests := []struct {
 		name                 string
 		votesForCurrentRound map[string]*simplex.Vote
@@ -31,7 +30,7 @@ func TestNewNotarization(t *testing.T) {
 				votes := make(map[string]*simplex.Vote)
 				nodeIds := [][]byte{{1}, {2}, {3}, {4}, {5}}
 				for _, nodeId := range nodeIds {
-					vote, err := newTestVote(testBlock, nodeId, testSigner)
+					vote, err := newTestVote(testBlock, nodeId)
 					require.NoError(t, err)
 					votes[string(nodeId)] = vote
 				}
@@ -54,7 +53,7 @@ func TestNewNotarization(t *testing.T) {
 				votes := make(map[string]*simplex.Vote)
 				nodeIds := [][]byte{{1}, {2}, {3}, {4}, {5}}
 				for _, nodeId := range nodeIds {
-					vote, err := newTestVote(testBlock, nodeId, testSigner)
+					vote, err := newTestVote(testBlock, nodeId)
 					require.NoError(t, err)
 					votes[string(nodeId)] = vote
 				}
@@ -86,7 +85,6 @@ func TestNewNotarization(t *testing.T) {
 
 func TestNewFinalizationCertificate(t *testing.T) {
 	l := makeLogger(t, 1)
-	signer := &testSigner{}
 	tests := []struct {
 		name                 string
 		finalizations        []*simplex.Finalization
@@ -98,31 +96,31 @@ func TestNewFinalizationCertificate(t *testing.T) {
 		{
 			name: "valid finalizations in order",
 			finalizations: []*simplex.Finalization{
-				newTestFinalization(t, &testBlock{}, []byte{1}, signer),
-				newTestFinalization(t, &testBlock{}, []byte{2}, signer),
-				newTestFinalization(t, &testBlock{}, []byte{3}, signer),
+				newTestFinalization(t, &testBlock{}, []byte{1}),
+				newTestFinalization(t, &testBlock{}, []byte{2}),
+				newTestFinalization(t, &testBlock{}, []byte{3}),
 			},
 			signatureAggregator:  &testSignatureAggregator{},
-			expectedFinalization: &newTestFinalization(t, &testBlock{}, []byte{1}, signer).Finalization,
+			expectedFinalization: &newTestFinalization(t, &testBlock{}, []byte{1}).Finalization,
 			expectError:          nil,
 		},
 		{
 			name: "unsorted finalizations",
 			finalizations: []*simplex.Finalization{
-				newTestFinalization(t, &testBlock{}, []byte{3}, signer),
-				newTestFinalization(t, &testBlock{}, []byte{1}, signer),
-				newTestFinalization(t, &testBlock{}, []byte{2}, signer),
+				newTestFinalization(t, &testBlock{}, []byte{3}),
+				newTestFinalization(t, &testBlock{}, []byte{1}),
+				newTestFinalization(t, &testBlock{}, []byte{2}),
 			},
 			signatureAggregator:  &testSignatureAggregator{},
-			expectedFinalization: &newTestFinalization(t, &testBlock{}, []byte{1}, signer).Finalization,
+			expectedFinalization: &newTestFinalization(t, &testBlock{}, []byte{1}).Finalization,
 			expectError:          nil,
 		},
 		{
 			name: "finalizations with different digests",
 			finalizations: []*simplex.Finalization{
-				newTestFinalization(t, &testBlock{digest: [32]byte{1}}, []byte{1}, signer),
-				newTestFinalization(t, &testBlock{digest: [32]byte{2}}, []byte{2}, signer),
-				newTestFinalization(t, &testBlock{digest: [32]byte{3}}, []byte{3}, signer),
+				newTestFinalization(t, &testBlock{digest: [32]byte{1}}, []byte{1}),
+				newTestFinalization(t, &testBlock{digest: [32]byte{2}}, []byte{2}),
+				newTestFinalization(t, &testBlock{digest: [32]byte{3}}, []byte{3}),
 			},
 			signatureAggregator: &testSignatureAggregator{},
 			expectError:         simplex.ErrorInvalidFinalizationDigest,
@@ -130,7 +128,7 @@ func TestNewFinalizationCertificate(t *testing.T) {
 		{
 			name: "signature aggregator errors",
 			finalizations: []*simplex.Finalization{
-				newTestFinalization(t, &testBlock{}, []byte{1}, signer),
+				newTestFinalization(t, &testBlock{}, []byte{1}),
 			},
 			signatureAggregator: &testSignatureAggregator{err: errorSigAggregation},
 			expectError:         errorSigAggregation,

--- a/record_test.go
+++ b/record_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID, signer simplex.Signer) ([]byte, error) {
+func newNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID) ([]byte, error) {
 	votesForCurrentRound := make(map[string]*simplex.Vote)
 	for _, id := range ids {
-		vote, err := newTestVote(block, id, signer)
+		vote, err := newTestVote(block, id)
 		if err != nil {
 			return nil, err
 		}
@@ -32,11 +32,11 @@ func newNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.Si
 }
 
 // creates a new finalization certificate
-func newFinalizationRecord(t *testing.T, logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID, signer simplex.Signer) (simplex.FinalizationCertificate, []byte) {
+func newFinalizationRecord(t *testing.T, logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID) (simplex.FinalizationCertificate, []byte) {
 	finalizations := make([]*simplex.Finalization, len(ids))
 	for i, id := range ids {
 		testBlock := block.(*testBlock)
-		finalizations[i] = newTestFinalization(t, testBlock, id, signer)
+		finalizations[i] = newTestFinalization(t, testBlock, id)
 	}
 
 	fCert, err := simplex.NewFinalizationCertificate(logger, signatureAggregator, finalizations)


### PR DESCRIPTION
Instead of instantiating the test signer in every test at the top most level, and rippling it downto where it is used, just instantiate it where we need it.