### PR TITLE
Remove redundant vote processing of piggybacked vote

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -996,7 +996,7 @@ func (e *Epoch) createBlockVerificationTask(block Block, from NodeID, vote Vote)
 		}
 		round.votes[string(vote.Signature.Signer)] = &vote
 
-		if err := e.doProposed(block, vote, from); err != nil {
+		if err := e.doProposed(block); err != nil {
 			e.Logger.Warn("Failed voting on block", zap.Error(err))
 		}
 
@@ -1237,7 +1237,7 @@ func (e *Epoch) startRound() error {
 	return e.handleBlockMessage(msgsForRound.proposal, leaderForCurrentRound)
 }
 
-func (e *Epoch) doProposed(block Block, voteFromLeader Vote, from NodeID) error {
+func (e *Epoch) doProposed(block Block) error {
 	vote, err := e.voteOnBlock(block)
 	if err != nil {
 		return err
@@ -1260,8 +1260,7 @@ func (e *Epoch) doProposed(block Block, voteFromLeader Vote, from NodeID) error 
 	if err := e.handleVoteMessage(&vote, e.ID); err != nil {
 		return err
 	}
-
-	return e.handleVoteMessage(&voteFromLeader, e.ID)
+	return nil
 }
 
 func (e *Epoch) voteOnBlock(block Block) (Vote, error) {

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -80,6 +80,10 @@ func notarizeAndFinalizeRound(t *testing.T, nodes []NodeID, round uint64, e *Epo
 
 	// start at one since our node has already voted
 	for i := 1; i < quorum; i++ {
+		// Skip the vote of the block proposer
+		if leader.Equals(nodes[i]) {
+			continue
+		}
 		injectTestVote(t, e, block, nodes[i])
 	}
 


### PR DESCRIPTION
Votes from the block proposer are piggybacked by the block message.

The current code verifies them twice, so I removed the redundant processing.
