### PR TITLE
Improve logging for tests

### DIFF
--- a/epoch_failover_test.go
+++ b/epoch_failover_test.go
@@ -6,6 +6,7 @@ package simplex_test
 import (
 	"context"
 	. "simplex"
+	"simplex/testutil"
 	"simplex/wal"
 	"sync/atomic"
 	"testing"
@@ -18,8 +19,8 @@ import (
 func TestEpochLeaderFailover(t *testing.T) {
 	timeoutDetected := make(chan struct{})
 
-	l := makeLogger(t, 1)
-	l.intercept(func(entry zapcore.Entry) error {
+	l := testutil.MakeLogger(t, 1)
+	l.Intercept(func(entry zapcore.Entry) error {
 		if entry.Message == `Timed out on block agreement` {
 			close(timeoutDetected)
 		}
@@ -89,8 +90,8 @@ func waitForEvent(start time.Time, e *Epoch, events chan struct{}) {
 func TestEpochLeaderFailoverNotNeeded(t *testing.T) {
 	var timedOut atomic.Bool
 
-	l := makeLogger(t, 1)
-	l.intercept(func(entry zapcore.Entry) error {
+	l := testutil.MakeLogger(t, 1)
+	l.Intercept(func(entry zapcore.Entry) error {
 		if entry.Message == `Timed out on block agreement` {
 			timedOut.Store(true)
 		}

--- a/epoch_multinode_test.go
+++ b/epoch_multinode_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	. "simplex"
 	"simplex/record"
+	"simplex/testutil"
 	"simplex/wal"
 	"sync"
 	"testing"
@@ -55,7 +56,7 @@ func (t *testInstance) start() {
 }
 
 func newSimplexNode(t *testing.T, id uint8, net *inMemNetwork, bb BlockBuilder) *testInstance {
-	l := makeLogger(t, int(id))
+	l := testutil.MakeLogger(t, int(id))
 	storage := newInMemStorage()
 
 	nodeID := NodeID{id}

--- a/notarization_test.go
+++ b/notarization_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"simplex"
+	"simplex/testutil"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +16,7 @@ import (
 var errorSigAggregation = errors.New("signature error")
 
 func TestNewNotarization(t *testing.T) {
-	l := makeLogger(t, 1)
+	l := testutil.MakeLogger(t, 1)
 	testBlock := &testBlock{}
 	tests := []struct {
 		name                 string
@@ -84,7 +85,7 @@ func TestNewNotarization(t *testing.T) {
 }
 
 func TestNewFinalizationCertificate(t *testing.T) {
-	l := makeLogger(t, 1)
+	l := testutil.MakeLogger(t, 1)
 	tests := []struct {
 		name                 string
 		finalizations        []*simplex.Finalization

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	. "simplex"
 	"simplex/record"
+	"simplex/testutil"
 	"simplex/wal"
 	"testing"
 
@@ -17,7 +18,7 @@ import (
 // TestRecoverFromWALProposed tests that the epoch can recover from
 // a wal with a single block record written to it(that we have proposed).
 func TestRecoverFromWALProposed(t *testing.T) {
-	l := makeLogger(t, 1)
+	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	wal := newTestWAL(t)
 	storage := newInMemStorage()
@@ -109,7 +110,7 @@ func TestRecoverFromWALProposed(t *testing.T) {
 // TestRecoverFromWALNotarized tests that the epoch can recover from a wal
 // with a block record written to it, and a notarization record.
 func TestRecoverFromNotarization(t *testing.T) {
-	l := makeLogger(t, 1)
+	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	wal := wal.NewMemWAL(t)
 	storage := newInMemStorage()
@@ -174,7 +175,7 @@ func TestRecoverFromNotarization(t *testing.T) {
 // TestRecoverFromWALFinalized tests that the epoch can recover from a wal
 // with a block already stored in the storage
 func TestRecoverFromWalWithStorage(t *testing.T) {
-	l := makeLogger(t, 1)
+	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	wal := wal.NewMemWAL(t)
 	storage := newInMemStorage()
@@ -243,7 +244,7 @@ func TestRecoverFromWalWithStorage(t *testing.T) {
 
 // TestWalCreated tests that the epoch correctly writes to the WAL
 func TestWalCreatedProperly(t *testing.T) {
-	l := makeLogger(t, 1)
+	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	storage := newInMemStorage()
 
@@ -315,7 +316,7 @@ func TestWalCreatedProperly(t *testing.T) {
 // TestWalWritesBlockRecord tests that the epoch correctly writes to the WAL
 // a block proposed by a node other than the epoch node
 func TestWalWritesBlockRecord(t *testing.T) {
-	l := makeLogger(t, 1)
+	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	storage := newInMemStorage()
 	blockDeserializer := &blockDeserializer{}
@@ -376,7 +377,7 @@ func TestWalWritesBlockRecord(t *testing.T) {
 }
 
 func TestWalWritesFinalizationCert(t *testing.T) {
-	l := makeLogger(t, 1)
+	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	storage := newInMemStorage()
 	sigAggregrator := &testSignatureAggregator{}
@@ -478,7 +479,7 @@ func TestWalWritesFinalizationCert(t *testing.T) {
 
 // TestRecoverFromMultipleRounds tests that the epoch can recover from a wal with multiple rounds written to it.
 func TestRecoverFromMultipleRounds(t *testing.T) {
-	l := makeLogger(t, 1)
+	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	wal := wal.NewMemWAL(t)
 	storage := newInMemStorage()
@@ -531,7 +532,7 @@ func TestRecoverFromMultipleRounds(t *testing.T) {
 // TestRecoverFromMultipleRounds tests that the epoch can recover from a wal with multiple rounds written to it.
 // Appends to the wal -> block, notarization, second block, notarization block 2, finalization for block 1.
 func TestRecoverFromMultipleNotarizations(t *testing.T) {
-	l := makeLogger(t, 1)
+	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	wal := wal.NewMemWAL(t)
 	storage := newInMemStorage()

--- a/testutil/logger.go
+++ b/testutil/logger.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2019-2024, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package testutil
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"os"
+	"strings"
+	"testing"
+)
+
+type TestLogger struct {
+	*zap.Logger
+	traceVerboseLogger *zap.Logger
+}
+
+func (t *TestLogger) Intercept(hook func(entry zapcore.Entry) error) {
+	logger := t.Logger.WithOptions(zap.Hooks(hook))
+	t.Logger = logger
+}
+
+func (tl *TestLogger) Trace(msg string, fields ...zap.Field) {
+	tl.traceVerboseLogger.Log(zapcore.DebugLevel, msg, fields...)
+}
+
+func (tl *TestLogger) Verbo(msg string, fields ...zap.Field) {
+	tl.traceVerboseLogger.Log(zapcore.DebugLevel, msg, fields...)
+}
+
+func MakeLogger(t *testing.T, node ...int) *TestLogger {
+	defaultEncoderConfig := zapcore.EncoderConfig{
+		TimeKey:        "timestamp",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "msg",
+		StacktraceKey:  "stacktrace",
+		EncodeDuration: zapcore.StringDurationEncoder,
+		EncodeCaller:   zapcore.ShortCallerEncoder,
+	}
+	config := defaultEncoderConfig
+	config.EncodeLevel = func(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+		enc.AppendString(strings.ToUpper(l.String()))
+	}
+	config.EncodeTime = zapcore.TimeEncoderOfLayout("[01-02|15:04:05.000]")
+	config.ConsoleSeparator = " "
+	encoder := zapcore.NewConsoleEncoder(config)
+
+	atomicLevel := zap.NewAtomicLevelAt(zapcore.DebugLevel)
+
+	core := zapcore.NewCore(encoder, zapcore.AddSync(os.Stdout), atomicLevel)
+
+	logger := zap.New(core, zap.AddCaller())
+	logger = logger.With(zap.String("test", t.Name()))
+	if len(node) > 0 {
+		logger = logger.With(zap.Int("node", node[0]))
+	}
+
+	traceVerboseLogger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1))
+	traceVerboseLogger = traceVerboseLogger.With(zap.String("test", t.Name()))
+
+	if len(node) > 0 {
+		traceVerboseLogger = traceVerboseLogger.With(zap.Int("node", node[0]))
+	}
+
+	l := &TestLogger{Logger: logger, traceVerboseLogger: traceVerboseLogger}
+
+	return l
+}


### PR DESCRIPTION
- Fix caller skip (was wrong)
- Move it to its own package to be imported from both _test package and non _test package
- Put a better looking date and time format
- Add the name of the test to the logger so we understand which test it corresponds to


Code shamelessly copied from avalancheGo