### PR TITLE
Use correct sequence and metadata when building block

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -1213,7 +1213,7 @@ func (e *Epoch) Metadata() ProtocolMetadata {
 func (e *Epoch) metadata() ProtocolMetadata {
 	var prev Digest
 	seq := e.Storage.Height()
-	if e.lastBlock != nil {
+	if len(e.rounds) > 0 {
 		// Build on top of the latest block
 		currMed := e.getHighestRound().block.BlockHeader()
 		prev = currMed.Digest

--- a/epoch_multinode_test.go
+++ b/epoch_multinode_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestSimplexMultiNodeSimple(t *testing.T) {
-	bb := newTestControlledBlockBuilder()
+	bb := newTestControlledBlockBuilder(t)
 
 	var net inMemNetwork
 	net.nodes = []NodeID{{1}, {2}, {3}, {4}}
@@ -228,12 +228,14 @@ type inMemNetwork struct {
 }
 
 type testControlledBlockBuilder struct {
+	t       *testing.T
 	control chan struct{}
 	testBlockBuilder
 }
 
-func newTestControlledBlockBuilder() *testControlledBlockBuilder {
+func newTestControlledBlockBuilder(t *testing.T) *testControlledBlockBuilder {
 	return &testControlledBlockBuilder{
+		t:                t,
 		control:          make(chan struct{}, 1),
 		testBlockBuilder: testBlockBuilder{out: make(chan *testBlock, 1)},
 	}
@@ -248,6 +250,7 @@ func (t *testControlledBlockBuilder) triggerNewBlock() {
 }
 
 func (t *testControlledBlockBuilder) BuildBlock(ctx context.Context, metadata ProtocolMetadata) (Block, bool) {
+	require.Equal(t.t, metadata.Seq, metadata.Round)
 	<-t.control
 	return t.testBlockBuilder.BuildBlock(ctx, metadata)
 }

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -62,6 +62,7 @@ func notarizeAndFinalizeRound(t *testing.T, nodes []NodeID, round uint64, e *Epo
 		md := e.Metadata()
 		_, ok := bb.BuildBlock(context.Background(), md)
 		require.True(t, ok)
+		require.Equal(t, md.Round, md.Seq)
 	}
 
 	block := <-bb.out


### PR DESCRIPTION
When building a block, we look at the latest round and build the round on top of it, only if we have already committed a block already.

However, since we notarize rounds asynchronously, we may advance to a new round before we commit a block.

We therefore need to use the rounds themselves as an indicator.