### PR TITLE
Decouple vote from handleBlockMessage

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -103,12 +103,18 @@ func (e *Epoch) HandleMessage(msg *Message, from NodeID) error {
 		return nil
 	}
 
+	if from.Equals(e.ID) {
+		e.Logger.Warn("Received message from self")
+		return nil
+	}
+
 	// Guard against receiving messages from unknown nodes
 	_, known := e.eligibleNodeIDs[string(from)]
 	if !known {
 		e.Logger.Warn("Received message from an unknown node", zap.Stringer("nodeID", from))
 		return nil
 	}
+
 
 	switch {
 	case msg.BlockMessage != nil:
@@ -904,12 +910,6 @@ func (e *Epoch) handleBlockMessage(message *BlockMessage, from NodeID) error {
 	if md.Round-e.round >= e.maxRoundWindow {
 		e.Logger.Debug("Received a block message for a too high round",
 			zap.Uint64("round", md.Round), zap.Uint64("our round", e.round))
-		return nil
-	}
-
-	// Ignore block messages sent by us
-	if e.ID.Equals(from) {
-		e.Logger.Debug("Got a BlockMessage from ourselves or created by us")
 		return nil
 	}
 

--- a/epoch.go
+++ b/epoch.go
@@ -876,16 +876,16 @@ func (e *Epoch) hasSomeNodeSignedTwice(nodeIDs []NodeID) bool {
 	return false
 }
 
-// handleBlockMessageFromLeader expects the block message 
+// handleBlockMessageFromLeader expects the block message
 // to come from the leader of the round, otherwise the block will not be processed.
 func (e *Epoch) handleBlockMessageFromLeader(message *BlockMessage, from NodeID) error {
 	e.Logger.Verbo("Received block message",
 		zap.Stringer("from", from), zap.Uint64("round", message.Block.BlockHeader().Round))
-	
+
 	vote := message.Vote
 	from = vote.Signature.Signer
 	md := message.Block.BlockHeader()
-	
+
 	// Check that the node is a leader for the round corresponding to the block.
 	if !LeaderForRound(e.nodes, md.Round).Equals(from) {
 		// The block is associated with a round in which the sender is not the leader,

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -151,7 +151,7 @@ func TestEpochBlockSentFromNonLeader(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, e.Start())
-	
+
 	md := e.Metadata()
 	block, ok := bb.BuildBlock(context.Background(), md)
 	require.True(t, ok)

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -11,8 +11,6 @@ import (
 	"encoding/asn1"
 	"encoding/binary"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 	"math"
 	rand2 "math/rand"
 	. "simplex"
@@ -20,6 +18,9 @@ import (
 	"simplex/wal"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestEpochFinalizeThenNotarize(t *testing.T) {
@@ -116,6 +117,56 @@ func TestEpochSimpleFlow(t *testing.T) {
 	for round := uint64(0); round < rounds; round++ {
 		notarizeAndFinalizeRound(t, nodes, round, e, bb, quorum, storage, false)
 	}
+}
+
+func TestEpochBlockSentFromNonLeader(t *testing.T) {
+	l := testutil.MakeLogger(t, 1)
+	nonLeaderMessage := false
+
+	l.Intercept(func(entry zapcore.Entry) error {
+		if entry.Message == "Got block from a block proposer that is not the leader of the round" {
+			nonLeaderMessage = true
+		}
+		return nil
+	})
+
+	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
+	storage := newInMemStorage()
+
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+	conf := EpochConfig{
+		MaxProposalWait:     DefaultMaxProposalWaitTime,
+		Logger:              l,
+		ID:                  nodes[1],
+		Signer:              &testSigner{},
+		WAL:                 wal.NewMemWAL(t),
+		Verifier:            &testVerifier{},
+		Storage:             storage,
+		Comm:                noopComm(nodes),
+		BlockBuilder:        bb,
+		SignatureAggregator: &testSignatureAggregator{},
+	}
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+
+	require.NoError(t, e.Start())
+	
+	md := e.Metadata()
+	block, ok := bb.BuildBlock(context.Background(), md)
+	require.True(t, ok)
+
+	notLeader := nodes[3]
+	vote, err := newTestVote(block, notLeader)
+	require.NoError(t, err)
+	err = e.HandleMessage(&Message{
+		BlockMessage: &BlockMessage{
+			Vote:  *vote,
+			Block: block,
+		},
+	}, notLeader)
+	require.NoError(t, err)
+	require.True(t, nonLeaderMessage)
 }
 
 func notarizeAndFinalizeRound(t *testing.T, nodes []NodeID, round uint64, e *Epoch, bb *testBlockBuilder, quorum int, storage *InMemStorage, skipNotarization bool) {


### PR DESCRIPTION
When handling `blockMessages` we also process a vote attached to the message. During replication, we wont have this vote attached to blocks. This PR decouples the logic for handling votes and verifying blocks, allowing us to use the same logic during replication.