### PR TITLE
Cleanup recovery from fCert in WAL

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -115,7 +115,6 @@ func (e *Epoch) HandleMessage(msg *Message, from NodeID) error {
 		return nil
 	}
 
-
 	switch {
 	case msg.BlockMessage != nil:
 		return e.handleBlockMessage(msg.BlockMessage, from)
@@ -156,13 +155,7 @@ func (e *Epoch) init() error {
 	if err != nil {
 		return err
 	}
-	err = e.setMetadataFromStorage()
-	if err != nil {
-		return err
-	}
-
-	e.loadLastRound()
-	return nil
+	return e.setMetadataFromStorage()
 }
 
 func (e *Epoch) Start() error {
@@ -182,6 +175,7 @@ func (e *Epoch) syncBlockRecord(r []byte) error {
 	if !b {
 		return fmt.Errorf("failed to store block from WAL")
 	}
+
 	e.Logger.Info("Block Proposal Recovered From WAL", zap.Uint64("Round", block.BlockHeader().Round), zap.Bool("stored", b))
 	return nil
 }
@@ -263,11 +257,11 @@ func (e *Epoch) resumeFromWal(records [][]byte) error {
 
 		finalizationCertificate := &Message{FinalizationCertificate: &fCert}
 		e.Comm.Broadcast(finalizationCertificate)
-	
+
 		e.Logger.Debug("Broadcast finalization certificate",
 			zap.Uint64("round", fCert.Finalization.Round),
 			zap.Stringer("digest", fCert.Finalization.BlockHeader.Digest))
-	
+
 		return e.startRound()
 	default:
 		return errors.New("unknown record type")
@@ -298,8 +292,10 @@ func (e *Epoch) setMetadataFromRecords(records [][]byte) error {
 			if err != nil {
 				return err
 			}
-			e.round = notarization.Vote.Round + 1
-			e.Epoch = notarization.Vote.BlockHeader.Epoch
+			if notarization.Vote.Round >= e.round {
+				e.round = notarization.Vote.Round + 1
+				e.Epoch = notarization.Vote.BlockHeader.Epoch
+			}
 			return nil
 		}
 	}
@@ -349,14 +345,6 @@ func (e *Epoch) loadLastBlock() error {
 
 	e.lastBlock = block
 	return nil
-}
-
-func (e *Epoch) loadLastRound() {
-	// Put the last block we committed in the rounds map.
-	if e.lastBlock != nil {
-		round := NewRound(e.lastBlock)
-		e.rounds[round.num] = round
-	}
 }
 
 func (e *Epoch) Stop() {

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -11,8 +11,6 @@ import (
 	"encoding/asn1"
 	"encoding/binary"
 	"fmt"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 	"math"
 	rand2 "math/rand"
 	. "simplex"
@@ -20,6 +18,9 @@ import (
 	"simplex/wal"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestEpochFinalizeThenNotarize(t *testing.T) {

--- a/monitor.go
+++ b/monitor.go
@@ -5,9 +5,10 @@ package simplex
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"sync/atomic"
 	"time"
+
+	"go.uber.org/zap"
 )
 
 type Monitor struct {

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -60,7 +60,7 @@ func TestRecoverFromWALProposed(t *testing.T) {
 	err = e.Start()
 	require.NoError(t, err)
 
-	rounds := uint64(1)
+	rounds := uint64(100)
 	for i := uint64(0); i < rounds; i++ {
 		leader := LeaderForRound(nodes, uint64(i))
 		isEpochNode := leader.Equals(e.ID)
@@ -551,7 +551,8 @@ func TestRecoverFromMultipleNotarizations(t *testing.T) {
 	require.Equal(t, fCert2, storage.data[1].FinalizationCertificate)
 }
 
-// Block1, notarization 1, block 2, block 3,
+// TestRecoversFromMultipleNotarizations tests that the epoch can recover from a wal
+// with its last notarization record being from a less recent round. 
 func TestRecoveryWithoutNotarization(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
@@ -615,4 +616,5 @@ func TestRecoveryWithoutNotarization(t *testing.T) {
 
 	// ensure the round is properly set to 3
 	require.Equal(t, uint64(3), e.Metadata().Round)
+	require.Equal(t, uint64(3), e.Metadata().Seq)
 }

--- a/testutil/logger.go
+++ b/testutil/logger.go
@@ -4,11 +4,12 @@
 package testutil
 
 import (
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"os"
 	"strings"
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type TestLogger struct {


### PR DESCRIPTION
Couple small improvements
- No need to call `persistFinalizationCertifcate` when recovering from the WAL
- Fixed tests to reflect WAL(we would never add a fCert to the wal if its the next sequence to commit).