### PR TITLE
    Prevent re-execution of a block in the same round

### DIFF
--- a/sched.go
+++ b/sched.go
@@ -5,6 +5,7 @@ package simplex
 
 import (
 	"go.uber.org/zap"
+	"math"
 	"sync"
 )
 
@@ -167,4 +168,31 @@ func (t *dependencies) Remove(id Digest) []task {
 	dependents := t.dependsOn[id]
 	delete(t.dependsOn, id)
 	return dependents
+}
+
+// oneTimeBlockScheduler ensures each block is only scheduled once by forcing that blocks
+// would be scheduled in ascending order.
+type oneTimeBlockScheduler struct {
+	scheduler          *scheduler
+	lastRoundScheduled uint64
+}
+
+func newOneTimeBlockScheduler(scheduler *scheduler) *oneTimeBlockScheduler {
+	return &oneTimeBlockScheduler{scheduler: scheduler, lastRoundScheduled: math.MaxUint64}
+}
+
+func (otb *oneTimeBlockScheduler) Size() int {
+	return otb.scheduler.Size()
+}
+
+func (otb *oneTimeBlockScheduler) Schedule(f func() Digest, prev Digest, round uint64, ready bool) {
+	lastRoundScheduled := otb.lastRoundScheduled
+
+	if lastRoundScheduled != math.MaxUint64 && round <= lastRoundScheduled {
+		return
+	}
+
+	// Else, round > lastRoundScheduled, or it's the first time we entered this function because lastRoundScheduled is math.MaxUint64.
+	otb.lastRoundScheduled = round
+	otb.scheduler.Schedule(f, prev, ready)
 }


### PR DESCRIPTION
This commit prevents re-execution of a block of the same round, twice or more.
    
This prevents two things:
    
- A leader sending a block twice to the same node
- A node executing a block twice by receiving one from the leader via the consensus agreement path, and also receiving one from the replication code path.
    
It works by introducing a wrapper around the existing scheduler, which tracks the round number of the block being executed.

This doesn't prevent the same block from being proposed by different nodes in different rounds.
