### PR TITLE
Try to collect an empty notarization after sending an empty vote

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -1582,6 +1582,11 @@ func (e *Epoch) triggerProposalWaitTimeExpired(round uint64) {
 	emptyVotes.votes[string(e.ID)] = &signedEV
 
 	e.Comm.Broadcast(&Message{EmptyVoteMessage: &signedEV})
+
+	if err := e.maybeAssembleEmptyNotarization(); err != nil {
+		e.Logger.Error("Failed assembling empty notarization", zap.Error(err))
+		e.haltedError = err
+	}
 }
 
 func (e *Epoch) monitorProgress(round uint64) {


### PR DESCRIPTION
A node might be the last node among a quorum that times out. It therefore receives the empty votes before sending the empty vote itself, so it should check if it is possible to assemble an empty notarization right after sending the empty vote, because otherwise it might never get a trigger to check if an empty notarization can be assembled.