### PR TITLE
Check if round exists before accessing fields in metadata

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -1640,8 +1640,9 @@ func (e *Epoch) metadata() ProtocolMetadata {
 	highestRound := e.getHighestRound()
 	if highestRound != nil {
 		// Build on top of the latest block
-		prev = highestRound.block.BlockHeader().Digest
-		seq = highestRound.block.BlockHeader().Seq + 1
+		currMed := e.getHighestRound().block.BlockHeader()
+		prev = currMed.Digest
+		seq = currMed.Seq + 1
 	}
 
 	if e.lastBlock != nil {
@@ -2086,7 +2087,6 @@ func (e *Epoch) processReplicationState() error {
 // getHighestRound returns the highest round that has either a notarization of finalization
 func (e *Epoch) getHighestRound() *Round {
 	var max uint64
-
 	for _, round := range e.rounds {
 		if round.num > max {
 			if round.notarization == nil && round.fCert == nil {
@@ -2096,8 +2096,7 @@ func (e *Epoch) getHighestRound() *Round {
 		}
 	}
 
-	round := e.rounds[max]
-	return round
+	return e.rounds[max]
 }
 
 // isRoundTooFarAhead returns true if [round] is more than `maxRoundWindow` rounds ahead of the current round.

--- a/epoch.go
+++ b/epoch.go
@@ -1625,7 +1625,7 @@ func (e *Epoch) proposeBlock(block Block) error {
 	return errors.Join(e.handleVoteMessage(&vote, e.ID), e.maybeLoadFutureMessages())
 }
 
-// Metadata returns the metadata of the next expected block of the epoch. 
+// Metadata returns the metadata of the next expected block of the epoch.
 func (e *Epoch) Metadata() ProtocolMetadata {
 	e.lock.Lock()
 	defer e.lock.Unlock()
@@ -1637,8 +1637,8 @@ func (e *Epoch) metadata() ProtocolMetadata {
 	var prev Digest
 	seq := e.Storage.Height()
 
-	highestRound, ok := e.getHighestRound()
-	if ok {
+	highestRound := e.getHighestRound()
+	if highestRound != nil {
 		// Build on top of the latest block
 		prev = highestRound.block.BlockHeader().Digest
 		seq = highestRound.block.BlockHeader().Seq + 1
@@ -2084,7 +2084,7 @@ func (e *Epoch) processReplicationState() error {
 }
 
 // getHighestRound returns the highest round that has either a notarization of finalization
-func (e *Epoch) getHighestRound() (*Round, bool) {
+func (e *Epoch) getHighestRound() *Round {
 	var max uint64
 
 	for _, round := range e.rounds {
@@ -2096,8 +2096,8 @@ func (e *Epoch) getHighestRound() (*Round, bool) {
 		}
 	}
 
-	round, ok := e.rounds[max]
-	return round, ok
+	round := e.rounds[max]
+	return round
 }
 
 // isRoundTooFarAhead returns true if [round] is more than `maxRoundWindow` rounds ahead of the current round.

--- a/epoch_failover_test.go
+++ b/epoch_failover_test.go
@@ -766,7 +766,7 @@ func runCrashAndRestartExecution(t *testing.T, e *Epoch, bb *testBlockBuilder, w
 	// 2) The node crashes and restarts.
 	cloneWAL := wal.Clone()
 	cloneStorage := storage.Clone()
-	
+
 	nodes := e.Comm.ListNodes()
 
 	// Clone the block builder

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -650,5 +650,38 @@ func TestEpochCorrectlyInitializesMetadataFromStorage(t *testing.T) {
 	require.Equal(t, uint64(1), e.Metadata().Round)
 	require.Equal(t, uint64(1), e.Metadata().Seq)
 	require.Equal(t, block.BlockHeader().Digest, e.Metadata().Prev)
+}
 
+func TestRecoveryAsLeader(t *testing.T) {
+	l := testutil.MakeLogger(t, 1)
+	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+	finalizedBlocks := createBlocks(t, nodes, bb, 4)
+	storage := newInMemStorage()
+	for _, finalizedBlock := range finalizedBlocks {
+		storage.Index(finalizedBlock.Block, finalizedBlock.FCert)
+	}
+
+	conf := EpochConfig{
+		MaxProposalWait:   DefaultMaxProposalWaitTime,
+		Logger:            l,
+		ID:                nodes[0],
+		Signer:            &testSigner{},
+		WAL:               wal.NewMemWAL(t),
+		Verifier:          &testVerifier{},
+		Storage:           storage,
+		Comm:              noopComm(nodes),
+		BlockBuilder:      bb,
+		BlockDeserializer: &blockDeserializer{},
+		QCDeserializer:    &testQCDeserializer{t: t},
+	}
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+	require.Equal(t, uint64(4), e.Storage.Height())
+	require.NoError(t, e.Start())
+
+	// ensure the round is properly set
+	require.Equal(t, uint64(4), e.Metadata().Round)
+	require.Equal(t, uint64(4), e.Metadata().Seq)
 }

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -11,6 +11,7 @@ import (
 	"simplex/testutil"
 	"simplex/wal"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -680,6 +681,11 @@ func TestRecoveryAsLeader(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(4), e.Storage.Height())
 	require.NoError(t, e.Start())
+
+	<-bb.out
+
+	// wait for the block to finish verifying
+	time.Sleep(50 * time.Millisecond)
 
 	// ensure the round is properly set
 	require.Equal(t, uint64(4), e.Metadata().Round)


### PR DESCRIPTION
when the e.rounds map is populated but has no blocks with `notarizations` or `finalizations` the `metadata` function would panic on a `nil` dereference.