### PR TITLE
Add Go Fmt action to CI

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   format:
     name: Check Go Formatting

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,33 @@
+name: Go Format Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  format:
+    name: Check Go Formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Check Go Fmt
+        run: |
+          UNFORMATTED=$(gofmt -l .)
+
+          # If any files would be changed by gofmt, fail the check
+          if [ -n "$UNFORMATTED" ]; then
+            echo "The following files are not formatted properly:"
+            echo "$UNFORMATTED"
+            echo "Please run 'go fmt ./...' to format your code."
+            exit 1
+          fi
+
+          echo "All Go files are properly formatted."

--- a/epoch.go
+++ b/epoch.go
@@ -250,7 +250,7 @@ func (e *Epoch) restoreEmptyVoteRecord(r []byte) error {
 	emptyVote := &EmptyVote{
 		Signature: Signature{
 			Signer: e.ID,
-			Value: signature,
+			Value:  signature,
 		},
 		Vote: vote,
 	}
@@ -326,11 +326,11 @@ func (e *Epoch) resumeFromWal(records [][]byte) error {
 			return err
 		}
 		round, exists := e.emptyVotes[ev.Round]
-		if ! exists {
+		if !exists {
 			return fmt.Errorf("round %d not found for empty vote", ev.Round)
 		}
 		emptyVote, exists := round.votes[string(e.ID)]
-		if ! exists {
+		if !exists {
 			return fmt.Errorf("could not find my own vote for round %d", ev.Round)
 		}
 		lastMessage := Message{EmptyVoteMessage: emptyVote}

--- a/epoch_failover_test.go
+++ b/epoch_failover_test.go
@@ -766,7 +766,7 @@ func runCrashAndRestartExecution(t *testing.T, e *Epoch, bb *testBlockBuilder, w
 	// 2) The node crashes and restarts.
 	cloneWAL := wal.Clone()
 	cloneStorage := storage.Clone()
-	
+
 	nodes := e.Comm.ListNodes()
 
 	// Clone the block builder


### PR DESCRIPTION
@yacovm, i know you are not a fan of having linters so early on in the dev process, but I find myself running `go fmt` often and it many unnecessary diffs in our PRs. I think go fmt is a very standard and basic lint check that would be helpful to add.