### PR TITLE
Delete Old Runtime Map Key/Values

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -250,7 +250,7 @@ func (e *Epoch) restoreEmptyVoteRecord(r []byte) error {
 	emptyVote := &EmptyVote{
 		Signature: Signature{
 			Signer: e.ID,
-			Value: signature,
+			Value:  signature,
 		},
 		Vote: vote,
 	}
@@ -326,11 +326,11 @@ func (e *Epoch) resumeFromWal(records [][]byte) error {
 			return err
 		}
 		round, exists := e.emptyVotes[ev.Round]
-		if ! exists {
+		if !exists {
 			return fmt.Errorf("round %d not found for empty vote", ev.Round)
 		}
 		emptyVote, exists := round.votes[string(e.ID)]
-		if ! exists {
+		if !exists {
 			return fmt.Errorf("could not find my own vote for round %d", ev.Round)
 		}
 		lastMessage := Message{EmptyVoteMessage: emptyVote}
@@ -1812,7 +1812,7 @@ func (e *Epoch) voteOnBlock(block Block) (Vote, error) {
 
 func (e *Epoch) deleteRoundsTooFarInThePast() {
 	for i, round := range e.rounds {
-		if round.block.BlockHeader().Round + e.maxRoundWindow < e.round {
+		if round.block.BlockHeader().Round+e.maxRoundWindow < e.round {
 			if round.fCert != nil {
 				delete(e.rounds, i)
 			}
@@ -1824,7 +1824,7 @@ func (e *Epoch) deleteEmptyVoteForPreviousRound() {
 	if e.round == 0 {
 		return
 	}
-	delete(e.emptyVotes, e.round - 1)
+	delete(e.emptyVotes, e.round-1)
 }
 
 func (e *Epoch) increaseRound() {

--- a/epoch.go
+++ b/epoch.go
@@ -1820,14 +1820,11 @@ func (e *Epoch) deleteRoundsTooFarInThePast() {
 	}
 }
 
-func (e *Epoch) deleteEmptyVotesTooFarInThePast() {
-	for i, emptyVote := range e.emptyVotes {
-		if i + e.maxRoundWindow < e.round {
-			if emptyVote.emptyNotarization != nil {
-				delete(e.emptyVotes, i)
-			}
-		}
+func (e *Epoch) deleteEmptyVoteForPreviousRound() {
+	if e.round == 0 {
+		return
 	}
+	delete(e.emptyVotes, e.round - 1)
 }
 
 func (e *Epoch) increaseRound() {
@@ -1836,7 +1833,7 @@ func (e *Epoch) increaseRound() {
 	e.cancelWaitForBlockNotarization()
 
 	e.deleteRoundsTooFarInThePast()
-	e.deleteEmptyVotesTooFarInThePast()
+	e.deleteEmptyVoteForPreviousRound()
 
 	leader := LeaderForRound(e.nodes, e.round)
 	e.Logger.Info("Moving to a new round",

--- a/epoch_failover_test.go
+++ b/epoch_failover_test.go
@@ -766,7 +766,7 @@ func runCrashAndRestartExecution(t *testing.T, e *Epoch, bb *testBlockBuilder, w
 	// 2) The node crashes and restarts.
 	cloneWAL := wal.Clone()
 	cloneStorage := storage.Clone()
-	
+
 	nodes := e.Comm.ListNodes()
 
 	// Clone the block builder


### PR DESCRIPTION
Rather than deleting from `emptyVotes` immediately after persisting to the wal, we delete once the round has advanced enough. This is needed for replication, since nodes need to be able to retrieve `emptyNotarziation` when requested.  

Tthis PR also adds the same logic to the `rounds` map, as before `rounds` could have grown indefinitely. 