### PR TITLE
Distinguish between verified and unverified blocks

### DIFF
--- a/api.go
+++ b/api.go
@@ -37,7 +37,7 @@ type BlockBuilder interface {
 	// BuildBlock blocks until some transactions are available to be batched into a block,
 	// in which case a block and true are returned.
 	// When the given context is cancelled by the caller, returns false.
-	BuildBlock(ctx context.Context, metadata ProtocolMetadata) (Block, bool)
+	BuildBlock(ctx context.Context, metadata ProtocolMetadata) (VerifiedBlock, bool)
 
 	// IncomingBlock returns when either the given context is cancelled,
 	// or when the application signals that a block should be built.
@@ -48,8 +48,8 @@ type Storage interface {
 	Height() uint64
 	// Retrieve returns the block and finalization certificate at [seq].
 	// If [seq] is not found, returns false.
-	Retrieve(seq uint64) (Block, FinalizationCertificate, bool)
-	Index(block Block, certificate FinalizationCertificate)
+	Retrieve(seq uint64) (VerifiedBlock, FinalizationCertificate, bool)
+	Index(block VerifiedBlock, certificate FinalizationCertificate)
 }
 
 type Communication interface {
@@ -82,19 +82,24 @@ type Block interface {
 	// BlockHeader encodes a succinct and collision-free representation of a block.
 	BlockHeader() BlockHeader
 
+	// Verify verifies the block by speculatively executing it on top of its ancestor.
+	Verify(ctx context.Context) (VerifiedBlock, error)
+}
+
+type VerifiedBlock interface {
+	// BlockHeader encodes a succinct and collision-free representation of a block.
+	BlockHeader() BlockHeader
+
 	// Bytes returns a byte encoding of the block
 	Bytes() []byte
-
-	// Verify verifies the block by speculatively executing it on top of its ancestor.
-	Verify(ctx context.Context) error
 }
 
 // BlockDeserializer deserializes blocks according to formatting
 // enforced by the application.
 type BlockDeserializer interface {
-	// DeserializeBlock parses the given bytes and initializes a Block.
+	// DeserializeBlock parses the given bytes and initializes a VerifiedBlock.
 	// Returns an error upon failure.
-	DeserializeBlock(bytes []byte) (Block, error)
+	DeserializeBlock(bytes []byte) (VerifiedBlock, error)
 }
 
 // Signature encodes a signature and the node that signed it, without the message it was signed on.

--- a/encoding.go
+++ b/encoding.go
@@ -124,7 +124,7 @@ func BlockRecord(bh BlockHeader, blockData []byte) []byte {
 	return buff
 }
 
-func BlockFromRecord(blockDeserializer BlockDeserializer, record []byte) (Block, error) {
+func BlockFromRecord(blockDeserializer BlockDeserializer, record []byte) (VerifiedBlock, error) {
 	_, payload, err := ParseBlockRecord(record)
 	if err != nil {
 		return nil, err

--- a/epoch.go
+++ b/epoch.go
@@ -35,14 +35,14 @@ type EmptyVoteSet struct {
 
 type Round struct {
 	num           uint64
-	block         Block
+	block         VerifiedBlock
 	votes         map[string]*Vote // NodeID --> vote
 	notarization  *Notarization
 	finalizations map[string]*Finalization // NodeID --> vote
 	fCert         *FinalizationCertificate
 }
 
-func NewRound(block Block) *Round {
+func NewRound(block VerifiedBlock) *Round {
 	return &Round{
 		num:           block.BlockHeader().Round,
 		block:         block,
@@ -74,7 +74,7 @@ type Epoch struct {
 	// Runtime
 	sched                          *oneTimeBlockScheduler
 	lock                           sync.Mutex
-	lastBlock                      Block // latest block commited
+	lastBlock                      VerifiedBlock // latest block commited
 	canReceiveMessages             atomic.Bool
 	finishCtx                      context.Context
 	finishFn                       context.CancelFunc
@@ -303,8 +303,8 @@ func (e *Epoch) resumeFromWal(records [][]byte) error {
 			}
 			proposal := &Message{
 				BlockMessage: &BlockMessage{
-					Block: block,
-					Vote:  vote,
+					VerifiedBlock: block,
+					Vote:          vote,
 				},
 			}
 			// broadcast only if we are the leader
@@ -909,7 +909,7 @@ func (e *Epoch) indexFinalizationCertificates(startRound uint64) {
 	}
 }
 
-func (e *Epoch) indexFinalizationCertificate(block Block, fCert FinalizationCertificate) {
+func (e *Epoch) indexFinalizationCertificate(block VerifiedBlock, fCert FinalizationCertificate) {
 	e.Storage.Index(block, fCert)
 	e.Logger.Info("Committed block",
 		zap.Uint64("round", fCert.Finalization.Round),
@@ -1336,7 +1336,8 @@ func (e *Epoch) createBlockVerificationTask(block Block, from NodeID, vote Vote)
 			e.Logger.Debug("Block verification ended", zap.Uint64("round", md.Round), zap.Duration("elapsed", elapsed))
 		}()
 
-		if err := block.Verify(context.Background()); err != nil {
+		verifiedBlock, err := block.Verify(context.Background())
+		if err != nil {
 			e.Logger.Debug("Failed verifying block", zap.Error(err))
 			return md.Digest
 		}
@@ -1344,7 +1345,7 @@ func (e *Epoch) createBlockVerificationTask(block Block, from NodeID, vote Vote)
 		e.lock.Lock()
 		defer e.lock.Unlock()
 
-		record := BlockRecord(md, block.Bytes())
+		record := BlockRecord(md, verifiedBlock.Bytes())
 		if err := e.WAL.Append(record); err != nil {
 			e.haltedError = err
 			e.Logger.Error("Failed to append block record to WAL", zap.Error(err))
@@ -1355,7 +1356,7 @@ func (e *Epoch) createBlockVerificationTask(block Block, from NodeID, vote Vote)
 			zap.Uint64("round", md.Round),
 			zap.Stringer("digest", md.Digest))
 
-		if !e.storeProposal(block) {
+		if !e.storeProposal(verifiedBlock) {
 			e.Logger.Warn("Unable to store proposed block for the round", zap.Stringer("NodeID", from), zap.Uint64("round", md.Round))
 			return md.Digest
 			// TODO: timeout
@@ -1384,7 +1385,7 @@ func (e *Epoch) createBlockVerificationTask(block Block, from NodeID, vote Vote)
 		}
 		round.votes[string(vote.Signature.Signer)] = &vote
 
-		if err := e.doProposed(block); err != nil {
+		if err := e.doProposed(verifiedBlock); err != nil {
 			e.Logger.Warn("Failed voting on block", zap.Error(err))
 		}
 
@@ -1404,7 +1405,8 @@ func (e *Epoch) createBlockFinalizedVerificationTask(finalizedBlock FinalizedBlo
 			e.Logger.Debug("Block verification ended", zap.Uint64("round", md.Round), zap.Duration("elapsed", elapsed))
 		}()
 
-		if err := block.Verify(context.Background()); err != nil {
+		verifiedBlock, err := block.Verify(context.Background())
+		if err != nil {
 			e.Logger.Debug("Failed verifying block", zap.Error(err))
 			return md.Digest
 		}
@@ -1420,8 +1422,8 @@ func (e *Epoch) createBlockFinalizedVerificationTask(finalizedBlock FinalizedBlo
 				zap.Uint64("seq", md.Seq), zap.Uint64("height", e.Storage.Height()))
 			return md.Digest
 		}
-		e.indexFinalizationCertificate(block, finalizedBlock.FCert)
-		err := e.processReplicationState()
+		e.indexFinalizationCertificate(verifiedBlock, finalizedBlock.FCert)
+		err = e.processReplicationState()
 		if err != nil {
 			e.haltedError = err
 			e.Logger.Error("Failed to process replication state", zap.Error(err))
@@ -1521,7 +1523,7 @@ func (e *Epoch) verifyProposalIsPartOfOurChain(block Block) bool {
 // 2) Else, on storage.
 // Compares to the given digest, and if it's the same, returns it.
 // Otherwise, returns false.
-func (e *Epoch) locateBlock(seq uint64, digest []byte) (Block, bool) {
+func (e *Epoch) locateBlock(seq uint64, digest []byte) (VerifiedBlock, bool) {
 	// TODO index rounds by digest too to make it quicker
 	// TODO: optimize this by building an index from digest to round
 	for _, round := range e.rounds {
@@ -1583,7 +1585,7 @@ func (e *Epoch) createBlockBuildingTask(metadata ProtocolMetadata) func() Digest
 	}
 }
 
-func (e *Epoch) proposeBlock(block Block) error {
+func (e *Epoch) proposeBlock(block VerifiedBlock) error {
 	md := block.BlockHeader()
 
 	// Write record to WAL before broadcasting it, so that
@@ -1607,8 +1609,8 @@ func (e *Epoch) proposeBlock(block Block) error {
 
 	proposal := &Message{
 		BlockMessage: &BlockMessage{
-			Block: block,
-			Vote:  vote,
+			VerifiedBlock: block,
+			Vote:          vote,
 		},
 	}
 
@@ -1780,7 +1782,7 @@ func (e *Epoch) startRound() error {
 	return e.handleBlockMessage(msgsForRound.proposal, leaderForCurrentRound)
 }
 
-func (e *Epoch) doProposed(block Block) error {
+func (e *Epoch) doProposed(block VerifiedBlock) error {
 	vote, err := e.voteOnBlock(block)
 	if err != nil {
 		return err
@@ -1803,7 +1805,7 @@ func (e *Epoch) doProposed(block Block) error {
 	return e.handleVoteMessage(&vote, e.ID)
 }
 
-func (e *Epoch) voteOnBlock(block Block) (Vote, error) {
+func (e *Epoch) voteOnBlock(block VerifiedBlock) (Vote, error) {
 	vote := ToBeSignedVote{BlockHeader: block.BlockHeader()}
 	sig, err := vote.Sign(e.Signer)
 	if err != nil {
@@ -1954,7 +1956,7 @@ func (e *Epoch) futureMessagesForRoundEmpty(msgs *messagesForRound) bool {
 
 // storeProposal stores a block in the epochs memory(NOT storage).
 // it creates a new round with the block and stores it in the rounds map.
-func (e *Epoch) storeProposal(block Block) bool {
+func (e *Epoch) storeProposal(block VerifiedBlock) bool {
 	md := block.BlockHeader()
 
 	// Have we already received a block from that node?
@@ -2006,8 +2008,8 @@ func (e *Epoch) handleFinalizationCertificateRequest(req *FinalizationCertificat
 			break
 		}
 		data[i] = FinalizedBlock{
-			Block: block,
-			FCert: fCert,
+			VerifiedBlock: block,
+			FCert:         fCert,
 		}
 	}
 	e.Logger.Debug("Sending finalization certificate response", zap.Int("num seqs", len(data)), zap.Any("seqs", seqs))
@@ -2016,7 +2018,7 @@ func (e *Epoch) handleFinalizationCertificateRequest(req *FinalizationCertificat
 	}
 }
 
-func (e *Epoch) locateSequence(seq uint64) (Block, FinalizationCertificate, bool) {
+func (e *Epoch) locateSequence(seq uint64) (VerifiedBlock, FinalizationCertificate, bool) {
 	for _, round := range e.rounds {
 		blockSeq := round.block.BlockHeader().Seq
 		if blockSeq == seq {

--- a/epoch_failover_test.go
+++ b/epoch_failover_test.go
@@ -91,7 +91,7 @@ func TestEpochLeaderFailoverWithEmptyNotarization(t *testing.T) {
 	for len(bb.out) > 0 {
 		<-bb.out
 	}
-	for _, block := range []Block{block1, block2, block3} {
+	for _, block := range []VerifiedBlock{block1, block2, block3} {
 		bb.out <- block.(*testBlock)
 		bb.in <- block.(*testBlock)
 	}
@@ -368,18 +368,18 @@ func TestEpochNoFinalizationAfterEmptyVote(t *testing.T) {
 
 	waitForBlockProposerTimeout(t, e, start)
 
-	block, _, ok := storage.Retrieve(0)
+	b, _, ok := storage.Retrieve(0)
 	require.True(t, ok)
 
 	leader := LeaderForRound(nodes, 1)
 	_, ok = bb.BuildBlock(context.Background(), ProtocolMetadata{
-		Prev:  block.BlockHeader().Digest,
+		Prev:  b.BlockHeader().Digest,
 		Round: 1,
 		Seq:   1,
 	})
 	require.True(t, ok)
 
-	block = <-bb.out
+	block := <-bb.out
 
 	vote, err := newTestVote(block, leader)
 	require.NoError(t, err)

--- a/msg.go
+++ b/msg.go
@@ -184,8 +184,9 @@ func (n *Notarization) Verify() error {
 }
 
 type BlockMessage struct {
-	Block Block
-	Vote  Vote
+	Block         Block
+	VerifiedBlock VerifiedBlock
+	Vote          Vote
 }
 
 type EmptyNotarization struct {
@@ -228,8 +229,9 @@ type FinalizationCertificateRequest struct {
 }
 
 type FinalizedBlock struct {
-	Block Block
-	FCert FinalizationCertificate
+	Block         Block
+	VerifiedBlock VerifiedBlock
+	FCert         FinalizationCertificate
 }
 
 type FinalizationCertificateResponse struct {

--- a/notarization_test.go
+++ b/notarization_test.go
@@ -21,7 +21,7 @@ func TestNewNotarization(t *testing.T) {
 	tests := []struct {
 		name                 string
 		votesForCurrentRound map[string]*simplex.Vote
-		block                simplex.Block
+		block                simplex.VerifiedBlock
 		expectError          error
 		signatureAggregator  simplex.SignatureAggregator
 	}{

--- a/record_test.go
+++ b/record_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newNotarization(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID) (simplex.Notarization, error) {
+func newNotarization(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.VerifiedBlock, ids []simplex.NodeID) (simplex.Notarization, error) {
 	votesForCurrentRound := make(map[string]*simplex.Vote)
 	for _, id := range ids {
 		vote, err := newTestVote(block, id)
@@ -26,7 +26,7 @@ func newNotarization(logger simplex.Logger, signatureAggregator simplex.Signatur
 	return notarization, err
 }
 
-func newNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID) ([]byte, error) {
+func newNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.VerifiedBlock, ids []simplex.NodeID) ([]byte, error) {
 	notarization, err := newNotarization(logger, signatureAggregator, block, ids)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func newNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.Si
 }
 
 // creates a new finalization certificate
-func newFinalizationRecord(t *testing.T, logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID) (simplex.FinalizationCertificate, []byte) {
+func newFinalizationRecord(t *testing.T, logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.VerifiedBlock, ids []simplex.NodeID) (simplex.FinalizationCertificate, []byte) {
 	finalizations := make([]*simplex.Finalization, len(ids))
 	for i, id := range ids {
 		finalizations[i] = newTestFinalization(t, block, id)

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -167,7 +167,7 @@ func TestRecoverFromNotarization(t *testing.T) {
 		injectTestFinalization(t, e, block, nodes[i])
 	}
 
-	committedData := storage.data[0].Block.Bytes()
+	committedData := storage.data[0].VerifiedBlock.Bytes()
 	require.Equal(t, block.Bytes(), committedData)
 	require.Equal(t, uint64(1), e.Storage.Height())
 }
@@ -237,7 +237,7 @@ func TestRecoverFromWalWithStorage(t *testing.T) {
 		injectTestFinalization(t, e, block, nodes[i])
 	}
 
-	committedData := storage.data[1].Block.Bytes()
+	committedData := storage.data[1].VerifiedBlock.Bytes()
 	require.Equal(t, block.Bytes(), committedData)
 	require.Equal(t, uint64(2), e.Storage.Height())
 }
@@ -309,7 +309,7 @@ func TestWalCreatedProperly(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, records, 2)
 
-	committedData := storage.data[0].Block.Bytes()
+	committedData := storage.data[0].VerifiedBlock.Bytes()
 	require.Equal(t, block.Bytes(), committedData)
 }
 
@@ -546,8 +546,8 @@ func TestRecoverFromMultipleNotarizations(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(2), e.Storage.Height())
-	require.Equal(t, firstBlock.Bytes(), storage.data[0].Block.Bytes())
-	require.Equal(t, secondBlock.Bytes(), storage.data[1].Block.Bytes())
+	require.Equal(t, firstBlock.Bytes(), storage.data[0].VerifiedBlock.Bytes())
+	require.Equal(t, secondBlock.Bytes(), storage.data[1].VerifiedBlock.Bytes())
 	require.Equal(t, fCert1, storage.data[0].FinalizationCertificate)
 	require.Equal(t, fCert2, storage.data[1].FinalizationCertificate)
 }
@@ -660,7 +660,7 @@ func TestRecoveryAsLeader(t *testing.T) {
 	finalizedBlocks := createBlocks(t, nodes, bb, 4)
 	storage := newInMemStorage()
 	for _, finalizedBlock := range finalizedBlocks {
-		storage.Index(finalizedBlock.Block, finalizedBlock.FCert)
+		storage.Index(finalizedBlock.VerifiedBlock, finalizedBlock.FCert)
 	}
 
 	conf := EpochConfig{

--- a/replication_test.go
+++ b/replication_test.go
@@ -41,7 +41,7 @@ func TestHandleFinalizationCertificateRequest(t *testing.T) {
 
 	seqs := createBlocks(t, nodes, bb, 10)
 	for _, data := range seqs {
-		conf.Storage.Index(data.Block, data.FCert)
+		conf.Storage.Index(data.VerifiedBlock, data.FCert)
 	}
 	e, err := simplex.NewEpoch(conf)
 	require.NoError(t, err)
@@ -141,7 +141,7 @@ func TestReplicationStartsBeforeCurrentRound(t *testing.T) {
 	normalNode3 := newSimplexNodeWithStorage(t, nodes[2], net, bb, storageData)
 	laggingNode := newSimplexNode(t, nodes[3], net, bb, true)
 
-	firstBlock := storageData[0].Block
+	firstBlock := storageData[0].VerifiedBlock
 	record := simplex.BlockRecord(firstBlock.BlockHeader(), firstBlock.Bytes())
 	laggingNode.wal.Append(record)
 
@@ -149,7 +149,7 @@ func TestReplicationStartsBeforeCurrentRound(t *testing.T) {
 	require.NoError(t, err)
 	laggingNode.wal.Append(firstNotarizationRecord)
 
-	secondBlock := storageData[1].Block
+	secondBlock := storageData[1].VerifiedBlock
 	record = simplex.BlockRecord(secondBlock.BlockHeader(), secondBlock.Bytes())
 	laggingNode.wal.Append(record)
 
@@ -368,8 +368,8 @@ func createBlocks(t *testing.T, nodes []simplex.NodeID, bb simplex.BlockBuilder,
 		prev = block.BlockHeader().Digest
 		fCert, _ := newFinalizationRecord(t, logger, &testSignatureAggregator{}, block, nodes)
 		data = append(data, simplex.FinalizedBlock{
-			Block: block,
-			FCert: fCert,
+			VerifiedBlock: block,
+			FCert:         fCert,
 		})
 	}
 	return data

--- a/util.go
+++ b/util.go
@@ -12,7 +12,7 @@ import (
 // RetrieveLastIndexFromStorage retrieves the latest block and fCert from storage.
 // Returns an error if it cannot be retrieved but the storage has some block.
 // Returns (nil, nil) if the storage is empty.
-func RetrieveLastIndexFromStorage(s Storage) (Block, *FinalizationCertificate, error) {
+func RetrieveLastIndexFromStorage(s Storage) (VerifiedBlock, *FinalizationCertificate, error) {
 	height := s.Height()
 	if height == 0 {
 		return nil, nil, nil

--- a/util_test.go
+++ b/util_test.go
@@ -16,9 +16,9 @@ import (
 func TestRetrieveFromStorage(t *testing.T) {
 	brokenStorage := newInMemStorage()
 	brokenStorage.data[41] = struct {
-		Block
+		VerifiedBlock
 		FinalizationCertificate
-	}{Block: newTestBlock(ProtocolMetadata{Seq: 41})}
+	}{VerifiedBlock: newTestBlock(ProtocolMetadata{Seq: 41})}
 
 	block := newTestBlock(ProtocolMetadata{Seq: 0})
 	fCert := FinalizationCertificate{
@@ -28,15 +28,15 @@ func TestRetrieveFromStorage(t *testing.T) {
 	}
 	normalStorage := newInMemStorage()
 	normalStorage.data[0] = struct {
-		Block
+		VerifiedBlock
 		FinalizationCertificate
-	}{Block: block, FinalizationCertificate: fCert}
+	}{VerifiedBlock: block, FinalizationCertificate: fCert}
 
 	for _, testCase := range []struct {
 		description   string
 		storage       Storage
 		expectedErr   error
-		expectedBlock Block
+		expectedBlock VerifiedBlock
 		expectedFCert *FinalizationCertificate
 	}{
 		{


### PR DESCRIPTION
When we receive a block from the network, it should be verified before it can be persisted into stable storage.

Similarly, when we load a block from stable storage, there is no more need to verify it, as we had verified it before.

This commit makes the compiler enforce that a block received from the network cannot be persisted into stable storage before it has been verified.