### PR TITLE
Update Collect Finalization Certificates to Properly Return Early

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -52,7 +52,7 @@ func (r *ReplicationState) collectFutureFinalizationCertificates(fCert *Finaliza
 	fCertSeq := fCert.Finalization.Seq
 	// Don't exceed the max round window
 	endSeq := math.Min(float64(fCertSeq), float64(r.maxRoundWindow+currentRound))
-	
+
 	// Node is behind, but we've already sent messages to collect future fCerts
 	if r.highestFCertReceived != nil && r.lastSequenceRequested >= uint64(endSeq) {
 		return

--- a/replication.go
+++ b/replication.go
@@ -52,12 +52,14 @@ func (r *ReplicationState) collectFutureFinalizationCertificates(fCert *Finaliza
 	fCertSeq := fCert.Finalization.Seq
 	// Don't exceed the max round window
 	endSeq := math.Min(float64(fCertSeq), float64(r.maxRoundWindow+currentRound))
+	
+	// Node is behind, but we've already sent messages to collect future fCerts
+	if r.highestFCertReceived != nil && r.lastSequenceRequested >= uint64(endSeq) {
+		return
+	}
+
 	if r.highestFCertReceived == nil || fCertSeq > r.highestFCertReceived.Finalization.Seq {
 		r.highestFCertReceived = fCert
-	}
-	// Node is behind, but we've already sent messages to collect future fCerts
-	if r.lastSequenceRequested >= uint64(endSeq) {
-		return
 	}
 
 	startSeq := math.Max(float64(nextSeqToCommit), float64(r.lastSequenceRequested))


### PR DESCRIPTION
The previous code would have returned early if the lagging node requested had an `endSeq` of 0. Therefore, because `lastSequenceRequested` defaults to 0, we also need to check if `highestFcertReceived` is populated before exiting early. 
