### PR TITLE
Make sure QC only contains authorized signers and is not signed twice

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -471,7 +471,7 @@ func (e *Epoch) handleFinalizationCertificateMessage(message *FinalizationCertif
 		return nil
 	}
 
-	valid := IsFinalizationCertificateValid(message, e.quorumSize, e.Logger)
+	valid := IsFinalizationCertificateValid(e.eligibleNodeIDs, message, e.quorumSize, e.Logger)
 	if !valid {
 		e.Logger.Debug("Received an invalid finalization certificate",
 			zap.Int("round", int(message.Finalization.Round)),
@@ -1059,6 +1059,7 @@ func (e *Epoch) persistNotarization(notarization Notarization) error {
 		e.Logger.Error("Failed to append notarization record to WAL", zap.Error(err))
 		return err
 	}
+
 	e.Logger.Debug("Persisted notarization to WAL",
 		zap.Int("size", len(record)),
 		zap.Uint64("round", notarization.Vote.Round),
@@ -1109,8 +1110,8 @@ func (e *Epoch) handleEmptyNotarizationMessage(emptyNotarization *EmptyNotarizat
 	}
 
 	// Otherwise, this round is not notarized or finalized yet, so verify the empty notarization and store it.
-	if err := emptyNotarization.Verify(); err != nil {
-		e.Logger.Debug("Empty Notarization is invalid", zap.Error(err))
+
+	if !e.verifyEmptyNotarization(emptyNotarization) {
 		return nil
 	}
 
@@ -1126,6 +1127,37 @@ func (e *Epoch) handleEmptyNotarizationMessage(emptyNotarization *EmptyNotarizat
 	return e.persistEmptyNotarization(emptyNotarization, false)
 }
 
+func (e *Epoch) verifyEmptyNotarization(emptyNotarization *EmptyNotarization) bool {
+	// Check empty notarization was signed by only eligible nodes
+	for _, signer := range emptyNotarization.QC.Signers() {
+		if _, exists := e.eligibleNodeIDs[string(signer)]; !exists {
+			e.Logger.Warn("Empty notarization quorum certificate contains an unknown signer", zap.Stringer("signer", signer))
+			return false
+		}
+	}
+
+	// Ensure no node signed the empty notarization twice
+	doubleSigner, signedTwice := hasSomeNodeSignedTwice(emptyNotarization.QC.Signers(), e.Logger)
+	if signedTwice {
+		e.Logger.Warn("A node has signed the empty notarization twice", zap.Stringer("signer", doubleSigner))
+		return false
+	}
+
+	// Check enough signers signed the empty notarization
+	if e.quorumSize > len(emptyNotarization.QC.Signers()) {
+		e.Logger.Warn("Empty notarization signed by insufficient nodes",
+			zap.Int("count", len(emptyNotarization.QC.Signers())),
+			zap.Int("Quorum", e.quorumSize))
+		return false
+	}
+
+	if err := emptyNotarization.Verify(); err != nil {
+		e.Logger.Debug("Empty Notarization is invalid", zap.Error(err))
+		return false
+	}
+	return true
+}
+
 func (e *Epoch) handleNotarizationMessage(message *Notarization, from NodeID) error {
 	vote := message.Vote
 
@@ -1138,9 +1170,7 @@ func (e *Epoch) handleNotarizationMessage(message *Notarization, from NodeID) er
 		return nil
 	}
 
-	if err := message.Verify(); err != nil {
-		e.Logger.Debug("Notarization quorum certificate is invalid",
-			zap.Stringer("NodeID", from), zap.Error(err))
+	if !e.verifyNotarization(message, from) {
 		return nil
 	}
 
@@ -1166,6 +1196,38 @@ func (e *Epoch) handleNotarizationMessage(message *Notarization, from NodeID) er
 	// Note that we don't need to check if we have timed out on this round,
 	// because if we had collected an empty notarization for this round, we would have progressed to the next round.
 	return e.persistNotarization(*message)
+}
+
+func (e *Epoch) verifyNotarization(message *Notarization, from NodeID) bool {
+	// Ensure no node signed the notarization twice
+	doubleSigner, signedTwice := hasSomeNodeSignedTwice(message.QC.Signers(), e.Logger)
+	if signedTwice {
+		e.Logger.Warn("A node has signed the notarization twice", zap.Stringer("signer", doubleSigner))
+		return false
+	}
+
+	// Check enough signers signed the notarization
+	if e.quorumSize > len(message.QC.Signers()) {
+		e.Logger.Warn("Notarization certificate signed by insufficient nodes",
+			zap.Int("count", len(message.QC.Signers())),
+			zap.Int("Quorum", e.quorumSize))
+		return false
+	}
+
+	// Check notarization was signed by only eligible nodes
+	for _, signer := range message.QC.Signers() {
+		if _, exists := e.eligibleNodeIDs[string(signer)]; !exists {
+			e.Logger.Warn("Notarization quorum certificate contains an unknown signer", zap.Stringer("signer", signer))
+			return false
+		}
+	}
+
+	if err := message.Verify(); err != nil {
+		e.Logger.Debug("Notarization quorum certificate is invalid",
+			zap.Stringer("NodeID", from), zap.Error(err))
+		return false
+	}
+	return true
 }
 
 func (e *Epoch) handleBlockMessage(message *BlockMessage, from NodeID) error {
@@ -2049,7 +2111,7 @@ func (e *Epoch) handleFinalizationCertificateResponse(resp *FinalizationCertific
 			continue
 		}
 
-		valid := IsFinalizationCertificateValid(&data.FCert, e.quorumSize, e.Logger)
+		valid := IsFinalizationCertificateValid(e.eligibleNodeIDs, &data.FCert, e.quorumSize, e.Logger)
 		// verify the finalization certificate
 		if !valid {
 			e.Logger.Debug("Received invalid finalization certificate", zap.Uint64("seq", data.FCert.Finalization.Seq), zap.String("from", from.String()))

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -16,6 +16,7 @@ import (
 	. "simplex"
 	"simplex/testutil"
 	"simplex/wal"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -545,6 +546,177 @@ func TestEpochBlockSentTwice(t *testing.T) {
 	wal.assertWALSize(0)
 	require.True(t, alreadyReceivedMsg)
 
+}
+
+func TestEpochQCSignedByNonExistentNodes(t *testing.T) {
+	l := testutil.MakeLogger(t, 1)
+
+	var wg sync.WaitGroup
+	wg.Add(6)
+
+	//defer wg.Wait()
+
+	unknownNotarizationChan := make(chan struct{})
+	unknownEmptyNotarizationChan := make(chan struct{})
+	unknownFinalizationChan := make(chan struct{})
+	doubleNotarizationChan := make(chan struct{})
+	doubleEmptyNotarizationChan := make(chan struct{})
+	doubleFinalizationChan := make(chan struct{})
+
+	callbacks := map[string]func(){
+		"Notarization quorum certificate contains an unknown signer": func() {
+			wg.Done()
+			close(unknownNotarizationChan)
+		},
+		"Empty notarization quorum certificate contains an unknown signer": func() {
+			wg.Done()
+			close(unknownEmptyNotarizationChan)
+		},
+		"Finalization Quorum Certificate contains an unknown signer": func() {
+			wg.Done()
+			close(unknownFinalizationChan)
+		},
+		"A node has signed the notarization twice": func() {
+			wg.Done()
+			close(doubleNotarizationChan)
+		},
+		"A node has signed the empty notarization twice": func() {
+			wg.Done()
+			close(doubleEmptyNotarizationChan)
+		},
+		"Finalization certificate signed twice by the same node": func() {
+			wg.Done()
+			close(doubleFinalizationChan)
+		},
+	}
+
+	l.Intercept(func(entry zapcore.Entry) error {
+		for key, f := range callbacks {
+			if strings.Contains(entry.Message, key) {
+				f()
+			}
+		}
+		return nil
+	})
+
+	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
+	storage := newInMemStorage()
+
+	wal := newTestWAL(t)
+
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+	conf := EpochConfig{
+		MaxProposalWait:     DefaultMaxProposalWaitTime,
+		Logger:              l,
+		ID:                  nodes[0],
+		Signer:              &testSigner{},
+		WAL:                 wal,
+		Verifier:            &testVerifier{},
+		Storage:             storage,
+		Comm:                noopComm(nodes),
+		BlockBuilder:        bb,
+		SignatureAggregator: &testSignatureAggregator{},
+	}
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+
+	require.NoError(t, e.Start())
+
+	block := <-bb.out
+
+	wal.assertWALSize(1)
+
+	t.Run("notarization with unknown signer isn't taken into account", func(t *testing.T) {
+		notarization, err := newNotarization(l, &testSignatureAggregator{}, block, []NodeID{{2}, {3}, {5}})
+		require.NoError(t, err)
+
+		err = e.HandleMessage(&Message{
+			Notarization: &notarization,
+		}, nodes[1])
+		require.NoError(t, err)
+
+		time.Sleep(time.Second)
+		rawWAL, err := wal.WriteAheadLog.ReadAll()
+		require.NoError(t, err)
+		fmt.Println(">>>", len(rawWAL))
+
+		wal.assertWALSize(1)
+	})
+
+	t.Run("notarization with double signer isn't taken into account", func(t *testing.T) {
+		notarization, err := newNotarization(l, &testSignatureAggregator{}, block, []NodeID{{2}, {3}, {2}})
+		require.NoError(t, err)
+
+		err = e.HandleMessage(&Message{
+			Notarization: &notarization,
+		}, nodes[1])
+		require.NoError(t, err)
+
+		wal.assertWALSize(1)
+	})
+
+	t.Run("empty notarization with unknown signer isn't taken into account", func(t *testing.T) {
+		var qc testQC
+		for i, n := range []NodeID{{2}, {3}, {5}} {
+			qc = append(qc, Signature{Signer: n, Value: []byte{byte(i)}})
+		}
+
+		err = e.HandleMessage(&Message{
+			EmptyNotarization: &EmptyNotarization{
+				Vote: ToBeSignedEmptyVote{ProtocolMetadata: ProtocolMetadata{
+					Round: 0,
+					Seq:   0,
+				}},
+				QC: qc,
+			},
+		}, nodes[1])
+		require.NoError(t, err)
+
+		wal.assertWALSize(1)
+	})
+
+	t.Run("empty notarization with double signer isn't taken into account", func(t *testing.T) {
+		var qc testQC
+		for i, n := range []NodeID{{2}, {3}, {2}} {
+			qc = append(qc, Signature{Signer: n, Value: []byte{byte(i)}})
+		}
+
+		err = e.HandleMessage(&Message{
+			EmptyNotarization: &EmptyNotarization{
+				Vote: ToBeSignedEmptyVote{ProtocolMetadata: ProtocolMetadata{
+					Round: 0,
+					Seq:   0,
+				}},
+				QC: qc,
+			},
+		}, nodes[1])
+		require.NoError(t, err)
+
+		wal.assertWALSize(1)
+	})
+
+	t.Run("finalization certificate with unknown signer isn't taken into account", func(t *testing.T) {
+		fCert, _ := newFinalizationRecord(t, l, &testSignatureAggregator{}, block, []NodeID{{2}, {3}, {5}})
+
+		err = e.HandleMessage(&Message{
+			FinalizationCertificate: &fCert,
+		}, nodes[1])
+		require.NoError(t, err)
+
+		storage.ensureNoBlockCommit(t, 0)
+	})
+
+	t.Run("finalization certificate with double signer isn't taken into account", func(t *testing.T) {
+		fCert, _ := newFinalizationRecord(t, l, &testSignatureAggregator{}, block, []NodeID{{2}, {3}, {3}})
+
+		err = e.HandleMessage(&Message{
+			FinalizationCertificate: &fCert,
+		}, nodes[1])
+		require.NoError(t, err)
+
+		storage.ensureNoBlockCommit(t, 0)
+	})
 }
 
 func TestEpochBlockSentFromNonLeader(t *testing.T) {

--- a/util.go
+++ b/util.go
@@ -24,8 +24,8 @@ func RetrieveLastIndexFromStorage(s Storage) (Block, *FinalizationCertificate, e
 	return lastBlock, &fCert, nil
 }
 
-func IsFinalizationCertificateValid(fCert *FinalizationCertificate, quorumSize int, logger Logger) bool {
-	valid := validateFinalizationQC(fCert, quorumSize, logger)
+func IsFinalizationCertificateValid(eligibleSigners map[string]struct{}, fCert *FinalizationCertificate, quorumSize int, logger Logger) bool {
+	valid := validateFinalizationQC(eligibleSigners, fCert, quorumSize, logger)
 	if !valid {
 		return false
 	}
@@ -36,7 +36,7 @@ func IsFinalizationCertificateValid(fCert *FinalizationCertificate, quorumSize i
 	return true
 }
 
-func validateFinalizationQC(fCert *FinalizationCertificate, quorumSize int, logger Logger) bool {
+func validateFinalizationQC(eligibleSigners map[string]struct{}, fCert *FinalizationCertificate, quorumSize int, logger Logger) bool {
 	if fCert.QC == nil {
 		return false
 	}
@@ -49,10 +49,19 @@ func validateFinalizationQC(fCert *FinalizationCertificate, quorumSize int, logg
 		return false
 	}
 
-	signedTwice := hasSomeNodeSignedTwice(fCert.QC.Signers(), logger)
+	doubleSigner, signedTwice := hasSomeNodeSignedTwice(fCert.QC.Signers(), logger)
 
 	if signedTwice {
+		logger.Debug("Finalization certificate signed twice by the same node", zap.Stringer("signer", doubleSigner))
 		return false
+	}
+
+	// Finally, check that all signers are eligible of signing, and we don't have made up identities
+	for _, signer := range fCert.QC.Signers() {
+		if _, exists := eligibleSigners[string(signer)]; !exists {
+			logger.Debug("Finalization Quorum Certificate contains an unknown signer", zap.Stringer("signer", signer))
+			return false
+		}
 	}
 
 	if err := fCert.Verify(); err != nil {
@@ -62,16 +71,16 @@ func validateFinalizationQC(fCert *FinalizationCertificate, quorumSize int, logg
 	return true
 }
 
-func hasSomeNodeSignedTwice(nodeIDs []NodeID, logger Logger) bool {
+func hasSomeNodeSignedTwice(nodeIDs []NodeID, logger Logger) (NodeID, bool) {
 	seen := make(map[string]struct{}, len(nodeIDs))
 
 	for _, nodeID := range nodeIDs {
 		if _, alreadySeen := seen[string(nodeID)]; alreadySeen {
 			logger.Warn("Observed a signature originating at least twice from the same node")
-			return true
+			return nodeID, true
 		}
 		seen[string(nodeID)] = struct{}{}
 	}
 
-	return false
+	return NodeID{}, false
 }


### PR DESCRIPTION
This commit makes sure that a QC only contains signers that are among the nodes the Epoch was initialized with. Similarly, it checks the QC is not signed twice or not signed by too few nodes.

This eases the implementation of a QC by the application, especially for naive implementations where the QC contains the public keys of the signers, and the Signers() method just returns a deterministic derivation of the aforementioned public keys.