### PR TITLE
Replication of Future Sequences & Rounds

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,36 @@
+name: Go Format Check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  format:
+    name: Check Go Formatting
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Check Go Fmt
+        run: |
+          UNFORMATTED=$(gofmt -l .)
+
+          # If any files would be changed by gofmt, fail the check
+          if [ -n "$UNFORMATTED" ]; then
+            echo "The following files are not formatted properly:"
+            echo "$UNFORMATTED"
+            echo "Please run 'go fmt ./...' to format your code."
+            exit 1
+          fi
+
+          echo "All Go files are properly formatted."

--- a/api.go
+++ b/api.go
@@ -37,7 +37,7 @@ type BlockBuilder interface {
 	// BuildBlock blocks until some transactions are available to be batched into a block,
 	// in which case a block and true are returned.
 	// When the given context is cancelled by the caller, returns false.
-	BuildBlock(ctx context.Context, metadata ProtocolMetadata) (Block, bool)
+	BuildBlock(ctx context.Context, metadata ProtocolMetadata) (VerifiedBlock, bool)
 
 	// IncomingBlock returns when either the given context is cancelled,
 	// or when the application signals that a block should be built.
@@ -48,8 +48,8 @@ type Storage interface {
 	Height() uint64
 	// Retrieve returns the block and finalization certificate at [seq].
 	// If [seq] is not found, returns false.
-	Retrieve(seq uint64) (Block, FinalizationCertificate, bool)
-	Index(block Block, certificate FinalizationCertificate)
+	Retrieve(seq uint64) (VerifiedBlock, FinalizationCertificate, bool)
+	Index(block VerifiedBlock, certificate FinalizationCertificate)
 }
 
 type Communication interface {
@@ -82,19 +82,24 @@ type Block interface {
 	// BlockHeader encodes a succinct and collision-free representation of a block.
 	BlockHeader() BlockHeader
 
+	// Verify verifies the block by speculatively executing it on top of its ancestor.
+	Verify(ctx context.Context) (VerifiedBlock, error)
+}
+
+type VerifiedBlock interface {
+	// BlockHeader encodes a succinct and collision-free representation of a block.
+	BlockHeader() BlockHeader
+
 	// Bytes returns a byte encoding of the block
 	Bytes() []byte
-
-	// Verify verifies the block by speculatively executing it on top of its ancestor.
-	Verify() error
 }
 
 // BlockDeserializer deserializes blocks according to formatting
 // enforced by the application.
 type BlockDeserializer interface {
-	// DeserializeBlock parses the given bytes and initializes a Block.
+	// DeserializeBlock parses the given bytes and initializes a VerifiedBlock.
 	// Returns an error upon failure.
-	DeserializeBlock(bytes []byte) (Block, error)
+	DeserializeBlock(bytes []byte) (VerifiedBlock, error)
 }
 
 // Signature encodes a signature and the node that signed it, without the message it was signed on.

--- a/encoding.go
+++ b/encoding.go
@@ -124,7 +124,7 @@ func BlockRecord(bh BlockHeader, blockData []byte) []byte {
 	return buff
 }
 
-func BlockFromRecord(blockDeserializer BlockDeserializer, record []byte) (Block, error) {
+func BlockFromRecord(blockDeserializer BlockDeserializer, record []byte) (VerifiedBlock, error) {
 	_, payload, err := ParseBlockRecord(record)
 	if err != nil {
 		return nil, err

--- a/epoch_failover_test.go
+++ b/epoch_failover_test.go
@@ -5,6 +5,7 @@ package simplex_test
 
 import (
 	"context"
+	"simplex"
 	. "simplex"
 	"simplex/testutil"
 	"sync/atomic"
@@ -120,6 +121,25 @@ func TestEpochLeaderFailoverWithEmptyNotarization(t *testing.T) {
 	// Ensure our node proposes block with sequence 3 for round 4
 	notarizeAndFinalizeRound(t, nodes, nextRoundToCommit, nextBlockSeqToCommit, e, bb, quorum, storage, false)
 	require.Equal(t, uint64(4), storage.Height())
+}
+
+func newEmptyNotarization(t *testing.T, e *Epoch, round uint64) *EmptyNotarization {
+	quorum := simplex.Quorum(len(e.Comm.ListNodes()))
+	var qc testQC
+
+	for i := 0; i <= quorum; i++ {
+		qc = append(qc, Signature{Signer: NodeID{byte(i)}, Value: []byte{byte(i)}})
+	}
+
+	return &EmptyNotarization{
+		QC: qc,
+		Vote: ToBeSignedEmptyVote{ProtocolMetadata: ProtocolMetadata{
+			Prev:  Digest{},
+			Round: round,
+			Seq:   round,
+		}},
+
+	}
 }
 
 func TestEpochLeaderFailoverReceivesEmptyVotesEarly(t *testing.T) {

--- a/epoch_failover_test.go
+++ b/epoch_failover_test.go
@@ -5,7 +5,7 @@ package simplex_test
 
 import (
 	"context"
-	"simplex"
+	"fmt"
 	. "simplex"
 	"simplex/testutil"
 	"sync/atomic"
@@ -16,18 +16,25 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// TestEpochLeaderFailoverWithEmptyNotarization ensures leader failover works with
+// future empty notarizations.
+// The order of the test are as follows
+// index block @ round 0 into storage.
+// create but don't send blocks for rounds 1,3
+// send empty notarization for round 2 to epoch
+// notarize and finalize block for round 1
+// we expect the future empty notarization for round 2 to increment the round
 func TestEpochLeaderFailoverWithEmptyNotarization(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
 
 	bb := &testBlockBuilder{
-		out:                make(chan *testBlock, 3),
+		out:                make(chan *testBlock, 2),
 		blockShouldBeBuilt: make(chan struct{}, 1),
-		in:                 make(chan *testBlock, 3),
+		in:                 make(chan *testBlock, 2),
 	}
 	storage := newInMemStorage()
 
 	nodes := []NodeID{{1}, {2}, {3}, {4}}
-	quorum := Quorum(len(nodes))
 
 	wal := newTestWAL(t)
 
@@ -56,7 +63,7 @@ func TestEpochLeaderFailoverWithEmptyNotarization(t *testing.T) {
 	// The node should move to round 4 via the empty notarization it has received
 	// from earlier.
 
-	notarizeAndFinalizeRound(t, nodes, 0, 0, e, bb, quorum, storage, false)
+	advanceRound(t, e, bb, true, true)
 
 	block0, _, ok := storage.Retrieve(0)
 	require.True(t, ok)
@@ -69,76 +76,56 @@ func TestEpochLeaderFailoverWithEmptyNotarization(t *testing.T) {
 	require.True(t, ok)
 
 	block2, ok := bb.BuildBlock(context.Background(), ProtocolMetadata{
-		Round: 2,
+		Round: 3,
 		Prev:  block1.BlockHeader().Digest,
 		Seq:   2,
 	})
 	require.True(t, ok)
 
-	block3, ok := bb.BuildBlock(context.Background(), ProtocolMetadata{
-		Round: 4,
-		Prev:  block2.BlockHeader().Digest,
-		Seq:   3,
-	})
-	require.True(t, ok)
-
-	var qc testQC
-	for i := 1; i <= quorum; i++ {
-		qc = append(qc, Signature{Signer: NodeID{byte(i)}, Value: []byte{byte(i)}})
-	}
-
 	// Artificially force the block builder to output the blocks we want.
 	for len(bb.out) > 0 {
 		<-bb.out
 	}
-	for _, block := range []Block{block1, block2, block3} {
+	for _, block := range []VerifiedBlock{block1, block2} {
 		bb.out <- block.(*testBlock)
 		bb.in <- block.(*testBlock)
 	}
 
+	emptyNotarization := newEmptyNotarization(nodes[:3], 2, 1)
+
 	e.HandleMessage(&Message{
-		EmptyNotarization: &EmptyNotarization{
-			Vote: ToBeSignedEmptyVote{ProtocolMetadata: ProtocolMetadata{
-				Prev:  block2.BlockHeader().Digest,
-				Round: 3,
-				Seq:   2,
-			}},
-			QC: qc,
-		},
+		EmptyNotarization: emptyNotarization,
 	}, nodes[1])
 
-	for round := uint64(1); round <= 2; round++ {
-		notarizeAndFinalizeRound(t, nodes, round, round, e, bb, quorum, storage, false)
-	}
+	advanceRound(t, e, bb, true, true)
 
-	bb.blockShouldBeBuilt <- struct{}{}
+	wal.assertNotarization(2)
+	nextBlockSeqToCommit := uint64(2)
+	nextRoundToCommit := uint64(3)
 
-	wal.assertNotarization(3)
-
-	nextBlockSeqToCommit := uint64(3)
-	nextRoundToCommit := uint64(4)
-
-	// Ensure our node proposes block with sequence 3 for round 4
-	notarizeAndFinalizeRound(t, nodes, nextRoundToCommit, nextBlockSeqToCommit, e, bb, quorum, storage, false)
-	require.Equal(t, uint64(4), storage.Height())
+	runCrashAndRestartExecution(t, e, bb, wal, storage, func(t *testing.T, e *Epoch, bb *testBlockBuilder, storage *InMemStorage, wal *testWAL) {
+		// Ensure our node proposes block with sequence 3 for round 4
+		block, _ := advanceRound(t, e, bb, true, true)
+		require.Equal(t, nextBlockSeqToCommit, block.BlockHeader().Seq)
+		require.Equal(t, nextRoundToCommit, block.BlockHeader().Round)
+		require.Equal(t, uint64(3), storage.Height())
+	})
 }
 
-func newEmptyNotarization(t *testing.T, e *Epoch, round uint64) *EmptyNotarization {
-	quorum := simplex.Quorum(len(e.Comm.ListNodes()))
+// newEmptyNotarization creates a new empty notarization
+func newEmptyNotarization(nodes []NodeID, round uint64, seq uint64) *EmptyNotarization {
 	var qc testQC
 
-	for i := 0; i <= quorum; i++ {
-		qc = append(qc, Signature{Signer: NodeID{byte(i)}, Value: []byte{byte(i)}})
+	for i, node := range nodes {
+		qc = append(qc, Signature{Signer: node, Value: []byte{byte(i)}})
 	}
 
 	return &EmptyNotarization{
 		QC: qc,
 		Vote: ToBeSignedEmptyVote{ProtocolMetadata: ProtocolMetadata{
-			Prev:  Digest{},
 			Round: round,
-			Seq:   round,
+			Seq:   seq,
 		}},
-
 	}
 }
 
@@ -180,7 +167,7 @@ func TestEpochLeaderFailoverReceivesEmptyVotesEarly(t *testing.T) {
 	// to start complaining about a block not being notarized
 
 	for round := uint64(0); round < 3; round++ {
-		notarizeAndFinalizeRound(t, nodes, round, round, e, bb, quorum, storage, false)
+		advanceRound(t, e, bb, true, true)
 	}
 
 	lastBlock, _, ok := storage.Retrieve(storage.Height() - 1)
@@ -208,40 +195,43 @@ func TestEpochLeaderFailoverReceivesEmptyVotesEarly(t *testing.T) {
 
 	waitForBlockProposerTimeout(t, e, start)
 
-	wal.lock.Lock()
-	walContent, err := wal.ReadAll()
-	require.NoError(t, err)
-	wal.lock.Unlock()
+	runCrashAndRestartExecution(t, e, bb, wal, storage, func(t *testing.T, e *Epoch, bb *testBlockBuilder, storage *InMemStorage, wal *testWAL) {
+		wal.lock.Lock()
+		walContent, err := wal.ReadAll()
+		require.NoError(t, err)
+		wal.lock.Unlock()
 
-	rawEmptyVote, rawEmptyNotarization, rawProposal := walContent[len(walContent)-3], walContent[len(walContent)-2], walContent[len(walContent)-1]
-	emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
-	require.NoError(t, err)
-	require.Equal(t, createEmptyVote(emptyBlockMd, nodes[0]).Vote, emptyVote)
+		rawEmptyVote, rawEmptyNotarization, rawProposal := walContent[len(walContent)-3], walContent[len(walContent)-2], walContent[len(walContent)-1]
+		emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
+		require.NoError(t, err)
+		require.Equal(t, createEmptyVote(emptyBlockMd, nodes[0]).Vote, emptyVote)
 
-	emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
-	require.NoError(t, err)
-	require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
-	require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
-	require.Equal(t, uint64(2), emptyNotarization.Vote.Seq)
-	require.Equal(t, uint64(3), storage.Height())
+		emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
+		require.NoError(t, err)
+		require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
+		require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
+		require.Equal(t, uint64(2), emptyNotarization.Vote.Seq)
+		require.Equal(t, uint64(3), storage.Height())
 
-	header, _, err := ParseBlockRecord(rawProposal)
-	require.NoError(t, err)
-	require.Equal(t, uint64(4), header.Round)
-	require.Equal(t, uint64(3), header.Seq)
+		header, _, err := ParseBlockRecord(rawProposal)
+		require.NoError(t, err)
+		require.Equal(t, uint64(4), header.Round)
+		require.Equal(t, uint64(3), header.Seq)
 
-	// Ensure our node proposes block with sequence 3 for round 4
-	block := <-bb.out
+		// Ensure our node proposes block with sequence 3 for round 4
+		block := <-bb.out
 
-	for i := 1; i <= quorum; i++ {
-		injectTestFinalization(t, e, block, nodes[i])
-	}
+		for i := 1; i <= quorum; i++ {
+			injectTestFinalization(t, e, block, nodes[i])
+		}
 
-	block2 := storage.waitForBlockCommit(3)
-	require.Equal(t, block, block2)
-	require.Equal(t, uint64(4), storage.Height())
-	require.Equal(t, uint64(4), block2.BlockHeader().Round)
-	require.Equal(t, uint64(3), block2.BlockHeader().Seq)
+		block2 := storage.waitForBlockCommit(3)
+		require.Equal(t, block, block2)
+		require.Equal(t, uint64(4), storage.Height())
+		require.Equal(t, uint64(4), block2.BlockHeader().Round)
+		require.Equal(t, uint64(3), block2.BlockHeader().Seq)
+	})
+
 }
 
 func TestEpochLeaderFailover(t *testing.T) {
@@ -251,7 +241,6 @@ func TestEpochLeaderFailover(t *testing.T) {
 	storage := newInMemStorage()
 
 	nodes := []NodeID{{1}, {2}, {3}, {4}}
-	quorum := Quorum(len(nodes))
 
 	wal := newTestWAL(t)
 
@@ -282,57 +271,62 @@ func TestEpochLeaderFailover(t *testing.T) {
 	// to start complaining about a block not being notarized
 
 	for round := uint64(0); round < 3; round++ {
-		notarizeAndFinalizeRound(t, nodes, round, round, e, bb, quorum, storage, false)
+		advanceRound(t, e, bb, true, true)
 	}
 
 	bb.blockShouldBeBuilt <- struct{}{}
 
 	waitForBlockProposerTimeout(t, e, start)
 
-	lastBlock, _, ok := storage.Retrieve(storage.Height() - 1)
-	require.True(t, ok)
+	runCrashAndRestartExecution(t, e, bb, wal, storage, func(t *testing.T, e *Epoch, bb *testBlockBuilder, storage *InMemStorage, wal *testWAL) {
+		lastBlock, _, ok := storage.Retrieve(storage.Height() - 1)
+		require.True(t, ok)
 
-	prev := lastBlock.BlockHeader().Digest
+		prev := lastBlock.BlockHeader().Digest
 
-	emptyBlockMd := ProtocolMetadata{
-		Round: 3,
-		Seq:   2,
-		Prev:  prev,
-	}
+		emptyBlockMd := ProtocolMetadata{
+			Round: 3,
+			Seq:   2,
+			Prev:  prev,
+		}
 
-	nextBlockSeqToCommit := uint64(3)
-	nextRoundToCommit := uint64(4)
+		emptyVoteFrom1 := createEmptyVote(emptyBlockMd, nodes[1])
+		emptyVoteFrom2 := createEmptyVote(emptyBlockMd, nodes[2])
 
-	emptyVoteFrom1 := createEmptyVote(emptyBlockMd, nodes[1])
-	emptyVoteFrom2 := createEmptyVote(emptyBlockMd, nodes[2])
+		e.HandleMessage(&Message{
+			EmptyVoteMessage: emptyVoteFrom1,
+		}, nodes[1])
+		e.HandleMessage(&Message{
+			EmptyVoteMessage: emptyVoteFrom2,
+		}, nodes[2])
 
-	e.HandleMessage(&Message{
-		EmptyVoteMessage: emptyVoteFrom1,
-	}, nodes[1])
-	e.HandleMessage(&Message{
-		EmptyVoteMessage: emptyVoteFrom2,
-	}, nodes[2])
+		wal.lock.Lock()
+		walContent, err := wal.ReadAll()
+		require.NoError(t, err)
+		wal.lock.Unlock()
 
-	wal.lock.Lock()
-	walContent, err := wal.ReadAll()
-	require.NoError(t, err)
-	wal.lock.Unlock()
+		rawEmptyVote, rawEmptyNotarization := walContent[len(walContent)-2], walContent[len(walContent)-1]
+		emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
+		require.NoError(t, err)
+		require.Equal(t, createEmptyVote(emptyBlockMd, nodes[0]).Vote, emptyVote)
 
-	rawEmptyVote, rawEmptyNotarization := walContent[len(walContent)-2], walContent[len(walContent)-1]
-	emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
-	require.NoError(t, err)
-	require.Equal(t, createEmptyVote(emptyBlockMd, nodes[0]).Vote, emptyVote)
+		emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
+		require.NoError(t, err)
+		require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
+		require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
+		require.Equal(t, uint64(2), emptyNotarization.Vote.Seq)
+		require.Equal(t, uint64(3), storage.Height())
 
-	emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
-	require.NoError(t, err)
-	require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
-	require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
-	require.Equal(t, uint64(2), emptyNotarization.Vote.Seq)
-	require.Equal(t, uint64(3), storage.Height())
+		nextBlockSeqToCommit := uint64(3)
+		nextRoundToCommit := uint64(4)
 
-	// Ensure our node proposes block with sequence 3 for round 4
-	notarizeAndFinalizeRound(t, nodes, nextRoundToCommit, nextBlockSeqToCommit, e, bb, quorum, storage, false)
-	require.Equal(t, uint64(4), storage.Height())
+		// Ensure our node proposes block with sequence 3 for round 4
+		block, _ := advanceRound(t, e, bb, true, true)
+		require.Equal(t, nextRoundToCommit, block.BlockHeader().Round)
+		require.Equal(t, nextBlockSeqToCommit, block.BlockHeader().Seq)
+
+		require.Equal(t, uint64(4), storage.Height())
+	})
 }
 
 func TestEpochNoFinalizationAfterEmptyVote(t *testing.T) {
@@ -369,7 +363,7 @@ func TestEpochNoFinalizationAfterEmptyVote(t *testing.T) {
 
 	require.NoError(t, e.Start())
 
-	notarizeAndFinalizeRound(t, nodes, 0, 0, e, bb, quorum, storage, false)
+	advanceRound(t, e, bb, true, true)
 
 	// Drain the messages recorded
 	for len(recordedMessages) > 0 {
@@ -380,18 +374,18 @@ func TestEpochNoFinalizationAfterEmptyVote(t *testing.T) {
 
 	waitForBlockProposerTimeout(t, e, start)
 
-	block, _, ok := storage.Retrieve(0)
+	b, _, ok := storage.Retrieve(0)
 	require.True(t, ok)
 
 	leader := LeaderForRound(nodes, 1)
 	_, ok = bb.BuildBlock(context.Background(), ProtocolMetadata{
-		Prev:  block.BlockHeader().Digest,
+		Prev:  b.BlockHeader().Digest,
 		Round: 1,
 		Seq:   1,
 	})
 	require.True(t, ok)
 
-	block = <-bb.out
+	block := <-bb.out
 
 	vote, err := newTestVote(block, leader)
 	require.NoError(t, err)
@@ -432,7 +426,6 @@ func TestEpochLeaderFailoverAfterProposal(t *testing.T) {
 	storage := newInMemStorage()
 
 	nodes := []NodeID{{1}, {2}, {3}, {4}}
-	quorum := Quorum(len(nodes))
 
 	wal := newTestWAL(t)
 
@@ -463,8 +456,8 @@ func TestEpochLeaderFailoverAfterProposal(t *testing.T) {
 	// Node 4 proposes a block, but node 1 cannot collect votes until the timeout.
 	// After the timeout expires, node 1 is sent all the votes, and it should notarize the block.
 
-	for _, round := range []uint64{0, 1, 2} {
-		notarizeAndFinalizeRound(t, nodes, round, round, e, bb, quorum, storage, false)
+	for range 3 {
+		advanceRound(t, e, bb, true, true)
 	}
 
 	wal.assertWALSize(6) // (block, notarization) x 3 rounds
@@ -495,51 +488,55 @@ func TestEpochLeaderFailoverAfterProposal(t *testing.T) {
 	bb.blockShouldBeBuilt <- struct{}{}
 	waitForBlockProposerTimeout(t, e, start)
 
-	lastBlock, _, ok := storage.Retrieve(storage.Height() - 1)
-	require.True(t, ok)
+	runCrashAndRestartExecution(t, e, bb, wal, storage, func(t *testing.T, e *Epoch, bb *testBlockBuilder, storage *InMemStorage, wal *testWAL) {
 
-	prev := lastBlock.BlockHeader().Digest
+		lastBlock, _, ok := storage.Retrieve(storage.Height() - 1)
+		require.True(t, ok)
 
-	md = ProtocolMetadata{
-		Round: 3,
-		Seq:   2,
-		Prev:  prev,
-	}
+		prev := lastBlock.BlockHeader().Digest
 
-	nextBlockSeqToCommit := uint64(3)
-	nextRoundToCommit := uint64(4)
+		md = ProtocolMetadata{
+			Round: 3,
+			Seq:   2,
+			Prev:  prev,
+		}
 
-	emptyVoteFrom1 := createEmptyVote(md, nodes[1])
-	emptyVoteFrom2 := createEmptyVote(md, nodes[2])
+		nextBlockSeqToCommit := uint64(3)
+		nextRoundToCommit := uint64(4)
 
-	e.HandleMessage(&Message{
-		EmptyVoteMessage: emptyVoteFrom1,
-	}, nodes[1])
-	e.HandleMessage(&Message{
-		EmptyVoteMessage: emptyVoteFrom2,
-	}, nodes[2])
+		emptyVoteFrom1 := createEmptyVote(md, nodes[1])
+		emptyVoteFrom2 := createEmptyVote(md, nodes[2])
 
-	// Ensure our node proposes block with sequence 3 for round 4
-	notarizeAndFinalizeRound(t, nodes, nextRoundToCommit, nextBlockSeqToCommit, e, bb, quorum, storage, false)
+		e.HandleMessage(&Message{
+			EmptyVoteMessage: emptyVoteFrom1,
+		}, nodes[1])
+		e.HandleMessage(&Message{
+			EmptyVoteMessage: emptyVoteFrom2,
+		}, nodes[2])
 
-	// WAL must contain an empty vote and an empty block.
-	walContent, err := wal.ReadAll()
-	require.NoError(t, err)
+		// Ensure our node proposes block with sequence 3 for round 4
+		block, _ := advanceRound(t, e, bb, true, true)
+		require.Equal(t, nextRoundToCommit, block.BlockHeader().Round)
+		require.Equal(t, nextBlockSeqToCommit, block.BlockHeader().Seq)
 
-	// WAL should be: [..., <empty vote>, <empty block>, <notarization for 4>, <block3>]
-	rawEmptyVote, rawEmptyNotarization := walContent[len(walContent)-4], walContent[len(walContent)-3]
+		// WAL must contain an empty vote and an empty block.
+		walContent, err := wal.ReadAll()
+		require.NoError(t, err)
 
-	emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
-	require.NoError(t, err)
-	require.Equal(t, createEmptyVote(md, nodes[0]).Vote, emptyVote)
+		// WAL should be: [..., <empty vote>, <empty block>, <notarization for 4>, <block3>]
+		rawEmptyVote, rawEmptyNotarization := walContent[len(walContent)-4], walContent[len(walContent)-3]
 
-	emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
-	require.NoError(t, err)
-	require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
-	require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
-	require.Equal(t, uint64(2), emptyNotarization.Vote.Seq)
-	require.Equal(t, uint64(4), storage.Height())
+		emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
+		require.NoError(t, err)
+		require.Equal(t, createEmptyVote(md, nodes[0]).Vote, emptyVote)
 
+		emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
+		require.NoError(t, err)
+		require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
+		require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
+		require.Equal(t, uint64(2), emptyNotarization.Vote.Seq)
+		require.Equal(t, uint64(4), storage.Height())
+	})
 }
 
 func TestEpochLeaderFailoverTwice(t *testing.T) {
@@ -549,7 +546,6 @@ func TestEpochLeaderFailoverTwice(t *testing.T) {
 	storage := newInMemStorage()
 
 	nodes := []NodeID{{1}, {2}, {3}, {4}}
-	quorum := Quorum(len(nodes))
 
 	wal := newTestWAL(t)
 
@@ -573,8 +569,8 @@ func TestEpochLeaderFailoverTwice(t *testing.T) {
 
 	require.NoError(t, e.Start())
 
-	for _, round := range []uint64{0, 1} {
-		notarizeAndFinalizeRound(t, nodes, round, round, e, bb, quorum, storage, false)
+	for range 2 {
+		advanceRound(t, e, bb, true, true)
 	}
 
 	t.Log("Node 2 crashes, leader failover to node 3")
@@ -583,75 +579,81 @@ func TestEpochLeaderFailoverTwice(t *testing.T) {
 
 	waitForBlockProposerTimeout(t, e, start)
 
-	lastBlock, _, ok := storage.Retrieve(storage.Height() - 1)
-	require.True(t, ok)
+	runCrashAndRestartExecution(t, e, bb, wal, storage, func(t *testing.T, e *Epoch, bb *testBlockBuilder, storage *InMemStorage, wal *testWAL) {
+		lastBlock, _, ok := storage.Retrieve(storage.Height() - 1)
+		require.True(t, ok)
 
-	prev := lastBlock.BlockHeader().Digest
+		prev := lastBlock.BlockHeader().Digest
 
-	md := ProtocolMetadata{
-		Round: 2,
-		Seq:   1,
-		Prev:  prev,
-	}
+		md := ProtocolMetadata{
+			Round: 2,
+			Seq:   1,
+			Prev:  prev,
+		}
 
-	emptyVoteFrom2 := createEmptyVote(md, nodes[2])
-	emptyVoteFrom3 := createEmptyVote(md, nodes[3])
+		emptyVoteFrom2 := createEmptyVote(md, nodes[2])
+		emptyVoteFrom3 := createEmptyVote(md, nodes[3])
 
-	e.HandleMessage(&Message{
-		EmptyVoteMessage: emptyVoteFrom2,
-	}, nodes[2])
-	e.HandleMessage(&Message{
-		EmptyVoteMessage: emptyVoteFrom3,
-	}, nodes[3])
+		e.HandleMessage(&Message{
+			EmptyVoteMessage: emptyVoteFrom2,
+		}, nodes[2])
+		e.HandleMessage(&Message{
+			EmptyVoteMessage: emptyVoteFrom3,
+		}, nodes[3])
 
-	wal.assertNotarization(2)
+		wal.assertNotarization(2)
 
-	t.Log("Node 3 crashes and node 2 comes back up (just in time)")
+		t.Log("Node 3 crashes and node 2 comes back up (just in time)")
 
-	bb.blockShouldBeBuilt <- struct{}{}
+		bb.blockShouldBeBuilt <- struct{}{}
 
-	waitForBlockProposerTimeout(t, e, start)
+		waitForBlockProposerTimeout(t, e, start)
 
-	md = ProtocolMetadata{
-		Round: 3,
-		Seq:   1,
-		Prev:  prev,
-	}
+		runCrashAndRestartExecution(t, e, bb, wal, storage, func(t *testing.T, e *Epoch, bb *testBlockBuilder, storage *InMemStorage, wal *testWAL) {
+			md := ProtocolMetadata{
+				Round: 3,
+				Seq:   1,
+				Prev:  prev,
+			}
 
-	emptyVoteFrom1 := createEmptyVote(md, nodes[1])
-	emptyVoteFrom3 = createEmptyVote(md, nodes[3])
+			emptyVoteFrom1 := createEmptyVote(md, nodes[1])
+			emptyVoteFrom3 = createEmptyVote(md, nodes[3])
 
-	e.HandleMessage(&Message{
-		EmptyVoteMessage: emptyVoteFrom1,
-	}, nodes[1])
-	e.HandleMessage(&Message{
-		EmptyVoteMessage: emptyVoteFrom3,
-	}, nodes[3])
+			e.HandleMessage(&Message{
+				EmptyVoteMessage: emptyVoteFrom1,
+			}, nodes[1])
+			e.HandleMessage(&Message{
+				EmptyVoteMessage: emptyVoteFrom3,
+			}, nodes[3])
 
-	wal.assertNotarization(3)
+			wal.assertNotarization(3)
 
-	// Ensure our node proposes block with sequence 2 for round 4
-	nextRoundToCommit := uint64(4)
-	nextBlockSeqToCommit := uint64(2)
-	notarizeAndFinalizeRound(t, nodes, nextRoundToCommit, nextBlockSeqToCommit, e, bb, quorum, storage, false)
+			// Ensure our node proposes block with sequence 2 for round 4
+			nextRoundToCommit := uint64(4)
+			nextBlockSeqToCommit := uint64(2)
+			block, _ := advanceRound(t, e, bb, true, true)
+			require.Equal(t, nextRoundToCommit, block.BlockHeader().Round)
+			require.Equal(t, nextBlockSeqToCommit, block.BlockHeader().Seq)
 
-	// WAL must contain an empty vote and an empty block.
-	walContent, err := wal.ReadAll()
-	require.NoError(t, err)
+			// WAL must contain an empty vote and an empty block.
+			walContent, err := wal.ReadAll()
+			require.NoError(t, err)
 
-	// WAL should be: [..., <empty vote>, <empty block>, <notarization for 4>, <block2>]
-	rawEmptyVote, rawEmptyNotarization := walContent[len(walContent)-4], walContent[len(walContent)-3]
+			// WAL should be: [..., <empty vote>, <empty block>, <notarization for 4>, <block2>]
+			rawEmptyVote, rawEmptyNotarization := walContent[len(walContent)-4], walContent[len(walContent)-3]
 
-	emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
-	require.NoError(t, err)
-	require.Equal(t, createEmptyVote(md, nodes[0]).Vote, emptyVote)
+			emptyVote, err := ParseEmptyVoteRecord(rawEmptyVote)
+			require.NoError(t, err)
+			require.Equal(t, createEmptyVote(md, nodes[0]).Vote, emptyVote)
 
-	emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
-	require.NoError(t, err)
-	require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
-	require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
-	require.Equal(t, uint64(1), emptyNotarization.Vote.Seq)
-	require.Equal(t, uint64(3), storage.Height())
+			emptyNotarization, err := EmptyNotarizationFromRecord(rawEmptyNotarization, &testQCDeserializer{t: t})
+			require.NoError(t, err)
+			require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
+			require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
+			require.Equal(t, uint64(1), emptyNotarization.Vote.Seq)
+			require.Equal(t, uint64(3), storage.Height())
+		})
+	})
 }
 
 func createEmptyVote(md ProtocolMetadata, signer NodeID) *EmptyVote {
@@ -732,7 +734,7 @@ func TestEpochLeaderFailoverNotNeeded(t *testing.T) {
 	rounds := uint64(3)
 
 	for round := uint64(0); round < rounds; round++ {
-		notarizeAndFinalizeRound(t, nodes, round, round, e, bb, quorum, storage, false)
+		advanceRound(t, e, bb, true, true)
 	}
 	bb.blockShouldBeBuilt <- struct{}{}
 	e.AdvanceTime(start.Add(conf.MaxProposalWait / 2))
@@ -766,6 +768,70 @@ func TestEpochLeaderFailoverNotNeeded(t *testing.T) {
 	require.False(t, timedOut.Load())
 }
 
+func runCrashAndRestartExecution(t *testing.T, e *Epoch, bb *testBlockBuilder, wal *testWAL, storage *InMemStorage, f epochExecution) {
+	// Split the test into two scenarios:
+	// 1) The node proceeds as usual.
+	// 2) The node crashes and restarts.
+	cloneWAL := wal.Clone()
+	cloneStorage := storage.Clone()
+
+	nodes := e.Comm.ListNodes()
+
+	// Clone the block builder
+	bbAfterCrash := &testBlockBuilder{
+		out:                cloneBlockChan(bb.out),
+		in:                 cloneBlockChan(bb.in),
+		blockShouldBeBuilt: make(chan struct{}, cap(bb.blockShouldBeBuilt)),
+	}
+
+	// Case 1:
+	t.Run(fmt.Sprintf("%s-no-crash", t.Name()), func(t *testing.T) {
+		f(t, e, bb, storage, wal)
+	})
+
+	// Case 2:
+	t.Run(fmt.Sprintf("%s-with-crash", t.Name()), func(t *testing.T) {
+		conf := EpochConfig{
+			QCDeserializer:      &testQCDeserializer{t: t},
+			BlockDeserializer:   &blockDeserializer{},
+			MaxProposalWait:     DefaultMaxProposalWaitTime,
+			StartTime:           time.Now(),
+			Logger:              testutil.MakeLogger(t, 1),
+			ID:                  nodes[0],
+			Signer:              &testSigner{},
+			WAL:                 cloneWAL,
+			Verifier:            &testVerifier{},
+			Storage:             cloneStorage,
+			Comm:                noopComm(nodes),
+			BlockBuilder:        bbAfterCrash,
+			SignatureAggregator: &testSignatureAggregator{},
+		}
+
+		e, err := NewEpoch(conf)
+		require.NoError(t, err)
+
+		require.NoError(t, e.Start())
+		f(t, e, bbAfterCrash, cloneStorage, cloneWAL)
+	})
+}
+
+func cloneBlockChan(in chan *testBlock) chan *testBlock {
+	tmp := make(chan *testBlock, cap(in))
+	out := make(chan *testBlock, cap(in))
+
+	for len(in) > 0 {
+		block := <-in
+		tmp <- block
+		out <- block
+	}
+
+	for len(tmp) > 0 {
+		in <- <-tmp
+	}
+
+	return out
+}
+
 type recordingComm struct {
 	Communication
 	BroadcastMessages chan *Message
@@ -775,3 +841,5 @@ func (rc *recordingComm) Broadcast(msg *Message) {
 	rc.BroadcastMessages <- msg
 	rc.Communication.Broadcast(msg)
 }
+
+type epochExecution func(t *testing.T, e *Epoch, bb *testBlockBuilder, storage *InMemStorage, wal *testWAL)

--- a/epoch_multinode_test.go
+++ b/epoch_multinode_test.go
@@ -45,7 +45,8 @@ func (t *testNode) start() {
 
 func newSimplexNodeWithStorage(t *testing.T, nodeID NodeID, net *inMemNetwork, bb BlockBuilder, storage []FinalizedBlock) *testNode {
 	wal := newTestWAL(t)
-	conf := defaultTestNodeEpochConfig(t, nodeID, net, wal, bb, true)
+	comm := newTestComm(nodeID, net)
+	conf := defaultTestNodeEpochConfig(t, nodeID, comm, wal, bb, true)
 	for _, data := range storage {
 		conf.Storage.Index(data.Block, data.FCert)
 	}
@@ -67,7 +68,8 @@ func newSimplexNodeWithStorage(t *testing.T, nodeID NodeID, net *inMemNetwork, b
 
 func newSimplexNode(t *testing.T, nodeID NodeID, net *inMemNetwork, bb BlockBuilder, replicationEnabled bool) *testNode {
 	wal := newTestWAL(t)
-	conf := defaultTestNodeEpochConfig(t, nodeID, net, wal, bb, replicationEnabled)
+	comm := newTestComm(nodeID, net)
+	conf := defaultTestNodeEpochConfig(t, nodeID, comm, wal, bb, replicationEnabled)
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)
 	ti := &testNode{
@@ -84,12 +86,12 @@ func newSimplexNode(t *testing.T, nodeID NodeID, net *inMemNetwork, bb BlockBuil
 	return ti
 }
 
-func defaultTestNodeEpochConfig(t *testing.T, nodeID NodeID, net *inMemNetwork, wal WriteAheadLog, bb BlockBuilder, replicationEnabled bool) EpochConfig {
+func defaultTestNodeEpochConfig(t *testing.T, nodeID NodeID, comm Communication, wal WriteAheadLog, bb BlockBuilder, replicationEnabled bool) EpochConfig {
 	l := testutil.MakeLogger(t, int(nodeID[0]))
 	storage := newInMemStorage()
 	conf := EpochConfig{
 		MaxProposalWait:     DefaultMaxProposalWaitTime,
-		Comm:                newTestComm(nodeID, net),
+		Comm:                comm,
 		Logger:              l,
 		ID:                  nodeID,
 		Signer:              &testSigner{},

--- a/msg.go
+++ b/msg.go
@@ -216,10 +216,12 @@ type QuorumCertificate interface {
 
 type ReplicationRequest struct {
 	FinalizationCertificateRequest *FinalizationCertificateRequest
+	NotarizationRequest *NotarizationRequest
 }
 
 type ReplicationResponse struct {
 	FinalizationCertificateResponse *FinalizationCertificateResponse
+	NotarizationResponse *NotarizationResponse
 }
 
 // request a finalization certificate for the given sequence number
@@ -234,4 +236,27 @@ type FinalizedBlock struct {
 
 type FinalizationCertificateResponse struct {
 	Data []FinalizedBlock
+}
+
+type NotarizationRequest struct {
+	// the starting round to request notarizations
+	StartRound uint64
+}
+
+type NotarizationResponse struct {
+	Data []NotarizedBlock
+}
+
+type NotarizedBlock struct {
+	Block Block
+	Notarization *Notarization
+	EmptyNotarization *EmptyNotarization
+}
+
+func (n NotarizedBlock) GetRound() uint64 {
+	if n.EmptyNotarization != nil {
+		return n.EmptyNotarization.Vote.Round
+	}
+
+	return n.Block.BlockHeader().Round
 }

--- a/notarization_test.go
+++ b/notarization_test.go
@@ -21,7 +21,7 @@ func TestNewNotarization(t *testing.T) {
 	tests := []struct {
 		name                 string
 		votesForCurrentRound map[string]*simplex.Vote
-		block                simplex.Block
+		block                simplex.VerifiedBlock
 		expectError          error
 		signatureAggregator  simplex.SignatureAggregator
 	}{

--- a/record_test.go
+++ b/record_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newNotarization(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID) (simplex.Notarization, error) {
+func newNotarization(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.VerifiedBlock, ids []simplex.NodeID) (simplex.Notarization, error) {
 	votesForCurrentRound := make(map[string]*simplex.Vote)
 	for _, id := range ids {
 		vote, err := newTestVote(block, id)
@@ -26,7 +26,7 @@ func newNotarization(logger simplex.Logger, signatureAggregator simplex.Signatur
 	return notarization, err
 }
 
-func newNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID) ([]byte, error) {
+func newNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.VerifiedBlock, ids []simplex.NodeID) ([]byte, error) {
 	notarization, err := newNotarization(logger, signatureAggregator, block, ids)
 	if err != nil {
 		return nil, err
@@ -37,7 +37,7 @@ func newNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.Si
 }
 
 // creates a new finalization certificate
-func newFinalizationRecord(t *testing.T, logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.Block, ids []simplex.NodeID) (simplex.FinalizationCertificate, []byte) {
+func newFinalizationRecord(t *testing.T, logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.VerifiedBlock, ids []simplex.NodeID) (simplex.FinalizationCertificate, []byte) {
 	finalizations := make([]*simplex.Finalization, len(ids))
 	for i, id := range ids {
 		finalizations[i] = newTestFinalization(t, block, id)

--- a/replication.go
+++ b/replication.go
@@ -4,8 +4,6 @@
 package simplex
 
 import (
-	"bytes"
-	"fmt"
 	"math"
 
 	"go.uber.org/zap"
@@ -21,68 +19,73 @@ type ReplicationState struct {
 	// latest seq requested
 	lastSequenceRequested uint64
 
-	// highest sequence we have received a finalization certificate for
-	highestFCertReceived *FinalizationCertificate
+	// highest sequence we have received
+	highestSeqReceived uint64
 
-	// received
-	receivedFinalizationCertificates map[uint64]FinalizedBlock
+	// receivedQuorumRounds maps rounds to quorum rounds
+	receivedQuorumRounds map[uint64]QuorumRound
+
+	// sent a replication request before
+	sentOnce bool
 }
 
 func NewReplicationState(logger Logger, comm Communication, id NodeID, maxRoundWindow uint64, enabled bool) *ReplicationState {
 	return &ReplicationState{
-		logger:                           logger,
-		enabled:                          enabled,
-		comm:                             comm,
-		id:                               id,
-		maxRoundWindow:                   maxRoundWindow,
-		receivedFinalizationCertificates: make(map[uint64]FinalizedBlock),
+		logger:               logger,
+		enabled:              enabled,
+		comm:                 comm,
+		id:                   id,
+		maxRoundWindow:       maxRoundWindow,
+		receivedQuorumRounds: make(map[uint64]QuorumRound),
 	}
 }
 
-// isReplicationComplete returns true if the replication state has caught up to the highest finalization certificate.
-// TODO: when we add notarization requests, this function should also make sure we have caught up to the highest notarization.
-func (r *ReplicationState) isReplicationComplete(nextSeqToCommit uint64) bool {
-	return nextSeqToCommit > r.highestFCertReceived.Finalization.Seq
+// isReplicationComplete returns true if we have finished the replication process.
+// The process is considered finished once [currentRound] has caught up to the highest round received.
+func (r *ReplicationState) isReplicationComplete(nextSeqToCommit uint64, currentRound uint64) bool {
+	if !r.sentOnce {
+		return true
+	}
+
+	return nextSeqToCommit > r.highestSeqReceived
 }
 
-func (r *ReplicationState) collectFutureFinalizationCertificates(fCert *FinalizationCertificate, currentRound uint64, nextSeqToCommit uint64) {
-	if !r.enabled {
-		return
-	}
-	fCertSeq := fCert.Finalization.Seq
-	// Don't exceed the max round window
-	endSeq := math.Min(float64(fCertSeq), float64(r.maxRoundWindow+currentRound))
-	if r.highestFCertReceived == nil || fCertSeq > r.highestFCertReceived.Finalization.Seq {
-		r.highestFCertReceived = fCert
-	}
+func (r *ReplicationState) collectMissingSequences(receivedSeq uint64, currentRound uint64, nextSeqToCommit uint64) {
 	// Node is behind, but we've already sent messages to collect future fCerts
-	if r.lastSequenceRequested >= uint64(endSeq) {
+	if r.lastSequenceRequested >= receivedSeq && r.sentOnce {
 		return
+	}
+
+	if receivedSeq > r.highestSeqReceived {
+		r.highestSeqReceived = receivedSeq
 	}
 
 	startSeq := math.Max(float64(nextSeqToCommit), float64(r.lastSequenceRequested))
-	r.logger.Debug("Node is behind, requesting missing finalization certificates", zap.Uint64("seq", fCertSeq), zap.Uint64("startSeq", uint64(startSeq)), zap.Uint64("endSeq", uint64(endSeq)))
-	r.sendFutureCertficatesRequests(uint64(startSeq), uint64(endSeq))
+
+	// Don't exceed the max round window
+	endSeq := math.Min(float64(receivedSeq), float64(r.maxRoundWindow+nextSeqToCommit))
+
+	r.logger.Debug("Node is behind, requesting missing finalization certificates", zap.Uint64("seq", receivedSeq), zap.Uint64("startSeq", uint64(startSeq)), zap.Uint64("endSeq", uint64(endSeq)))
+	r.sendReplicationRequests(uint64(startSeq), uint64(endSeq))
 }
 
-// sendFutureCertficatesRequests sends requests for future finalization certificates for the
+// sendReplicationRequests sends requests for missing sequences for the
 // range of sequences [start, end] <- inclusive
-func (r *ReplicationState) sendFutureCertficatesRequests(start uint64, end uint64) {
+func (r *ReplicationState) sendReplicationRequests(start uint64, end uint64) {
 	seqs := make([]uint64, (end+1)-start)
 	for i := start; i <= end; i++ {
 		seqs[i-start] = i
 	}
-
-	roundRequest := &ReplicationRequest{
-		FinalizationCertificateRequest: &FinalizationCertificateRequest{
-			Sequences: seqs,
-		},
+	request := &ReplicationRequest{
+		Seqs:        seqs,
+		LatestRound: r.highestSeqReceived,
 	}
-	msg := &Message{ReplicationRequest: roundRequest}
+	msg := &Message{ReplicationRequest: request}
 
 	requestFrom := r.requestFrom()
 
 	r.lastSequenceRequested = end
+	r.sentOnce = true
 	r.comm.SendMessage(msg, requestFrom)
 }
 
@@ -95,38 +98,82 @@ func (r *ReplicationState) requestFrom() NodeID {
 			return node
 		}
 	}
+
 	return NodeID{}
 }
 
-// maybeCollectFutureFinalizationCertificates attempts to collect future finalization certificates if
-// there are more fCerts to be collected and the round has caught up.
-func (r *ReplicationState) maybeCollectFutureFinalizationCertificates(round uint64, nextSequenceToCommit uint64) {
-	if r.highestFCertReceived == nil {
+func (r *ReplicationState) replicateBlocks(fCert *FinalizationCertificate, currentRound uint64, nextSeqToCommit uint64) {
+	if !r.enabled {
 		return
 	}
 
-	if r.lastSequenceRequested >= r.highestFCertReceived.Finalization.Seq {
+	r.collectMissingSequences(fCert.Finalization.Seq, currentRound, nextSeqToCommit)
+}
+
+// maybeCollectFutureSequences attempts to collect future sequences if
+// there are more to be collected and the round has caught up for us to send the request.
+func (r *ReplicationState) maybeCollectFutureSequences(round uint64, nextSequenceToCommit uint64) {
+	if r.lastSequenceRequested >= r.highestSeqReceived {
 		return
 	}
 
 	// we send out more requests once our seq has caught up to 1/2 of the maxRoundWindow
 	if round+r.maxRoundWindow/2 > r.lastSequenceRequested {
-		r.collectFutureFinalizationCertificates(r.highestFCertReceived, round, nextSequenceToCommit)
+		r.collectMissingSequences(r.highestSeqReceived, round, nextSequenceToCommit)
 	}
 }
 
-func (r *ReplicationState) StoreFinalizedBlock(data FinalizedBlock) error {
-	// ensure the finalization certificate we get relates to the block
-	blockDigest := data.Block.BlockHeader().Digest
-	if !bytes.Equal(blockDigest[:], data.FCert.Finalization.Digest[:]) {
-		return fmt.Errorf("finalization certificate does not match the block")
+func (r *ReplicationState) StoreQuorumRound(round QuorumRound) {
+	if _, ok := r.receivedQuorumRounds[round.GetRound()]; ok {
+		return
 	}
 
-	// don't store the same finalization certificate twice
-	if _, ok := r.receivedFinalizationCertificates[data.FCert.Finalization.Seq]; ok {
+	r.receivedQuorumRounds[round.GetRound()] = round
+}
+
+func (r *ReplicationState) GetFinalizedBlockForSequence(seq uint64) *FinalizedBlock {
+	for _, round := range r.receivedQuorumRounds {
+		if round.GetSequence() == seq {
+			if round.Block == nil || round.FCert == nil {
+				return nil
+			}
+			return &FinalizedBlock{
+				Block: round.Block,
+				FCert: *round.FCert,
+			}
+		}
+	}
+
+	return nil
+}
+
+type NotarizedBlock struct {
+	notarization Notarization
+	block        Block
+}
+
+func (r *ReplicationState) GetNotarizedBlockForRound(round uint64) *NotarizedBlock {
+	qRound, ok := r.receivedQuorumRounds[round]
+	if !ok {
 		return nil
 	}
 
-	r.receivedFinalizationCertificates[data.FCert.Finalization.Seq] = data
-	return nil
+	if qRound.Block == nil || qRound.Notarization == nil {
+		return nil
+	}
+
+	return &NotarizedBlock{
+		notarization: *qRound.Notarization,
+		block:        qRound.Block,
+	}
+}
+
+func (r *ReplicationState) highestNotarizedRound() uint64 {
+	var highestRound uint64
+	for round := range r.receivedQuorumRounds {
+		if round > highestRound {
+			highestRound = round
+		}
+	}
+	return highestRound
 }

--- a/replication_request_test.go
+++ b/replication_request_test.go
@@ -1,0 +1,191 @@
+package simplex_test
+
+import (
+	"bytes"
+	"simplex"
+	"simplex/testutil"
+	"simplex/wal"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReplicationRequestIndexedBlocks tests replication requests for indexed blocks.
+func TestReplicationeRequestIndexedBlocks(t *testing.T) {
+	l := testutil.MakeLogger(t, 1)
+	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
+	storage := newInMemStorage()
+	nodes := []simplex.NodeID{{1}, {2}, {3}, {4}}
+	signatureAggregator := &testSignatureAggregator{}
+	wal := wal.NewMemWAL(t)
+	conf := simplex.EpochConfig{
+		Logger:              l,
+		ID:                  nodes[0],
+		Signer:              &testSigner{},
+		WAL:                 wal,
+		Verifier:            &testVerifier{},
+		Storage:             storage,
+		Comm:                noopComm(nodes),
+		BlockBuilder:        bb,
+		SignatureAggregator: signatureAggregator,
+		BlockDeserializer:   &blockDeserializer{},
+		QCDeserializer:      &testQCDeserializer{t: t},
+		ReplicationEnabled:  true,
+	}
+
+	numBlocks := uint64(10)
+	seqs := createBlocks(t, nodes, bb, numBlocks)
+	for _, data := range seqs {
+		conf.Storage.Index(data.VerifiedBlock, data.FCert)
+	}
+	e, err := simplex.NewEpoch(conf)
+	require.NoError(t, err)
+	require.NoError(t, e.Start())
+	sequences := []uint64{0, 1, 2, 3}
+	req := &simplex.ReplicationRequest{
+		Seqs:        sequences,
+		LatestRound: numBlocks,
+	}
+
+	resp, err := e.HandleReplicationRequest(req, nodes[1])
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Nil(t, resp.LatestRound)
+	require.Equal(t, len(sequences), len(resp.Data))
+	for i, data := range resp.Data {
+		require.Equal(t, seqs[i].FCert, *data.FCert)
+		require.Equal(t, seqs[i].VerifiedBlock, data.VerifiedBlock)
+	}
+
+	// request out of scope
+	req = &simplex.ReplicationRequest{
+		Seqs: []uint64{11, 12, 13},
+	}
+
+	resp, err = e.HandleReplicationRequest(req, nodes[1])
+	require.NoError(t, err)
+	require.Zero(t, len(resp.Data))
+}
+
+// TestReplicationRequestNotarizations tests replication requests for notarized blocks.
+func TestReplicationRequestNotarizations(t *testing.T) {
+	// generate 5 blocks & notarizations
+	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
+	nodes := []simplex.NodeID{{1}, {2}, {3}, {4}}
+	conf := defaultTestNodeEpochConfig(t, nodes[0], noopComm(nodes), bb)
+	conf.ReplicationEnabled = true
+
+	e, err := simplex.NewEpoch(conf)
+	require.NoError(t, err)
+	require.NoError(t, e.Start())
+
+	numBlocks := uint64(5)
+	rounds := make(map[uint64]simplex.VerifiedQuorumRound)
+	for i := uint64(0); i < numBlocks; i++ {
+		block, notarization := advanceRound(t, e, bb, true, false)
+
+		rounds[i] = simplex.VerifiedQuorumRound{
+			VerifiedBlock: block,
+			Notarization:  notarization,
+		}
+	}
+
+	require.Equal(t, uint64(numBlocks), e.Metadata().Round)
+
+	seqs := make([]uint64, 0, len(rounds))
+	for k := range rounds {
+		seqs = append(seqs, k)
+	}
+	req := &simplex.ReplicationRequest{
+		Seqs:        seqs,
+		LatestRound: 0,
+	}
+
+	resp, err := e.HandleReplicationRequest(req, nodes[1])
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, *resp.LatestRound, rounds[numBlocks-1])
+	for _, round := range resp.Data {
+		require.Nil(t, round.EmptyNotarization)
+		notarizedBlock, ok := rounds[round.VerifiedBlock.BlockHeader().Round]
+		require.True(t, ok)
+		require.Equal(t, notarizedBlock.VerifiedBlock, round.VerifiedBlock)
+		require.Equal(t, notarizedBlock.Notarization, round.Notarization)
+	}
+}
+
+// TestReplicationRequestMixed ensures the replication response also includes empty notarizations
+func TestReplicationRequestMixed(t *testing.T) {
+	// generate 5 blocks & notarizations
+	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
+	nodes := []simplex.NodeID{{1}, {2}, {3}, {4}}
+	conf := defaultTestNodeEpochConfig(t, nodes[0], noopComm(nodes), bb)
+	conf.ReplicationEnabled = true
+
+	e, err := simplex.NewEpoch(conf)
+	require.NoError(t, err)
+	require.NoError(t, e.Start())
+
+	numBlocks := uint64(8)
+	rounds := make(map[uint64]simplex.VerifiedQuorumRound)
+	// only produce a notarization for blocks we are the leader, otherwise produce an empty notarization
+	for i := range numBlocks {
+		leaderForRound := bytes.Equal(simplex.LeaderForRound(nodes, uint64(i)), e.ID)
+		emptyBlock := !leaderForRound
+		if emptyBlock {
+			emptyNotarization := newEmptyNotarization(nodes, uint64(i), uint64(i))
+			e.HandleMessage(&simplex.Message{
+				EmptyNotarization: emptyNotarization,
+			}, nodes[1])
+			e.WAL.(*testWAL).assertNotarization(uint64(i))
+			rounds[i] = simplex.VerifiedQuorumRound{
+				EmptyNotarization: emptyNotarization,
+			}
+			continue
+		}
+		block, notarization := advanceRound(t, e, bb, true, false)
+
+		rounds[i] = simplex.VerifiedQuorumRound{
+			VerifiedBlock: block,
+			Notarization:  notarization,
+		}
+	}
+
+	require.Equal(t, uint64(numBlocks), e.Metadata().Round)
+	seqs := make([]uint64, 0, len(rounds))
+	for k := range rounds {
+		seqs = append(seqs, k)
+	}
+
+	req := &simplex.ReplicationRequest{
+		Seqs:        seqs,
+		LatestRound: 0,
+	}
+	resp, err := e.HandleReplicationRequest(req, nodes[1])
+	require.NoError(t, err)
+
+	require.Equal(t, *resp.LatestRound, rounds[numBlocks-1])
+	for _, round := range resp.Data {
+		notarizedBlock, ok := rounds[round.GetRound()]
+		require.True(t, ok)
+		require.Equal(t, notarizedBlock.VerifiedBlock, round.VerifiedBlock)
+		require.Equal(t, notarizedBlock.Notarization, round.Notarization)
+		require.Equal(t, notarizedBlock.EmptyNotarization, round.EmptyNotarization)
+	}
+}
+
+func TestNilReplicationResponse(t *testing.T) {
+	bb := newTestControlledBlockBuilder(t)
+	nodes := []simplex.NodeID{{1}, {2}, {3}, {4}}
+	net := newInMemNetwork(t, nodes)
+
+	normalNode0 := newSimplexNode(t, nodes[0], net, bb, nil)
+	normalNode0.start()
+
+	err := normalNode0.HandleMessage(&simplex.Message{
+		ReplicationResponse: &simplex.ReplicationResponse{
+			Data: []simplex.QuorumRound{{}},
+		},
+	}, nodes[1])
+	require.NoError(t, err)
+}

--- a/util.go
+++ b/util.go
@@ -12,7 +12,7 @@ import (
 // RetrieveLastIndexFromStorage retrieves the latest block and fCert from storage.
 // Returns an error if it cannot be retrieved but the storage has some block.
 // Returns (nil, nil) if the storage is empty.
-func RetrieveLastIndexFromStorage(s Storage) (Block, *FinalizationCertificate, error) {
+func RetrieveLastIndexFromStorage(s Storage) (VerifiedBlock, *FinalizationCertificate, error) {
 	height := s.Height()
 	if height == 0 {
 		return nil, nil, nil
@@ -24,8 +24,8 @@ func RetrieveLastIndexFromStorage(s Storage) (Block, *FinalizationCertificate, e
 	return lastBlock, &fCert, nil
 }
 
-func IsFinalizationCertificateValid(fCert *FinalizationCertificate, quorumSize int, logger Logger) bool {
-	valid := validateFinalizationQC(fCert, quorumSize, logger)
+func IsFinalizationCertificateValid(eligibleSigners map[string]struct{}, fCert *FinalizationCertificate, quorumSize int, logger Logger) bool {
+	valid := validateFinalizationQC(eligibleSigners, fCert, quorumSize, logger)
 	if !valid {
 		return false
 	}
@@ -36,7 +36,7 @@ func IsFinalizationCertificateValid(fCert *FinalizationCertificate, quorumSize i
 	return true
 }
 
-func validateFinalizationQC(fCert *FinalizationCertificate, quorumSize int, logger Logger) bool {
+func validateFinalizationQC(eligibleSigners map[string]struct{}, fCert *FinalizationCertificate, quorumSize int, logger Logger) bool {
 	if fCert.QC == nil {
 		return false
 	}
@@ -49,10 +49,19 @@ func validateFinalizationQC(fCert *FinalizationCertificate, quorumSize int, logg
 		return false
 	}
 
-	signedTwice := hasSomeNodeSignedTwice(fCert.QC.Signers(), logger)
+	doubleSigner, signedTwice := hasSomeNodeSignedTwice(fCert.QC.Signers(), logger)
 
 	if signedTwice {
+		logger.Debug("Finalization certificate signed twice by the same node", zap.Stringer("signer", doubleSigner))
 		return false
+	}
+
+	// Finally, check that all signers are eligible of signing, and we don't have made up identities
+	for _, signer := range fCert.QC.Signers() {
+		if _, exists := eligibleSigners[string(signer)]; !exists {
+			logger.Debug("Finalization Quorum Certificate contains an unknown signer", zap.Stringer("signer", signer))
+			return false
+		}
 	}
 
 	if err := fCert.Verify(); err != nil {
@@ -62,16 +71,16 @@ func validateFinalizationQC(fCert *FinalizationCertificate, quorumSize int, logg
 	return true
 }
 
-func hasSomeNodeSignedTwice(nodeIDs []NodeID, logger Logger) bool {
+func hasSomeNodeSignedTwice(nodeIDs []NodeID, logger Logger) (NodeID, bool) {
 	seen := make(map[string]struct{}, len(nodeIDs))
 
 	for _, nodeID := range nodeIDs {
 		if _, alreadySeen := seen[string(nodeID)]; alreadySeen {
 			logger.Warn("Observed a signature originating at least twice from the same node")
-			return true
+			return nodeID, true
 		}
 		seen[string(nodeID)] = struct{}{}
 	}
 
-	return false
+	return NodeID{}, false
 }

--- a/util_test.go
+++ b/util_test.go
@@ -16,9 +16,9 @@ import (
 func TestRetrieveFromStorage(t *testing.T) {
 	brokenStorage := newInMemStorage()
 	brokenStorage.data[41] = struct {
-		Block
+		VerifiedBlock
 		FinalizationCertificate
-	}{Block: newTestBlock(ProtocolMetadata{Seq: 41})}
+	}{VerifiedBlock: newTestBlock(ProtocolMetadata{Seq: 41})}
 
 	block := newTestBlock(ProtocolMetadata{Seq: 0})
 	fCert := FinalizationCertificate{
@@ -28,15 +28,15 @@ func TestRetrieveFromStorage(t *testing.T) {
 	}
 	normalStorage := newInMemStorage()
 	normalStorage.data[0] = struct {
-		Block
+		VerifiedBlock
 		FinalizationCertificate
-	}{Block: block, FinalizationCertificate: fCert}
+	}{VerifiedBlock: block, FinalizationCertificate: fCert}
 
 	for _, testCase := range []struct {
 		description   string
 		storage       Storage
 		expectedErr   error
-		expectedBlock Block
+		expectedBlock VerifiedBlock
 		expectedFCert *FinalizationCertificate
 	}{
 		{
@@ -67,6 +67,10 @@ func TestRetrieveFromStorage(t *testing.T) {
 func TestFinalizationCertificateValidation(t *testing.T) {
 	l := testutil.MakeLogger(t, 0)
 	nodes := []NodeID{{1}, {2}, {3}, {4}, {5}}
+	eligibleSigners := make(map[string]struct{})
+	for _, n := range nodes {
+		eligibleSigners[string(n)] = struct{}{}
+	}
 	quorumSize := Quorum(len(nodes))
 	signatureAggregator := &testSignatureAggregator{}
 	// Test
@@ -112,11 +116,21 @@ func TestFinalizationCertificateValidation(t *testing.T) {
 			quorumSize: quorumSize,
 			valid:      false,
 		},
+		{
+			name: "nodes are not eligible signers",
+			fCert: func() FinalizationCertificate {
+				block := newTestBlock(ProtocolMetadata{})
+				signers := []NodeID{{1}, {2}, {3}, {4}, {6}}
+				fCert, _ := newFinalizationRecord(t, l, signatureAggregator, block, signers)
+				return fCert
+			}(), quorumSize: quorumSize,
+			valid: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			valid := simplex.IsFinalizationCertificateValid(&tt.fCert, tt.quorumSize, l)
+			valid := simplex.IsFinalizationCertificateValid(eligibleSigners, &tt.fCert, tt.quorumSize, l)
 			require.Equal(t, tt.valid, valid)
 		})
 	}


### PR DESCRIPTION
This PR updates the code for replication. Rather than having two separate requests for notarizations and finalizations, this consolidates them into a single `ReplicationRequest` struct. 

```go
type  ReplicationRequest  struct {
	Seqs []uint64  // sequences we are requesting
	LatestRound  uint64  // latest round that we are aware of
}

type  ReplicationResponse  struct {
	Data []QuorumRound
	LatestRound  *QuorumRound
}

type  QuorumRound  struct {
	Block  Block
	Notarization  *Notarization
	FCert  *FinalizationCertificate
	EmptyNotarization  *EmptyNotarization
}
```

The `LatestRound` field notifies the responding node, whether the requesting node is behind. Receiving a higher latest round, tells the requesting node that it is still behind and may need to send out more replication requests. 