### PR TITLE
Fix monitor dropping tasks

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -106,7 +106,7 @@ func (m *Monitor) WaitFor(f func()) {
 	select {
 	case m.tasks <- f:
 	default:
-
+		m.logger.Warn("Dropping task because the monitor tasks channel is full")
 	}
 }
 


### PR DESCRIPTION
flake described in more detail in #133 

the solution is to ensure the previous task was executed before scheduling a new one. 