### PR TITLE
Assert WAL before checking metadata

### DIFF
--- a/replication_test.go
+++ b/replication_test.go
@@ -625,6 +625,7 @@ func testReplicationNotarizationWithoutFinalizations(t *testing.T, numBlocks uin
 
 	}
 
+	laggingNode.wal.assertNotarization(numBlocks - 1)
 	require.Equal(t, uint64(0), laggingNode.storage.Height())
 	require.Equal(t, uint64(numBlocks), laggingNode.e.Metadata().Round)
 


### PR DESCRIPTION
avoids a flake where we check the lagging nodes metadata before waiting for the wal to be updated.

