### PR TITLE
Resend Replication Requests After a Timeout

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -83,7 +83,7 @@ type Epoch struct {
 	eligibleNodeIDs                map[string]struct{}
 	quorumSize                     int
 	rounds                         map[uint64]*Round
-	emptyVotes                     map[uint64]*EmptyVoteSet
+	emptyVotes                      map[uint64]*EmptyVoteSet
 	futureMessages                 messagesFromNode
 	round                          uint64 // The current round we notarize
 	maxRoundWindow                 uint64

--- a/epoch.go
+++ b/epoch.go
@@ -25,6 +25,7 @@ const (
 	DefaultMaxPendingBlocks = 20
 
 	DefaultMaxProposalWaitTime = 5 * time.Second
+	DefaultReplicationRequestTimeout = 5 * time.Second
 )
 
 type EmptyVoteSet struct {
@@ -105,6 +106,7 @@ func NewEpoch(conf EpochConfig) (*Epoch, error) {
 // AdvanceTime hints the engine that the given amount of time has passed.
 func (e *Epoch) AdvanceTime(t time.Time) {
 	e.monitor.AdvanceTime(t)
+	e.replicationState.Tick(t)
 }
 
 // HandleMessage notifies the engine about a reception of a message.
@@ -173,7 +175,7 @@ func (e *Epoch) init() error {
 	e.maxPendingBlocks = DefaultMaxPendingBlocks
 	e.eligibleNodeIDs = make(map[string]struct{}, len(e.nodes))
 	e.futureMessages = make(messagesFromNode, len(e.nodes))
-	e.replicationState = NewReplicationState(e.Logger, e.Comm, e.ID, e.maxRoundWindow, e.ReplicationEnabled)
+	e.replicationState = NewReplicationState(e.Logger, e.Comm, e.ID, e.maxRoundWindow, e.ReplicationEnabled, e.StartTime)
 
 	for _, node := range e.nodes {
 		e.futureMessages[string(node)] = make(map[uint64]*messagesForRound)

--- a/epoch.go
+++ b/epoch.go
@@ -106,7 +106,7 @@ func NewEpoch(conf EpochConfig) (*Epoch, error) {
 // AdvanceTime hints the engine that the given amount of time has passed.
 func (e *Epoch) AdvanceTime(t time.Time) {
 	e.monitor.AdvanceTime(t)
-	e.replicationState.Tick(t)
+	e.replicationState.AdvanceTime(t)
 }
 
 // HandleMessage notifies the engine about a reception of a message.
@@ -2352,6 +2352,8 @@ func (e *Epoch) handleReplicationResponse(resp *ReplicationResponse, from NodeID
 		e.Logger.Debug("Failed processing latest round", zap.Error(err))
 		return nil
 	}
+
+	e.replicationState.receivedReplicationResponse(resp.Data, from)
 
 	return e.processReplicationState()
 }

--- a/epoch.go
+++ b/epoch.go
@@ -24,7 +24,7 @@ const (
 	DefaultMaxRoundWindow   = 10
 	DefaultMaxPendingBlocks = 20
 
-	DefaultMaxProposalWaitTime = 5 * time.Second
+	DefaultMaxProposalWaitTime       = 5 * time.Second
 	DefaultReplicationRequestTimeout = 5 * time.Second
 )
 
@@ -84,7 +84,7 @@ type Epoch struct {
 	eligibleNodeIDs                map[string]struct{}
 	quorumSize                     int
 	rounds                         map[uint64]*Round
-	emptyVotes                      map[uint64]*EmptyVoteSet
+	emptyVotes                     map[uint64]*EmptyVoteSet
 	futureMessages                 messagesFromNode
 	round                          uint64 // The current round we notarize
 	maxRoundWindow                 uint64

--- a/epoch_multinode_test.go
+++ b/epoch_multinode_test.go
@@ -271,6 +271,7 @@ func (tw *testWAL) containsEmptyNotarization(round uint64) bool {
 
 // messageFilter defines a function that filters
 // certain messages from being sent or broadcasted.
+// a message filter should return true if the message is allowed to be sent
 type messageFilter func(*Message, NodeID) bool
 
 // allowAllMessages allows every message to be sent

--- a/monitor_test.go
+++ b/monitor_test.go
@@ -4,12 +4,13 @@
 package simplex
 
 import (
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestMonitorDoubleClose(t *testing.T) {

--- a/replication.go
+++ b/replication.go
@@ -190,17 +190,7 @@ func (r *ReplicationState) receivedReplicationResponse(data []QuorumRound, node 
 
 	slices.Sort(seqs)
 
-	var task *TimeoutTask
-	// first find the id this request belongs too
-seq:
-	for _, seq := range seqs {
-		for _, t := range r.timeoutHandler.tasks[string(node)] {
-			if seq > t.Start && seq < t.End {
-				task = t
-				break seq
-			}
-		}
-	}
+	task := r.timeoutHandler.FindTask(node, seqs)
 
 	if task == nil {
 		return

--- a/replication.go
+++ b/replication.go
@@ -57,7 +57,7 @@ type ReplicationState struct {
 	// request iterator
 	requestIterator int
 
-	now time.Time
+	now     time.Time
 	handler TimeoutHandler
 }
 
@@ -69,7 +69,7 @@ func NewReplicationState(logger Logger, comm Communication, id NodeID, maxRoundW
 		id:                   id,
 		maxRoundWindow:       maxRoundWindow,
 		receivedQuorumRounds: make(map[uint64]QuorumRound),
-		now: start,
+		now:                  start,
 	}
 }
 
@@ -156,18 +156,19 @@ func (r *ReplicationState) sendRequestToNode(start uint64, end uint64, nodes []N
 
 	task, id := r.createReplicationTimeoutTask(start, end, nodes, index)
 	timeoutTask := &TimeoutTask{
-		ID: id,
-		Task: task,
+		ID:      id,
+		Task:    task,
 		Timeout: r.now.Add(DefaultReplicationRequestTimeout),
 	}
+
 	r.handler.AddTask(timeoutTask)
 	r.lastSequenceRequested = end
 	r.comm.SendMessage(msg, nodes[index])
 }
 
-func (r *ReplicationState) createReplicationTimeoutTask(start, end uint64, nodes []NodeID, index int) (func (), ID) {
+func (r *ReplicationState) createReplicationTimeoutTask(start, end uint64, nodes []NodeID, index int) (func(), ID) {
 	return func() {
-		r.sendRequestToNode(start, end, nodes, (index + 1) % len(nodes))
+		r.sendRequestToNode(start, end, nodes, (index+1)%len(nodes))
 	}, r.createUniqueTimeoutID(start, end, nodes, index)
 }
 

--- a/replication.go
+++ b/replication.go
@@ -159,9 +159,9 @@ func (r *ReplicationState) sendRequestToNode(start uint64, end uint64, nodes []N
 
 	task := r.createReplicationTimeoutTask(start, end, nodes, index)
 	timeoutTask := &TimeoutTask{
-		ID:      r.getUniqueTimeoutID(start, end, nodes[index]),
-		Task:    task,
-		Timeout: r.timeoutHandler.GetTime().Add(DefaultReplicationRequestTimeout),
+		ID:       r.getUniqueTimeoutID(start, end, nodes[index]),
+		Task:     task,
+		Deadline: r.timeoutHandler.GetTime().Add(DefaultReplicationRequestTimeout),
 	}
 
 	r.timeoutHandler.AddTask(timeoutTask)

--- a/replication.go
+++ b/replication.go
@@ -226,19 +226,17 @@ func (r *ReplicationState) receivedReplicationResponse(data []QuorumRound, node 
 	r.timeoutHandler.AddTask(newTask)
 }
 
+// findMissingNumbersInRange finds numbers in an array constructed by [start...end] that are not in [nums]
+// ex. (3, 10, [1,2,3,4,5,6]) -> [7,8,9,10]
 func findMissingNumbersInRange(start, end uint64, nums []uint64) []uint64 {
-	// Create a map to track numbers in the input array for O(1) lookups
 	numMap := make(map[uint64]bool)
 	for _, num := range nums {
 		numMap[num] = true
 	}
 
-	// Create result array of missing numbers
 	var result []uint64
 
-	// Check each number in the range
 	for i := start; i <= end; i++ {
-		// If number isn't in the map, add it to result
 		if _, exists := numMap[i]; !exists {
 			result = append(result, i)
 		}

--- a/replication.go
+++ b/replication.go
@@ -191,21 +191,19 @@ func (r *ReplicationState) receivedReplicationResponse(data []QuorumRound, node 
 	slices.Sort(seqs)
 
 	task := r.timeoutHandler.FindTask(node, seqs)
-
 	if task == nil {
 		return
 	}
 
-	// we found the buket, now
-	missing := findMissingNumbersInRange(task.Start, task.End, seqs)
-
-	// remove the old task
 	r.timeoutHandler.RemoveTask(node, task.TaskID)
 
+	// we found the timeout, now make sure all seqs were returned
+	missing := findMissingNumbersInRange(task.Start, task.End, seqs)
 	if len(missing) == 0 {
 		return
 	}
 
+	// not all sequences were returned, create new timeouts
 	nodes := r.highestSequenceObserved.signers.Remove(r.id)
 	lenNodes := len(nodes)
 

--- a/replication.go
+++ b/replication.go
@@ -68,7 +68,7 @@ func NewReplicationState(logger Logger, comm Communication, id NodeID, maxRoundW
 		id:                   id,
 		maxRoundWindow:       maxRoundWindow,
 		receivedQuorumRounds: make(map[uint64]QuorumRound),
-		handler:              *NewTimeoutHandler(start),
+		handler:              *NewTimeoutHandler(logger, start),
 	}
 }
 

--- a/replication.go
+++ b/replication.go
@@ -70,7 +70,7 @@ func NewReplicationState(logger Logger, comm Communication, id NodeID, maxRoundW
 		maxRoundWindow:       maxRoundWindow,
 		receivedQuorumRounds: make(map[uint64]QuorumRound),
 		now:                  start,
-		handler: *NewTimeoutHandler(start),
+		handler:              *NewTimeoutHandler(start),
 	}
 }
 

--- a/replication.go
+++ b/replication.go
@@ -70,12 +70,13 @@ func NewReplicationState(logger Logger, comm Communication, id NodeID, maxRoundW
 		maxRoundWindow:       maxRoundWindow,
 		receivedQuorumRounds: make(map[uint64]QuorumRound),
 		now:                  start,
+		handler: *NewTimeoutHandler(start),
 	}
 }
 
 func (r *ReplicationState) AdvanceTime(now time.Time) {
-	// r.now = now
-	// r.handler.Tick(now)
+	r.now = now
+	r.handler.Tick(now)
 }
 
 // isReplicationComplete returns true if we have finished the replication process.

--- a/replication.go
+++ b/replication.go
@@ -118,7 +118,8 @@ func (r *ReplicationState) sendReplicationRequests(start uint64, end uint64) {
 
 	numSeqs := end + 1 - start
 	seqsPerNode := numSeqs / uint64(numNodes)
-	r.logger.Debug("Distributing replication requests", zap.Uint64("start", start), zap.Uint64("end", end), zap.Stringer("ndoes", NodeIDs(nodes)), zap.Int("numnodes", len(nodes)))
+
+	r.logger.Debug("Distributing replication requests", zap.Uint64("start", start), zap.Uint64("end", end), zap.Stringer("ndoes", NodeIDs(nodes)))
 	// Distribute sequences evenly among nodes in round-robin fashion
 	for i := range numNodes {
 		nodeIndex := (r.requestIterator + i) % numNodes
@@ -139,7 +140,7 @@ func (r *ReplicationState) sendReplicationRequests(start uint64, end uint64) {
 }
 
 // sendRequestToNode requests the sequences [start, end] from nodes[index].
-// Incase the nodes[index] does not respond, we create a timeout that will
+// In case the nodes[index] does not respond, we create a timeout that will
 // re-send the request.
 func (r *ReplicationState) sendRequestToNode(start uint64, end uint64, nodes []NodeID, index int) {
 	r.logger.Debug("Requesting missing finalization certificates ",

--- a/replication.go
+++ b/replication.go
@@ -57,7 +57,7 @@ type ReplicationState struct {
 	// request iterator
 	requestIterator int
 
-	timeoutHandler TimeoutHandler
+	timeoutHandler *TimeoutHandler
 }
 
 func NewReplicationState(logger Logger, comm Communication, id NodeID, maxRoundWindow uint64, enabled bool, start time.Time) *ReplicationState {
@@ -68,7 +68,7 @@ func NewReplicationState(logger Logger, comm Communication, id NodeID, maxRoundW
 		id:                   id,
 		maxRoundWindow:       maxRoundWindow,
 		receivedQuorumRounds: make(map[uint64]QuorumRound),
-		timeoutHandler:       *NewTimeoutHandler(logger, start),
+		timeoutHandler:       NewTimeoutHandler(logger, start),
 	}
 }
 

--- a/replication_test.go
+++ b/replication_test.go
@@ -41,7 +41,7 @@ func testReplication(t *testing.T, startSeq uint64, nodes []simplex.NodeID) {
 	bb := newTestControlledBlockBuilder(t)
 	net := newInMemNetwork(t, nodes)
 
-	// initiate a network with 4 nodes. one node is behind by 8 blocks
+	// initiate a network with 4 nodes. one node is behind by startSeq blocks
 	storageData := createBlocks(t, nodes, &bb.testBlockBuilder, startSeq)
 	testEpochConfig := &testNodeConfig{
 		initialStorage:     storageData,

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -1,0 +1,70 @@
+package simplex_test
+
+import (
+	"simplex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func rejectReplicationRequests(msg *simplex.Message, from simplex.NodeID) bool {
+	if msg.ReplicationRequest != nil {
+		return false
+	}
+
+	return true
+}
+
+// A node attempts to request blocks to replicate, but fails to receive them
+func TestReplicationRequestTimeout(t *testing.T) {
+	nodes := []simplex.NodeID{{1}, {2}, {3}, []byte("lagging")}
+	startSeq := uint64(8)
+
+	// node begins replication
+	bb := newTestControlledBlockBuilder(t)
+	net := newInMemNetwork(t, nodes)
+
+	storageData := createBlocks(t, nodes, &bb.testBlockBuilder, startSeq)
+
+	newNodeConfig := func(from simplex.NodeID) *testNodeConfig {
+		comm := newTestComm(from, net, rejectReplicationRequests)
+		return &testNodeConfig{
+			initialStorage:     storageData,
+			comm:               comm,
+			replicationEnabled: true,
+		}
+	}
+
+	newSimplexNode(t, nodes[0], net, bb, newNodeConfig(nodes[0]))
+	newSimplexNode(t, nodes[1], net, bb, newNodeConfig(nodes[1]))
+	newSimplexNode(t, nodes[2], net, bb, newNodeConfig(nodes[2]))
+	laggingNode := newSimplexNode(t, nodes[3], net, bb, &testNodeConfig{
+		replicationEnabled: true,
+	})
+
+	net.startInstances()
+	bb.triggerNewBlock()
+
+	// typically the lagging node would catch up here, but since we block
+	// replication requests, the lagging node will be forced to resend requests after a timeout
+	for i := 0; i <= int(startSeq); i++ {
+		for _, n := range net.instances {
+			if n.e.ID.Equals(laggingNode.e.ID) {
+				continue
+			}
+			n.storage.waitForBlockCommit(uint64(startSeq))
+		}
+	}
+
+	// assert the lagging node has not received any replicaiton requests
+	require.Equal(t, uint64(0), laggingNode.storage.Height())
+
+	// after the timeout, the nodes should respond and the lagging node will replicate
+	net.setAllNodesMessageFilter(allowAllMessages)
+	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout / 2))
+
+	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout * 2))
+
+	laggingNode.storage.waitForBlockCommit(uint64(startSeq))
+}

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -6,7 +6,6 @@ package simplex_test
 import (
 	"simplex"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -126,7 +125,12 @@ func TestReplicationRequestTimeoutCancels(t *testing.T) {
 	}
 	laggingNode.e.Comm.(*testComm).setFilter(mf.failOnReplicationRequest)
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout * 2))
-	time.Sleep(50 * time.Millisecond) // give enough time to ensure a replication request doesn't go through
+
+	// ensure enough time passes after advanceTime is called
+	bb.triggerNewBlock()
+	for _, n := range net.instances {
+		n.storage.waitForBlockCommit(uint64(startSeq + 1))
+	}
 }
 
 // A node attempts to request blocks to replicate, but fails to

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -8,11 +8,7 @@ import (
 )
 
 func rejectReplicationRequests(msg *simplex.Message, from simplex.NodeID) bool {
-	if msg.ReplicationRequest != nil {
-		return false
-	}
-
-	return true
+	return msg.ReplicationRequest == nil
 }
 
 // A node attempts to request blocks to replicate, but fails to receive them

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -4,7 +4,6 @@
 package simplex_test
 
 import (
-	"fmt"
 	"simplex"
 	"testing"
 
@@ -196,7 +195,7 @@ func TestReplicationRequestTimeoutMultiple(t *testing.T) {
 	laggingNode.storage.waitForBlockCommit(startSeq)
 }
 
-// does every other
+// modifies the replication response to only send every other quorom round
 func incompleteReplicationResponseFilter(msg *simplex.Message, from simplex.NodeID) bool {
 	if msg.VerifiedReplicationResponse != nil || msg.ReplicationResponse != nil {
 		newLen := len(msg.VerifiedReplicationResponse.Data) / 2
@@ -206,8 +205,6 @@ func incompleteReplicationResponseFilter(msg *simplex.Message, from simplex.Node
 			newData = append(newData, msg.VerifiedReplicationResponse.Data[i])
 		}
 		msg.VerifiedReplicationResponse.Data = newData
-
-		fmt.Println("hereee")
 	}
 	return true
 }
@@ -266,7 +263,7 @@ func TestReplicationRequestIncompleteResponses(t *testing.T) {
 
 	// assert the lagging node has not received any replication responses
 	require.Equal(t, uint64(0), laggingNode.storage.Height())
-	normalNode2.e.Comm.(*testComm).setFilter(incompleteReplicationResponseFilter)
+	net.setAllNodesMessageFilter(incompleteReplicationResponseFilter)
 
 	// after the timeout, only normalNode2 should respond(but with incomplete data)
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout / 2))

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -4,6 +4,7 @@
 package simplex_test
 
 import (
+	"fmt"
 	"simplex"
 	"testing"
 
@@ -188,6 +189,90 @@ func TestReplicationRequestTimeoutMultiple(t *testing.T) {
 	require.Equal(t, uint64(0), laggingNode.storage.Height())
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout))
 	laggingNode.storage.waitForBlockCommit(startSeq / 3)
+
+	net.setAllNodesMessageFilter(allowAllMessages)
+	// timeout again, now all nodes will respond
+	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout * 2))
+	laggingNode.storage.waitForBlockCommit(startSeq)
+}
+
+// does every other
+func incompleteReplicationResponseFilter(msg *simplex.Message, from simplex.NodeID) bool {
+	if msg.VerifiedReplicationResponse != nil || msg.ReplicationResponse != nil {
+		newLen := len(msg.VerifiedReplicationResponse.Data) / 2
+		newData := make([]simplex.VerifiedQuorumRound, 0, newLen)
+
+		for i := 0; i < newLen; i += 2 {
+			newData = append(newData, msg.VerifiedReplicationResponse.Data[i])
+		}
+		msg.VerifiedReplicationResponse.Data = newData
+
+		fmt.Println("hereee")
+	}
+	return true
+}
+
+// A node attempts to request blocks to replicate, but receives incomplete
+// responses from nodes.
+func TestReplicationRequestIncompleteResponses(t *testing.T) {
+	nodes := []simplex.NodeID{{1}, {2}, {3}, []byte("lagging")}
+	startSeq := uint64(8)
+
+	// node begins replication
+	bb := newTestControlledBlockBuilder(t)
+	net := newInMemNetwork(t, nodes)
+
+	storageData := createBlocks(t, nodes, &bb.testBlockBuilder, startSeq)
+
+	newNodeConfig := func(from simplex.NodeID) *testNodeConfig {
+		comm := newTestComm(from, net, rejectReplicationRequests)
+		return &testNodeConfig{
+			initialStorage:     storageData,
+			comm:               comm,
+			replicationEnabled: true,
+		}
+	}
+
+	mf := &testTimeoutMessageFilter{
+		t:                    t,
+		replicationResponses: make(chan struct{}, 1),
+	}
+
+	newSimplexNode(t, nodes[0], net, bb, newNodeConfig(nodes[0]))
+	normalNode2 := newSimplexNode(t, nodes[1], net, bb, newNodeConfig(nodes[1]))
+	normalNode2.e.Comm.(*testComm).setFilter(mf.receivedReplicationRequest)
+	newSimplexNode(t, nodes[2], net, bb, newNodeConfig(nodes[2]))
+	laggingNode := newSimplexNode(t, nodes[3], net, bb, &testNodeConfig{
+		replicationEnabled: true,
+	})
+
+	net.startInstances()
+	bb.triggerNewBlock()
+
+	// typically the lagging node would catch up here, but since we block
+	// replication requests, the lagging node will be forced to resend requests after a timeout
+	for i := 0; i <= int(startSeq); i++ {
+		for _, n := range net.instances {
+			if n.e.ID.Equals(laggingNode.e.ID) {
+				continue
+			}
+			n.storage.waitForBlockCommit(uint64(startSeq))
+		}
+	}
+
+	// this is done from normalNode2 since the lagging node will request
+	// seqs [0-startSeq/3] after the timeout
+	<-mf.replicationResponses
+
+	// assert the lagging node has not received any replication responses
+	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	normalNode2.e.Comm.(*testComm).setFilter(incompleteReplicationResponseFilter)
+
+	// after the timeout, only normalNode2 should respond(but with incomplete data)
+	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout / 2))
+	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout))
+	laggingNode.storage.waitForBlockCommit(0)
 
 	net.setAllNodesMessageFilter(allowAllMessages)
 	// timeout again, now all nodes will respond

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -17,13 +17,13 @@ func rejectReplicationRequests(msg *simplex.Message, from simplex.NodeID) bool {
 // A node attempts to request blocks to replicate, but fails to receive them
 func TestReplicationRequestTimeout(t *testing.T) {
 	nodes := []simplex.NodeID{{1}, {2}, {3}, []byte("lagging")}
-	numInitalSeqs := uint64(8)
+	numInitialSeqs := uint64(8)
 
 	// node begins replication
 	bb := newTestControlledBlockBuilder(t)
 	net := newInMemNetwork(t, nodes)
 
-	storageData := createBlocks(t, nodes, &bb.testBlockBuilder, numInitalSeqs)
+	storageData := createBlocks(t, nodes, &bb.testBlockBuilder, numInitialSeqs)
 
 	newNodeConfig := func(from simplex.NodeID) *testNodeConfig {
 		comm := newTestComm(from, net, rejectReplicationRequests)
@@ -46,12 +46,12 @@ func TestReplicationRequestTimeout(t *testing.T) {
 
 	// typically the lagging node would catch up here, but since we block
 	// replication requests, the lagging node will be forced to resend requests after a timeout
-	for i := 0; i <= int(numInitalSeqs); i++ {
+	for i := 0; i <= int(numInitialSeqs); i++ {
 		for _, n := range net.instances {
 			if n.e.ID.Equals(laggingNode.e.ID) {
 				continue
 			}
-			n.storage.waitForBlockCommit(uint64(numInitalSeqs))
+			n.storage.waitForBlockCommit(uint64(numInitialSeqs))
 		}
 	}
 
@@ -64,7 +64,7 @@ func TestReplicationRequestTimeout(t *testing.T) {
 	require.Equal(t, uint64(0), laggingNode.storage.Height())
 
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout * 2))
-	laggingNode.storage.waitForBlockCommit(uint64(numInitalSeqs))
+	laggingNode.storage.waitForBlockCommit(uint64(numInitialSeqs))
 }
 
 type testTimeoutMessageFilter struct {

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -6,6 +6,7 @@ package simplex_test
 import (
 	"simplex"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -186,6 +187,9 @@ func TestReplicationRequestTimeoutMultiple(t *testing.T) {
 	// after the timeout, only normalNode2 should respond
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout / 2))
 	require.Equal(t, uint64(0), laggingNode.storage.Height())
+
+	// sleep so we do not drop the tick in timeout handler
+	time.Sleep(10 * time.Millisecond)
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout))
 	laggingNode.storage.waitForBlockCommit(startSeq / 3)
 

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -6,7 +6,6 @@ package simplex_test
 import (
 	"simplex"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -62,8 +61,8 @@ func TestReplicationRequestTimeout(t *testing.T) {
 	// after the timeout, the nodes should respond and the lagging node will replicate
 	net.setAllNodesMessageFilter(allowAllMessages)
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout / 2))
-
 	require.Equal(t, uint64(0), laggingNode.storage.Height())
+
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout * 2))
 	laggingNode.storage.waitForBlockCommit(uint64(startSeq))
 }
@@ -188,8 +187,6 @@ func TestReplicationRequestTimeoutMultiple(t *testing.T) {
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout / 2))
 	require.Equal(t, uint64(0), laggingNode.storage.Height())
 
-	// sleep so we do not drop the tick in timeout handler
-	time.Sleep(10 * time.Millisecond)
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout))
 	laggingNode.storage.waitForBlockCommit(startSeq / 3)
 
@@ -272,6 +269,7 @@ func TestReplicationRequestIncompleteResponses(t *testing.T) {
 	// after the timeout, only normalNode2 should respond(but with incomplete data)
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout / 2))
 	require.Equal(t, uint64(0), laggingNode.storage.Height())
+
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout))
 	laggingNode.storage.waitForBlockCommit(0)
 

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package simplex_test
 
 import (

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func rejectReplicationRequests(msg *simplex.Message, from simplex.NodeID) bool {
-	return msg.ReplicationRequest == nil
+	return msg.ReplicationRequest == nil && msg.ReplicationResponse == nil && msg.VerifiedReplicationResponse == nil
 }
 
 // A node attempts to request blocks to replicate, but fails to receive them
@@ -63,4 +63,129 @@ func TestReplicationRequestTimeout(t *testing.T) {
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout * 2))
 
 	laggingNode.storage.waitForBlockCommit(uint64(startSeq))
+}
+
+type TestMessageFilter struct {
+	t *testing.T
+
+	replicationRequest chan struct{}
+}
+
+func (m *TestMessageFilter) failOnReplicationRequest(msg *simplex.Message, from simplex.NodeID) bool {
+	require.Nil(m.t, msg.ReplicationRequest)
+	return true
+}
+
+func (m *TestMessageFilter) receivedReplicationRequest(msg *simplex.Message, from simplex.NodeID) bool {
+	if msg.VerifiedReplicationResponse != nil || msg.ReplicationResponse != nil {
+		m.replicationRequest <- struct{}{}
+		return false
+	}
+
+	return true
+}
+
+func TestReplicationRequestTimeoutCancels(t *testing.T) {
+	nodes := []simplex.NodeID{{1}, {2}, {3}, []byte("lagging")}
+	startSeq := uint64(8)
+
+	bb := newTestControlledBlockBuilder(t)
+	net := newInMemNetwork(t, nodes)
+
+	// initiate a network with 4 nodes. one node is behind by startSeq blocks
+	storageData := createBlocks(t, nodes, &bb.testBlockBuilder, startSeq)
+	testEpochConfig := &testNodeConfig{
+		initialStorage:     storageData,
+		replicationEnabled: true,
+	}
+	newSimplexNode(t, nodes[0], net, bb, testEpochConfig)
+	newSimplexNode(t, nodes[1], net, bb, testEpochConfig)
+	newSimplexNode(t, nodes[2], net, bb, testEpochConfig)
+	laggingNode := newSimplexNode(t, nodes[3], net, bb, &testNodeConfig{
+		replicationEnabled: true,
+	})
+
+	net.startInstances()
+	bb.triggerNewBlock()
+
+	// all blocks except the lagging node start at round 8, seq 8.
+	// lagging node starts at round 0, seq 0.
+	// this asserts that the lagging node catches up to the latest round
+	for i := 0; i <= int(startSeq); i++ {
+		for _, n := range net.instances {
+			n.storage.waitForBlockCommit(uint64(startSeq))
+		}
+	}
+
+	// ensure lagging node doesn't resed requests
+	mf := &TestMessageFilter{
+		t: t,
+	}
+	laggingNode.e.Comm.(*testComm).setFilter(mf.failOnReplicationRequest)
+	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout * 2))
+}
+
+// A node attempts to request blocks to replicate, but fails to
+// receive them multiple times
+func TestReplicationRequestTimeoutMultiple(t *testing.T) {
+	nodes := []simplex.NodeID{{1}, {2}, {3}, []byte("lagging")}
+	startSeq := uint64(8)
+
+	// node begins replication
+	bb := newTestControlledBlockBuilder(t)
+	net := newInMemNetwork(t, nodes)
+
+	storageData := createBlocks(t, nodes, &bb.testBlockBuilder, startSeq)
+
+	newNodeConfig := func(from simplex.NodeID) *testNodeConfig {
+		comm := newTestComm(from, net, rejectReplicationRequests)
+		return &testNodeConfig{
+			initialStorage:     storageData,
+			comm:               comm,
+			replicationEnabled: true,
+		}
+	}
+
+	mf := &TestMessageFilter{
+		t:                  t,
+		replicationRequest: make(chan struct{}, 1),
+	}
+
+	newSimplexNode(t, nodes[0], net, bb, newNodeConfig(nodes[0]))
+	normalNode2 := newSimplexNode(t, nodes[1], net, bb, newNodeConfig(nodes[1]))
+	normalNode2.e.Comm.(*testComm).setFilter(mf.receivedReplicationRequest)
+	newSimplexNode(t, nodes[2], net, bb, newNodeConfig(nodes[2]))
+	laggingNode := newSimplexNode(t, nodes[3], net, bb, &testNodeConfig{
+		replicationEnabled: true,
+	})
+
+	net.startInstances()
+	bb.triggerNewBlock()
+
+	// typically the lagging node would catch up here, but since we block
+	// replication requests, the lagging node will be forced to resend requests after a timeout
+	for i := 0; i <= int(startSeq); i++ {
+		for _, n := range net.instances {
+			if n.e.ID.Equals(laggingNode.e.ID) {
+				continue
+			}
+			n.storage.waitForBlockCommit(uint64(startSeq))
+		}
+	}
+
+	// assert the lagging node has not received any replication requests
+	<-mf.replicationRequest
+	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	normalNode2.e.Comm.(*testComm).setFilter(allowAllMessages)
+
+	// after the timeout, only normalNode1 should respond
+	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout / 2))
+	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout))
+	laggingNode.storage.waitForBlockCommit(startSeq / 3)
+
+	net.setAllNodesMessageFilter(allowAllMessages)
+	// timeout again
+	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout * 2))
+	laggingNode.storage.waitForBlockCommit(startSeq)
 }

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -64,7 +64,6 @@ func TestReplicationRequestTimeout(t *testing.T) {
 
 	require.Equal(t, uint64(0), laggingNode.storage.Height())
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout * 2))
-
 	laggingNode.storage.waitForBlockCommit(uint64(startSeq))
 }
 

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -6,6 +6,7 @@ package simplex_test
 import (
 	"simplex"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -125,6 +126,7 @@ func TestReplicationRequestTimeoutCancels(t *testing.T) {
 	}
 	laggingNode.e.Comm.(*testComm).setFilter(mf.failOnReplicationRequest)
 	laggingNode.e.AdvanceTime(laggingNode.e.StartTime.Add(simplex.DefaultReplicationRequestTimeout * 2))
+	time.Sleep(50 * time.Millisecond) // give enough time to ensure a replication request doesn't go through
 }
 
 // A node attempts to request blocks to replicate, but fails to

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -1,0 +1,73 @@
+package simplex
+
+import (
+	"sync"
+	"time"
+)
+
+type ID string
+
+type TimeoutTask struct {
+	id ID
+	task func()
+	timeout time.Time
+
+	index int // for heap to work more efficiently
+}
+
+type TimeoutHandler struct {
+	mu sync.Mutex
+
+	tasks map[ID]*TimeoutTask
+	heap TaskHeap
+	now time.Time
+}
+
+func (t *TimeoutHandler) Tick(now time.Time) {
+	// update the time of the handler
+	t.now = now
+
+	// go through the heap executing relevant tasks
+}
+
+func (t *TimeoutHandler) AddTask(task TimeoutTask) {
+	// adds a task to the heap and the tasks map
+}
+
+func (t *TimeoutHandler) RemoveTask(id ID) {
+	// find the task using the task map
+	// remove it from the heap using the index
+}
+
+
+
+
+// ----------------------------------------------------------------------
+type TaskHeap []*TimeoutTask
+
+func (h *TaskHeap) Len() int {return len(*h)}
+// Less returns if the task at index [i] has a lower timeout than the task at index [j]
+func (h *TaskHeap) Less(i, j int) bool { return (*h)[i].timeout.Before((*h)[j].timeout) }
+
+// Swap swaps the values at index [i] and [j]
+func (h *TaskHeap) Swap(i, j int) { 
+	(*h)[i], (*h)[j] = (*h)[j], (*h)[i] 
+	(*h)[i].index = i
+	(*h)[j].index = j
+}
+
+func (h *TaskHeap) Push(x any) {
+	task := x.(*TimeoutTask)
+	task.index = h.Len()
+	*h = append(*h, task)
+}
+
+func (h *TaskHeap) Pop() any {
+	old := *h
+	len := h.Len()
+	task := old[len-1]
+	old[len-1] = nil
+	*h = old[0: len - 1]
+	task.index = -1
+	return task
+}

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -6,17 +6,15 @@ import (
 	"time"
 )
 
-type ID string
-
 type TimeoutTask struct {
-	ID      ID
+	ID      string
 	Task    func()
 	Timeout time.Time
 
 	index int // for heap to work more efficiently
 }
 
-func NewTimeoutTask(ID ID, task func(), timeout time.Time) *TimeoutTask {
+func NewTimeoutTask(ID string, task func(), timeout time.Time) *TimeoutTask {
 	return &TimeoutTask{
 		ID:      ID,
 		Task:    task,
@@ -27,7 +25,7 @@ func NewTimeoutTask(ID ID, task func(), timeout time.Time) *TimeoutTask {
 type TimeoutHandler struct {
 	lock sync.Mutex
 
-	tasks map[ID]*TimeoutTask
+	tasks map[string]*TimeoutTask
 	heap  TaskHeap
 	now   time.Time
 }
@@ -35,7 +33,7 @@ type TimeoutHandler struct {
 func NewTimeoutHandler(startTime time.Time) *TimeoutHandler {
 	return &TimeoutHandler{
 		now:   startTime,
-		tasks: make(map[ID]*TimeoutTask),
+		tasks: make(map[string]*TimeoutTask),
 		heap:  TaskHeap{},
 	}
 }
@@ -63,7 +61,7 @@ func (t *TimeoutHandler) Tick(now time.Time) {
 
 		heap.Pop(&t.heap)
 		delete(t.tasks, next.ID)
-		go next.Task()
+		next.Task()
 	}
 }
 
@@ -81,7 +79,7 @@ func (t *TimeoutHandler) AddTask(task *TimeoutTask) {
 	heap.Push(&t.heap, task)
 }
 
-func (t *TimeoutHandler) RemoveTask(ID ID) {
+func (t *TimeoutHandler) RemoveTask(ID string) {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -6,8 +6,6 @@ package simplex
 import (
 	"container/heap"
 	"fmt"
-	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -186,25 +184,6 @@ const delimiter = "_"
 
 func getTimeoutID(start, end uint64) string {
 	return fmt.Sprintf("%d%s%d", start, delimiter, end)
-}
-
-func parseTimeoutID(id string) (uint64, uint64) {
-	parts := strings.Split(id, delimiter)
-	if len(parts) != 2 {
-		return 0, 0
-	}
-
-	start, err := strconv.ParseUint(parts[0], 10, 64)
-	if err != nil {
-		return 0, 0
-	}
-
-	end, err := strconv.ParseUint(parts[1], 10, 64)
-	if err != nil {
-		return 0, 0
-	}
-
-	return start, end
 }
 
 // ----------------------------------------------------------------------

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -47,7 +47,6 @@ func NewTimeoutHandler(log Logger, startTime time.Time, nodes []NodeID) *Timeout
 	t := &TimeoutHandler{
 		now:   startTime,
 		tasks: tasks,
-		heap:  TaskHeap{},
 		ticks: make(chan time.Time, 2),
 		close: make(chan struct{}),
 		log:   log,

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -40,6 +40,13 @@ func NewTimeoutHandler(startTime time.Time) *TimeoutHandler {
 	}
 }
 
+func (t *TimeoutHandler) GetTime() time.Time {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	return t.now
+}
+
 func (t *TimeoutHandler) Tick(now time.Time) {
 	t.lock.Lock()
 	defer t.lock.Unlock()

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -153,7 +153,7 @@ func (t *TimeoutHandler) RemoveTask(nodeID NodeID, ID string) {
 	// remove it from the heap using the index
 	t.log.Debug("Removing timeout task", zap.String("taskid", ID))
 	heap.Remove(&t.heap, t.tasks[string(nodeID)][ID].index)
-	delete(t.tasks, ID)
+	delete(t.tasks[string(nodeID)], ID)
 }
 
 func (t *TimeoutHandler) Close() {

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -12,18 +12,18 @@ import (
 )
 
 type TimeoutTask struct {
-	ID      string
-	Task    func()
-	Timeout time.Time
+	ID       string
+	Task     func()
+	Deadline time.Time
 
 	index int // for heap to work more efficiently
 }
 
 func NewTimeoutTask(ID string, task func(), timeout time.Time) *TimeoutTask {
 	return &TimeoutTask{
-		ID:      ID,
-		Task:    task,
-		Timeout: timeout,
+		ID:       ID,
+		Task:     task,
+		Deadline: timeout,
 	}
 }
 
@@ -68,7 +68,7 @@ func (t *TimeoutHandler) Tick(now time.Time) {
 		}
 
 		next := t.heap[0]
-		if next.Timeout.After(t.now) {
+		if next.Deadline.After(t.now) {
 			t.lock.Unlock()
 			break
 		}
@@ -117,7 +117,7 @@ type TaskHeap []*TimeoutTask
 func (h *TaskHeap) Len() int { return len(*h) }
 
 // Less returns if the task at index [i] has a lower timeout than the task at index [j]
-func (h *TaskHeap) Less(i, j int) bool { return (*h)[i].Timeout.Before((*h)[j].Timeout) }
+func (h *TaskHeap) Less(i, j int) bool { return (*h)[i].Deadline.Before((*h)[j].Deadline) }
 
 // Swap swaps the values at index [i] and [j]
 func (h *TaskHeap) Swap(i, j int) {

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -9,8 +9,8 @@ import (
 type ID string
 
 type TimeoutTask struct {
-	ID ID
-	Task func()
+	ID      ID
+	Task    func()
 	Timeout time.Time
 
 	index int // for heap to work more efficiently
@@ -18,8 +18,8 @@ type TimeoutTask struct {
 
 func NewTimeoutTask(ID ID, task func(), timeout time.Time) *TimeoutTask {
 	return &TimeoutTask{
-		ID: ID,
-		Task: task,
+		ID:      ID,
+		Task:    task,
 		Timeout: timeout,
 	}
 }
@@ -28,15 +28,15 @@ type TimeoutHandler struct {
 	lock sync.Mutex
 
 	tasks map[ID]*TimeoutTask
-	heap TaskHeap
-	now time.Time
+	heap  TaskHeap
+	now   time.Time
 }
 
 func NewTimeoutHandler(startTime time.Time) *TimeoutHandler {
 	return &TimeoutHandler{
-		now: startTime,
+		now:   startTime,
 		tasks: make(map[ID]*TimeoutTask),
-		heap: TaskHeap{},
+		heap:  TaskHeap{},
 	}
 }
 
@@ -91,13 +91,14 @@ func (t *TimeoutHandler) RemoveTask(ID ID) {
 // ----------------------------------------------------------------------
 type TaskHeap []*TimeoutTask
 
-func (h *TaskHeap) Len() int {return len(*h)}
+func (h *TaskHeap) Len() int { return len(*h) }
+
 // Less returns if the task at index [i] has a lower timeout than the task at index [j]
 func (h *TaskHeap) Less(i, j int) bool { return (*h)[i].Timeout.Before((*h)[j].Timeout) }
 
 // Swap swaps the values at index [i] and [j]
-func (h *TaskHeap) Swap(i, j int) { 
-	(*h)[i], (*h)[j] = (*h)[j], (*h)[i] 
+func (h *TaskHeap) Swap(i, j int) {
+	(*h)[i], (*h)[j] = (*h)[j], (*h)[i]
 	(*h)[i].index = i
 	(*h)[j].index = j
 }
@@ -113,7 +114,7 @@ func (h *TaskHeap) Pop() any {
 	len := h.Len()
 	task := old[len-1]
 	old[len-1] = nil
-	*h = old[0: len - 1]
+	*h = old[0 : len-1]
 	task.index = -1
 	return task
 }

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -217,11 +217,3 @@ func (h *TaskHeap) Pop() any {
 	task.index = -1
 	return task
 }
-
-func (h *TaskHeap) Peep() any {
-	if h.Len() == 0 {
-		return nil
-	}
-
-	return (*h)[0]
-}

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package simplex
 
 import (

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -124,17 +124,18 @@ func (t *TimeoutHandler) AddTask(task *TimeoutTask) {
 	defer t.lock.Unlock()
 
 	if _, ok := t.tasks[string(task.NodeID)]; !ok {
-		t.log.Info("Attempting to add a task for an unknown node", zap.Stringer("node", task.NodeID))
+		t.log.Debug("Attempting to add a task for an unknown node", zap.Stringer("from", task.NodeID))
+		return
 	}
 
 	// adds a task to the heap and the tasks map
 	if _, ok := t.tasks[string(task.NodeID)][task.TaskID]; ok {
-		t.log.Debug("Trying to add an already included task", zap.Stringer("node", task.NodeID), zap.String("Task ID", task.TaskID))
+		t.log.Debug("Trying to add an already included task", zap.Stringer("from", task.NodeID), zap.String("Task ID", task.TaskID))
 		return
 	}
 
 	t.tasks[string(task.NodeID)][task.TaskID] = task
-	t.log.Debug("Adding timeout task", zap.Stringer("node", task.NodeID), zap.String("taskid", task.TaskID))
+	t.log.Debug("Adding timeout task", zap.Stringer("from", task.NodeID), zap.String("taskid", task.TaskID))
 	heap.Push(&t.heap, task)
 }
 
@@ -143,7 +144,7 @@ func (t *TimeoutHandler) RemoveTask(nodeID NodeID, ID string) {
 	defer t.lock.Unlock()
 
 	if _, ok := t.tasks[string(nodeID)]; !ok {
-		t.log.Info("Attempting to add a remove a task for an unknown node", zap.Stringer("node", nodeID))
+		t.log.Debug("Attempting to remove a task for an unknown node", zap.Stringer("from", nodeID))
 		return
 	}
 
@@ -153,7 +154,7 @@ func (t *TimeoutHandler) RemoveTask(nodeID NodeID, ID string) {
 
 	// find the task using the task map
 	// remove it from the heap using the index
-	t.log.Debug("Removing timeout task", zap.String("taskid", ID))
+	t.log.Debug("Removing timeout task", zap.Stringer("from", nodeID), zap.String("taskid", ID))
 	heap.Remove(&t.heap, t.tasks[string(nodeID)][ID].index)
 	delete(t.tasks[string(nodeID)], ID)
 }

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -48,7 +48,7 @@ func NewTimeoutHandler(log Logger, startTime time.Time, nodes []NodeID) *Timeout
 		now:   startTime,
 		tasks: tasks,
 		heap:  TaskHeap{},
-		ticks: make(chan time.Time),
+		ticks: make(chan time.Time, 2),
 		close: make(chan struct{}),
 		log:   log,
 	}

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -39,7 +39,7 @@ func NewTimeoutHandler(log Logger, startTime time.Time) *TimeoutHandler {
 		now:   startTime,
 		tasks: make(map[string]*TimeoutTask),
 		heap:  TaskHeap{},
-		log: log,
+		log:   log,
 	}
 }
 

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -170,18 +170,15 @@ func (t *TimeoutHandler) Close() {
 // FindTask returns the first TimeoutTask assigned to [node] that contains any sequence in [seqs].
 // A sequence is considered "contained" if it falls between a task's Start (inclusive) and End (inclusive).
 func (t *TimeoutHandler) FindTask(node NodeID, seqs []uint64) *TimeoutTask {
-	var task *TimeoutTask
-seq:
 	for _, seq := range seqs {
 		for _, t := range t.tasks[string(node)] {
 			if seq >= t.Start && seq <= t.End {
-				task = t
-				break seq
+				return t
 			}
 		}
 	}
 
-	return task
+	return nil
 }
 
 const delimiter = "_"

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -165,6 +165,23 @@ func (t *TimeoutHandler) Close() {
 	}
 }
 
+// FindTask returns the first TimeoutTask assigned to [node] that contains any sequence in [seqs].
+// A sequence is considered "contained" if it falls between a task's Start (inclusive) and End (inclusive).
+func (t *TimeoutHandler) FindTask(node NodeID, seqs []uint64) *TimeoutTask {
+	var task *TimeoutTask
+seq:
+	for _, seq := range seqs {
+		for _, t := range t.tasks[string(node)] {
+			if seq >= t.Start && seq <= t.End {
+				task = t
+				break seq
+			}
+		}
+	}
+
+	return task
+}
+
 const delimiter = "_"
 
 func getTimeoutID(start, end uint64) string {

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -170,6 +170,9 @@ func (t *TimeoutHandler) Close() {
 // FindTask returns the first TimeoutTask assigned to [node] that contains any sequence in [seqs].
 // A sequence is considered "contained" if it falls between a task's Start (inclusive) and End (inclusive).
 func (t *TimeoutHandler) FindTask(node NodeID, seqs []uint64) *TimeoutTask {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
 	for _, seq := range seqs {
 		for _, t := range t.tasks[string(node)] {
 			if seq >= t.Start && seq <= t.End {

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -2,7 +2,6 @@ package simplex
 
 import (
 	"container/heap"
-	"sync"
 	"time"
 )
 
@@ -23,8 +22,6 @@ func NewTimeoutTask(ID string, task func(), timeout time.Time) *TimeoutTask {
 }
 
 type TimeoutHandler struct {
-	lock sync.Mutex
-
 	tasks map[string]*TimeoutTask
 	heap  TaskHeap
 	now   time.Time
@@ -39,16 +36,10 @@ func NewTimeoutHandler(startTime time.Time) *TimeoutHandler {
 }
 
 func (t *TimeoutHandler) GetTime() time.Time {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	return t.now
 }
 
 func (t *TimeoutHandler) Tick(now time.Time) {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	// update the time of the handler
 	t.now = now
 
@@ -67,9 +58,6 @@ func (t *TimeoutHandler) Tick(now time.Time) {
 
 func (t *TimeoutHandler) AddTask(task *TimeoutTask) {
 	// adds a task to the heap and the tasks map
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	if _, ok := t.tasks[task.ID]; ok {
 		// TODO: log warn instead of return
 		return
@@ -80,9 +68,6 @@ func (t *TimeoutHandler) AddTask(task *TimeoutTask) {
 }
 
 func (t *TimeoutHandler) RemoveTask(ID string) {
-	t.lock.Lock()
-	defer t.lock.Unlock()
-
 	if _, ok := t.tasks[ID]; !ok {
 		return
 	}

--- a/timeout_handler.go
+++ b/timeout_handler.go
@@ -47,7 +47,7 @@ func NewTimeoutHandler(log Logger, startTime time.Time, nodes []NodeID) *Timeout
 	t := &TimeoutHandler{
 		now:   startTime,
 		tasks: tasks,
-		ticks: make(chan time.Time, 2),
+		ticks: make(chan time.Time, 1),
 		close: make(chan struct{}),
 		log:   log,
 	}

--- a/timeout_handler_test.go
+++ b/timeout_handler_test.go
@@ -1,0 +1,174 @@
+package simplex_test
+
+import (
+	"simplex"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddAndRunTask(t *testing.T) {
+	start := time.Now()
+	handler := simplex.NewTimeoutHandler(start)
+	
+	sent := make(chan struct{}, 1)
+
+	task := simplex.NewTimeoutTask("task1", func() {
+		sent <- struct{}{}
+	}, start.Add(5 * time.Second))
+
+	handler.AddTask(task)
+	handler.Tick(start.Add(2 * time.Second))
+	require.Zero(t, len(sent))
+	handler.Tick(start.Add(6 * time.Second))
+	<-sent
+}
+
+func TestRemoveTask(t *testing.T) {
+	start := time.Now()
+	handler := simplex.NewTimeoutHandler(start)
+
+	var ran bool
+	task := &simplex.TimeoutTask{
+		ID:  "task2",
+		Timeout: start.Add(1 * time.Second),
+		Task: func() {
+			ran = true
+		},
+	}
+
+	handler.AddTask(task)
+	handler.RemoveTask("task2")
+	handler.Tick(start.Add(2 * time.Second))
+	require.False(t, ran)
+
+	// since we run tasks in different go routine
+	time.Sleep(10 * time.Millisecond)
+	require.False(t, ran)
+}
+
+func TestTaskOrder(t *testing.T) {
+	start := time.Now()
+	handler := simplex.NewTimeoutHandler(start)
+
+	var mu sync.Mutex
+	results := []string{}
+
+	handler.AddTask(&simplex.TimeoutTask{
+		ID:  "first",
+		Timeout: start.Add(1 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "first")
+			mu.Unlock()
+		},
+	})
+
+	handler.AddTask(&simplex.TimeoutTask{
+		ID:  "second",
+		Timeout: start.Add(2 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "second")
+			mu.Unlock()
+		},
+	})
+
+	handler.AddTask(&simplex.TimeoutTask{
+		ID:  "noruntask",
+		Timeout: start.Add(4 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "norun")
+			mu.Unlock()
+		},
+	})
+
+	handler.Tick(start.Add(3 * time.Second))
+	time.Sleep(20 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	require.Equal(t, 2, len(results))
+	// they may not be in the same order due to tasks running in ther own goroutine
+	require.Contains(t, results, "first")
+	require.Contains(t, results, "second")
+}
+
+func TestAddTasksOutOfOrder(t *testing.T) {
+	start := time.Now()
+	handler := simplex.NewTimeoutHandler(start)
+	
+	var mu sync.Mutex
+	results := []string{}
+
+	handler.AddTask(&simplex.TimeoutTask{
+		ID:  "third",
+		Timeout: start.Add(3 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "third")
+			mu.Unlock()
+		},
+	})
+
+	handler.AddTask(&simplex.TimeoutTask{
+		ID:  "second",
+		Timeout: start.Add(2 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "second")
+			mu.Unlock()
+		},
+	})
+
+
+	handler.AddTask(&simplex.TimeoutTask{
+		ID:  "fourth",
+		Timeout: start.Add(4 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "fourth")
+			mu.Unlock()
+		},
+	})
+
+	handler.AddTask(&simplex.TimeoutTask{
+		ID:  "first",
+		Timeout: start.Add(1 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "first")
+			mu.Unlock()
+		},
+	})
+
+	handler.Tick(start.Add(1 * time.Second))
+	time.Sleep(10 * time.Millisecond)
+
+	mu.Lock()	
+	require.Equal(t, 1, len(results))
+	require.Contains(t, results, "first")
+	mu.Unlock()
+
+	handler.Tick(start.Add(3 * time.Second))
+	time.Sleep(10 * time.Millisecond)
+
+	mu.Lock()
+	require.Equal(t, 3, len(results))
+	require.Contains(t, results, "second")
+	require.Contains(t, results, "third")
+	mu.Unlock()
+
+
+	handler.Tick(start.Add(4 * time.Second))
+	time.Sleep(10 * time.Millisecond)
+
+	mu.Lock()
+	require.Equal(t, 4, len(results))
+	require.Contains(t, results, "fourth")
+	mu.Unlock()
+}

--- a/timeout_handler_test.go
+++ b/timeout_handler_test.go
@@ -12,12 +12,12 @@ import (
 func TestAddAndRunTask(t *testing.T) {
 	start := time.Now()
 	handler := simplex.NewTimeoutHandler(start)
-	
+
 	sent := make(chan struct{}, 1)
 
 	task := simplex.NewTimeoutTask("task1", func() {
 		sent <- struct{}{}
-	}, start.Add(5 * time.Second))
+	}, start.Add(5*time.Second))
 
 	handler.AddTask(task)
 	handler.Tick(start.Add(2 * time.Second))
@@ -32,7 +32,7 @@ func TestRemoveTask(t *testing.T) {
 
 	var ran bool
 	task := &simplex.TimeoutTask{
-		ID:  "task2",
+		ID:      "task2",
 		Timeout: start.Add(1 * time.Second),
 		Task: func() {
 			ran = true
@@ -57,7 +57,7 @@ func TestTaskOrder(t *testing.T) {
 	results := []string{}
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:  "first",
+		ID:      "first",
 		Timeout: start.Add(1 * time.Second),
 		Task: func() {
 			mu.Lock()
@@ -67,7 +67,7 @@ func TestTaskOrder(t *testing.T) {
 	})
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:  "second",
+		ID:      "second",
 		Timeout: start.Add(2 * time.Second),
 		Task: func() {
 			mu.Lock()
@@ -77,7 +77,7 @@ func TestTaskOrder(t *testing.T) {
 	})
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:  "noruntask",
+		ID:      "noruntask",
 		Timeout: start.Add(4 * time.Second),
 		Task: func() {
 			mu.Lock()
@@ -101,12 +101,12 @@ func TestTaskOrder(t *testing.T) {
 func TestAddTasksOutOfOrder(t *testing.T) {
 	start := time.Now()
 	handler := simplex.NewTimeoutHandler(start)
-	
+
 	var mu sync.Mutex
 	results := []string{}
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:  "third",
+		ID:      "third",
 		Timeout: start.Add(3 * time.Second),
 		Task: func() {
 			mu.Lock()
@@ -116,7 +116,7 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	})
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:  "second",
+		ID:      "second",
 		Timeout: start.Add(2 * time.Second),
 		Task: func() {
 			mu.Lock()
@@ -125,9 +125,8 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 		},
 	})
 
-
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:  "fourth",
+		ID:      "fourth",
 		Timeout: start.Add(4 * time.Second),
 		Task: func() {
 			mu.Lock()
@@ -137,7 +136,7 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	})
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:  "first",
+		ID:      "first",
 		Timeout: start.Add(1 * time.Second),
 		Task: func() {
 			mu.Lock()
@@ -149,7 +148,7 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	handler.Tick(start.Add(1 * time.Second))
 	time.Sleep(10 * time.Millisecond)
 
-	mu.Lock()	
+	mu.Lock()
 	require.Equal(t, 1, len(results))
 	require.Contains(t, results, "first")
 	mu.Unlock()
@@ -162,7 +161,6 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	require.Contains(t, results, "second")
 	require.Contains(t, results, "third")
 	mu.Unlock()
-
 
 	handler.Tick(start.Add(4 * time.Second))
 	time.Sleep(10 * time.Millisecond)

--- a/timeout_handler_test.go
+++ b/timeout_handler_test.go
@@ -122,8 +122,8 @@ func TestTaskOrder(t *testing.T) {
 	defer mu.Unlock()
 
 	require.Equal(t, 2, len(results))
-	require.Contains(t, results, "first")
-	require.Contains(t, results, "second")
+	require.Equal(t, results[0], "first")
+	require.Equal(t, results[1], "second")
 }
 
 func TestAddTasksOutOfOrder(t *testing.T) {
@@ -189,7 +189,7 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	<-finished
 	mu.Lock()
 	require.Equal(t, 1, len(results))
-	require.Contains(t, results, "first")
+	require.Equal(t, results[0], "first")
 	mu.Unlock()
 
 	handler.Tick(start.Add(3 * time.Second))
@@ -197,15 +197,15 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	<-finished
 	mu.Lock()
 	require.Equal(t, 3, len(results))
-	require.Contains(t, results, "second")
-	require.Contains(t, results, "third")
+	require.Equal(t, results[1], "second")
+	require.Equal(t, results[2], "third")
 	mu.Unlock()
 
 	handler.Tick(start.Add(4 * time.Second))
 	<-finished
 	mu.Lock()
 	require.Equal(t, 4, len(results))
-	require.Contains(t, results, "fourth")
+	require.Equal(t, results[3], "fourth")
 	mu.Unlock()
 }
 

--- a/timeout_handler_test.go
+++ b/timeout_handler_test.go
@@ -38,8 +38,8 @@ func TestRemoveTask(t *testing.T) {
 
 	var ran bool
 	task := &simplex.TimeoutTask{
-		ID:      "task2",
-		Timeout: start.Add(1 * time.Second),
+		ID:       "task2",
+		Deadline: start.Add(1 * time.Second),
 		Task: func() {
 			ran = true
 		},
@@ -60,8 +60,8 @@ func TestTaskOrder(t *testing.T) {
 	results := []string{}
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:      "first",
-		Timeout: start.Add(1 * time.Second),
+		ID:       "first",
+		Deadline: start.Add(1 * time.Second),
 		Task: func() {
 			mu.Lock()
 			results = append(results, "first")
@@ -70,8 +70,8 @@ func TestTaskOrder(t *testing.T) {
 	})
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:      "second",
-		Timeout: start.Add(2 * time.Second),
+		ID:       "second",
+		Deadline: start.Add(2 * time.Second),
 		Task: func() {
 			mu.Lock()
 			results = append(results, "second")
@@ -80,8 +80,8 @@ func TestTaskOrder(t *testing.T) {
 	})
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:      "noruntask",
-		Timeout: start.Add(4 * time.Second),
+		ID:       "noruntask",
+		Deadline: start.Add(4 * time.Second),
 		Task: func() {
 			mu.Lock()
 			results = append(results, "norun")
@@ -108,8 +108,8 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	results := []string{}
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:      "third",
-		Timeout: start.Add(3 * time.Second),
+		ID:       "third",
+		Deadline: start.Add(3 * time.Second),
 		Task: func() {
 			mu.Lock()
 			results = append(results, "third")
@@ -118,8 +118,8 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	})
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:      "second",
-		Timeout: start.Add(2 * time.Second),
+		ID:       "second",
+		Deadline: start.Add(2 * time.Second),
 		Task: func() {
 			mu.Lock()
 			results = append(results, "second")
@@ -128,8 +128,8 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	})
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:      "fourth",
-		Timeout: start.Add(4 * time.Second),
+		ID:       "fourth",
+		Deadline: start.Add(4 * time.Second),
 		Task: func() {
 			mu.Lock()
 			results = append(results, "fourth")
@@ -138,8 +138,8 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	})
 
 	handler.AddTask(&simplex.TimeoutTask{
-		ID:      "first",
-		Timeout: start.Add(1 * time.Second),
+		ID:       "first",
+		Deadline: start.Add(1 * time.Second),
 		Task: func() {
 			mu.Lock()
 			results = append(results, "first")

--- a/timeout_handler_test.go
+++ b/timeout_handler_test.go
@@ -21,6 +21,7 @@ func TestAddAndRunTask(t *testing.T) {
 	defer handler.Close()
 
 	sent := make(chan struct{}, 1)
+	count := 0
 
 	task := &simplex.TimeoutTask{
 		NodeID:   nodes[0],
@@ -28,6 +29,7 @@ func TestAddAndRunTask(t *testing.T) {
 		Deadline: start.Add(5 * time.Second),
 		Task: func() {
 			sent <- struct{}{}
+			count += 1
 		},
 	}
 
@@ -38,6 +40,12 @@ func TestAddAndRunTask(t *testing.T) {
 	require.Zero(t, len(sent))
 	handler.Tick(start.Add(6 * time.Second))
 	<-sent
+	require.Equal(t, 1, count)
+
+	// test we only execute task once
+	handler.Tick(start.Add(12 * time.Second))
+	time.Sleep(10 * time.Millisecond)
+	require.Equal(t, 1, count)
 }
 
 func TestRemoveTask(t *testing.T) {

--- a/timeout_handler_test.go
+++ b/timeout_handler_test.go
@@ -2,6 +2,7 @@ package simplex_test
 
 import (
 	"simplex"
+	"simplex/testutil"
 	"sync"
 	"testing"
 	"time"
@@ -11,7 +12,8 @@ import (
 
 func TestAddAndRunTask(t *testing.T) {
 	start := time.Now()
-	handler := simplex.NewTimeoutHandler(start)
+	l := testutil.MakeLogger(t, 1)
+	handler := simplex.NewTimeoutHandler(l, start)
 
 	sent := make(chan struct{}, 1)
 
@@ -28,7 +30,8 @@ func TestAddAndRunTask(t *testing.T) {
 
 func TestRemoveTask(t *testing.T) {
 	start := time.Now()
-	handler := simplex.NewTimeoutHandler(start)
+	l := testutil.MakeLogger(t, 1)
+	handler := simplex.NewTimeoutHandler(l, start)
 
 	var ran bool
 	task := &simplex.TimeoutTask{
@@ -47,7 +50,8 @@ func TestRemoveTask(t *testing.T) {
 
 func TestTaskOrder(t *testing.T) {
 	start := time.Now()
-	handler := simplex.NewTimeoutHandler(start)
+	l := testutil.MakeLogger(t, 1)
+	handler := simplex.NewTimeoutHandler(l, start)
 
 	var mu sync.Mutex
 	results := []string{}
@@ -94,7 +98,8 @@ func TestTaskOrder(t *testing.T) {
 
 func TestAddTasksOutOfOrder(t *testing.T) {
 	start := time.Now()
-	handler := simplex.NewTimeoutHandler(start)
+	l := testutil.MakeLogger(t, 1)
+	handler := simplex.NewTimeoutHandler(l, start)
 
 	var mu sync.Mutex
 	results := []string{}

--- a/timeout_handler_test.go
+++ b/timeout_handler_test.go
@@ -43,10 +43,6 @@ func TestRemoveTask(t *testing.T) {
 	handler.RemoveTask("task2")
 	handler.Tick(start.Add(2 * time.Second))
 	require.False(t, ran)
-
-	// since we run tasks in different go routine
-	time.Sleep(10 * time.Millisecond)
-	require.False(t, ran)
 }
 
 func TestTaskOrder(t *testing.T) {
@@ -87,13 +83,11 @@ func TestTaskOrder(t *testing.T) {
 	})
 
 	handler.Tick(start.Add(3 * time.Second))
-	time.Sleep(20 * time.Millisecond)
 
 	mu.Lock()
 	defer mu.Unlock()
 
 	require.Equal(t, 2, len(results))
-	// they may not be in the same order due to tasks running in ther own goroutine
 	require.Contains(t, results, "first")
 	require.Contains(t, results, "second")
 }
@@ -146,7 +140,6 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	})
 
 	handler.Tick(start.Add(1 * time.Second))
-	time.Sleep(10 * time.Millisecond)
 
 	mu.Lock()
 	require.Equal(t, 1, len(results))
@@ -154,7 +147,6 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	mu.Unlock()
 
 	handler.Tick(start.Add(3 * time.Second))
-	time.Sleep(10 * time.Millisecond)
 
 	mu.Lock()
 	require.Equal(t, 3, len(results))
@@ -163,8 +155,6 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 	mu.Unlock()
 
 	handler.Tick(start.Add(4 * time.Second))
-	time.Sleep(10 * time.Millisecond)
-
 	mu.Lock()
 	require.Equal(t, 4, len(results))
 	require.Contains(t, results, "fourth")

--- a/timeout_handler_test.go
+++ b/timeout_handler_test.go
@@ -72,7 +72,7 @@ func TestTaskOrder(t *testing.T) {
 	finished := make(chan struct{})
 
 	var mu sync.Mutex
-	results := []string{}
+	var results []string
 
 	handler.AddTask(&simplex.TimeoutTask{
 		NodeID:   nodes[0],
@@ -130,7 +130,7 @@ func TestAddTasksOutOfOrder(t *testing.T) {
 		handler := simplex.NewTimeoutHandler(l, start, nodes)
 		finished := make(chan struct{})
 		var mu sync.Mutex
-		results := []string{}
+		var results []string
 
 		handler.AddTask(&simplex.TimeoutTask{
 			NodeID:   nodes[0],

--- a/timeout_handler_test.go
+++ b/timeout_handler_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package simplex_test
 
 import (

--- a/timeout_handler_test.go
+++ b/timeout_handler_test.go
@@ -18,6 +18,7 @@ func TestAddAndRunTask(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
 	nodes := []simplex.NodeID{{1}, {2}}
 	handler := simplex.NewTimeoutHandler(l, start, nodes)
+	defer handler.Close()
 
 	sent := make(chan struct{}, 1)
 
@@ -44,6 +45,7 @@ func TestRemoveTask(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
 	nodes := []simplex.NodeID{{1}, {2}}
 	handler := simplex.NewTimeoutHandler(l, start, nodes)
+	defer handler.Close()
 
 	var ran bool
 	task := &simplex.TimeoutTask{
@@ -69,6 +71,8 @@ func TestTaskOrder(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
 	nodes := []simplex.NodeID{{1}, {2}}
 	handler := simplex.NewTimeoutHandler(l, start, nodes)
+	defer handler.Close()
+
 	finished := make(chan struct{})
 
 	var mu sync.Mutex
@@ -123,86 +127,86 @@ func TestTaskOrder(t *testing.T) {
 }
 
 func TestAddTasksOutOfOrder(t *testing.T) {
-	for range 100 {
-		start := time.Now()
-		l := testutil.MakeLogger(t, 1)
-		nodes := []simplex.NodeID{{1}, {2}}
-		handler := simplex.NewTimeoutHandler(l, start, nodes)
-		finished := make(chan struct{})
-		var mu sync.Mutex
-		var results []string
+	start := time.Now()
+	l := testutil.MakeLogger(t, 1)
+	nodes := []simplex.NodeID{{1}, {2}}
+	handler := simplex.NewTimeoutHandler(l, start, nodes)
+	defer handler.Close()
 
-		handler.AddTask(&simplex.TimeoutTask{
-			NodeID:   nodes[0],
-			TaskID:   "third",
-			Deadline: start.Add(3 * time.Second),
-			Task: func() {
-				mu.Lock()
-				results = append(results, "third")
-				finished <- struct{}{}
-				mu.Unlock()
-			},
-		})
+	finished := make(chan struct{})
+	var mu sync.Mutex
+	var results []string
 
-		handler.AddTask(&simplex.TimeoutTask{
-			NodeID:   nodes[0],
-			TaskID:   "second",
-			Deadline: start.Add(2 * time.Second),
-			Task: func() {
-				mu.Lock()
-				results = append(results, "second")
-				finished <- struct{}{}
-				mu.Unlock()
-			},
-		})
+	handler.AddTask(&simplex.TimeoutTask{
+		NodeID:   nodes[0],
+		TaskID:   "third",
+		Deadline: start.Add(3 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "third")
+			finished <- struct{}{}
+			mu.Unlock()
+		},
+	})
 
-		handler.AddTask(&simplex.TimeoutTask{
-			NodeID:   nodes[1],
-			TaskID:   "fourth",
-			Deadline: start.Add(4 * time.Second),
-			Task: func() {
-				mu.Lock()
-				results = append(results, "fourth")
-				finished <- struct{}{}
-				mu.Unlock()
-			},
-		})
+	handler.AddTask(&simplex.TimeoutTask{
+		NodeID:   nodes[0],
+		TaskID:   "second",
+		Deadline: start.Add(2 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "second")
+			finished <- struct{}{}
+			mu.Unlock()
+		},
+	})
 
-		handler.AddTask(&simplex.TimeoutTask{
-			NodeID:   nodes[0],
-			TaskID:   "first",
-			Deadline: start.Add(1 * time.Second),
-			Task: func() {
-				mu.Lock()
-				results = append(results, "first")
-				finished <- struct{}{}
-				mu.Unlock()
-			},
-		})
+	handler.AddTask(&simplex.TimeoutTask{
+		NodeID:   nodes[1],
+		TaskID:   "fourth",
+		Deadline: start.Add(4 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "fourth")
+			finished <- struct{}{}
+			mu.Unlock()
+		},
+	})
 
-		handler.Tick(start.Add(1 * time.Second))
-		<-finished
-		mu.Lock()
-		require.Equal(t, 1, len(results))
-		require.Contains(t, results, "first")
-		mu.Unlock()
+	handler.AddTask(&simplex.TimeoutTask{
+		NodeID:   nodes[0],
+		TaskID:   "first",
+		Deadline: start.Add(1 * time.Second),
+		Task: func() {
+			mu.Lock()
+			results = append(results, "first")
+			finished <- struct{}{}
+			mu.Unlock()
+		},
+	})
 
-		handler.Tick(start.Add(3 * time.Second))
-		<-finished
-		<-finished
-		mu.Lock()
-		require.Equal(t, 3, len(results))
-		require.Contains(t, results, "second")
-		require.Contains(t, results, "third")
-		mu.Unlock()
+	handler.Tick(start.Add(1 * time.Second))
+	<-finished
+	mu.Lock()
+	require.Equal(t, 1, len(results))
+	require.Contains(t, results, "first")
+	mu.Unlock()
 
-		handler.Tick(start.Add(4 * time.Second))
-		<-finished
-		mu.Lock()
-		require.Equal(t, 4, len(results))
-		require.Contains(t, results, "fourth")
-		mu.Unlock()
-	}
+	handler.Tick(start.Add(3 * time.Second))
+	<-finished
+	<-finished
+	mu.Lock()
+	require.Equal(t, 3, len(results))
+	require.Contains(t, results, "second")
+	require.Contains(t, results, "third")
+	mu.Unlock()
+
+	handler.Tick(start.Add(4 * time.Second))
+	<-finished
+	mu.Lock()
+	require.Equal(t, 4, len(results))
+	require.Contains(t, results, "fourth")
+	mu.Unlock()
 }
 
 func TestFindTask(t *testing.T) {
@@ -212,6 +216,7 @@ func TestFindTask(t *testing.T) {
 	startTime := time.Now()
 
 	handler := simplex.NewTimeoutHandler(l, startTime, nodes)
+	defer handler.Close()
 
 	// Create some test tasks
 	task1 := &simplex.TimeoutTask{

--- a/util.go
+++ b/util.go
@@ -193,3 +193,40 @@ func (block *oneTimeVerifiedBlock) Verify(ctx context.Context) (VerifiedBlock, e
 
 	return vb, err
 }
+
+type Segment struct {
+	Start uint64
+	End   uint64
+}
+
+// compressSequences takes a sorted slice of uint64 values representing
+// missing sequence numbers and compresses consecutive numbers into segments.
+// Each segment represents a continuous block of missing sequence numbers.
+func CompressSequences(missingSeqs []uint64) []Segment {
+	var segments []Segment
+
+	if len(missingSeqs) == 0 {
+		return segments
+	}
+
+	startSeq := missingSeqs[0]
+	endSeq := missingSeqs[0]
+
+	for i, currentSeq := range missingSeqs[1:] {
+		if currentSeq != missingSeqs[i]+1 {
+			segments = append(segments, Segment{
+				Start: startSeq,
+				End:   endSeq,
+			})
+			startSeq = currentSeq
+		}
+		endSeq = currentSeq
+	}
+
+	segments = append(segments, Segment{
+		Start: startSeq,
+		End:   endSeq,
+	})
+
+	return segments
+}

--- a/util_test.go
+++ b/util_test.go
@@ -255,3 +255,57 @@ func TestGetHighestQuorumRound(t *testing.T) {
 		})
 	}
 }
+
+func TestCompressSequences(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []uint64
+		expected []Segment
+	}{
+		{
+			name:     "empty input",
+			input:    []uint64{},
+			expected: nil,
+		},
+		{
+			name:  "single element",
+			input: []uint64{5},
+			expected: []Segment{
+				{Start: 5, End: 5},
+			},
+		},
+		{
+			name:  "all consecutive",
+			input: []uint64{1, 2, 3, 4, 5},
+			expected: []Segment{
+				{Start: 1, End: 5},
+			},
+		},
+		{
+			name:  "no consecutive elements",
+			input: []uint64{2, 4, 6, 8},
+			expected: []Segment{
+				{Start: 2, End: 2},
+				{Start: 4, End: 4},
+				{Start: 6, End: 6},
+				{Start: 8, End: 8},
+			},
+		},
+		{
+			name:  "mixed consecutive and non-consecutive",
+			input: []uint64{3, 4, 5, 7, 8, 10},
+			expected: []Segment{
+				{Start: 3, End: 5},
+				{Start: 7, End: 8},
+				{Start: 10, End: 10},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CompressSequences(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a `TimeoutHandler`, that tracks outgoing replication requests and resends them once a timeout has occurred. 

The logic for handling incomplete requests is as follows

- we send out replication requests, and not the timeouts in `TimeoutHandler`
- when we receive a `ReplicationResponse` we check if the response data contains all the expected sequences
  - if so, we can return early and remove the timeout task
  - if not, we create new requests by figuring out the missing sequences and distributing them across nodes

This approach is nice because it keeps the logic fairly simple. However, because we only remove `1 TimeoutTask` every time we receive a response, it's possible we could send duplicate replication requests over the network. For example say we have 2 TimeoutTasks from a node one expects seqs 5-10 and another with 11-15. If we receive seqs `5-13` from the node, we will only remove the timeout with `5-10` from the tasks maps, and resend a request for 11-15 after a timeout. To keep the logic simpler, I chose to not worry about this case since it's highly unlikely that a node would have two separate timeouts for consecutive sequences. 


- [x] Create TimeoutHandler Struct
- [x] Make tests for TimeoutHandler
- [x] Integrate TimeoutHandler into ReplicationState
- [x] Make tests for replication when nodes timeout
- [x] Ensure incomplete responses don't get forgotten