### PR TITLE
Add Block Verification During Wal Recovery

### DIFF
--- a/api.go
+++ b/api.go
@@ -99,7 +99,7 @@ type VerifiedBlock interface {
 type BlockDeserializer interface {
 	// DeserializeBlock parses the given bytes and initializes a VerifiedBlock.
 	// Returns an error upon failure.
-	DeserializeBlock(bytes []byte) (VerifiedBlock, error)
+	DeserializeBlock(bytes []byte) (Block, error)
 }
 
 // Signature encodes a signature and the node that signed it, without the message it was signed on.

--- a/encoding.go
+++ b/encoding.go
@@ -125,7 +125,7 @@ func BlockRecord(bh BlockHeader, blockData []byte) []byte {
 	return buff
 }
 
-func BlockFromRecord(blockDeserializer BlockDeserializer, record []byte) (VerifiedBlock, error) {
+func BlockFromRecord(blockDeserializer BlockDeserializer, record []byte) (Block, error) {
 	_, payload, err := ParseBlockRecord(record)
 	if err != nil {
 		return nil, err

--- a/epoch.go
+++ b/epoch.go
@@ -227,6 +227,7 @@ func (e *Epoch) restoreBlockRecord(r []byte) error {
 	}
 
 	// we have not indexed this block so we need to verify before restoring
+	e.Logger.Debug("Verifying block from WAL", zap.Uint64("Round", block.BlockHeader().Round))
 	verifiedBlock, err := block.Verify(e.finishCtx)
 	if err != nil {
 		return fmt.Errorf("failed to verify block: %w", err)

--- a/epoch.go
+++ b/epoch.go
@@ -211,12 +211,28 @@ func (e *Epoch) Start() error {
 	return e.restoreFromWal()
 }
 
+func (e *Epoch) sequenceAlreadyIndexed(seq uint64) bool {
+	return seq < e.Storage.Height()
+}
+
 func (e *Epoch) restoreBlockRecord(r []byte) error {
 	block, err := BlockFromRecord(e.BlockDeserializer, r)
 	if err != nil {
 		return err
 	}
-	e.rounds[block.BlockHeader().Round] = NewRound(block)
+
+	if e.sequenceAlreadyIndexed(block.BlockHeader().Seq) {
+		e.Logger.Debug("Block already indexed, skipping restoration", zap.Uint64("Sequence", block.BlockHeader().Seq))
+		return nil
+	}
+
+	// we have not indexed this block so we need to verify before restoring
+	verifiedBlock, err := block.Verify(e.finishCtx)
+	if err != nil {
+		return fmt.Errorf("failed to verify block: %w", err)
+	}
+
+	e.rounds[block.BlockHeader().Round] = NewRound(verifiedBlock)
 	e.Logger.Info("Block Proposal Recovered From WAL", zap.Uint64("Round", block.BlockHeader().Round))
 	return nil
 }
@@ -226,6 +242,12 @@ func (e *Epoch) restoreNotarizationRecord(r []byte) error {
 	if err != nil {
 		return err
 	}
+
+	if e.sequenceAlreadyIndexed(notarization.Vote.Seq) {
+		e.Logger.Debug("Notarization already indexed, skipping restoration", zap.Uint64("Sequence", notarization.Vote.Seq))
+		return nil
+	}
+
 	round, exists := e.rounds[notarization.Vote.Round]
 	if !exists {
 		return fmt.Errorf("could not find round %d, its proposal was probably not persisted earlier", notarization.Vote.Round)
@@ -278,6 +300,12 @@ func (e *Epoch) restoreFinalizationRecord(r []byte) error {
 	if err != nil {
 		return err
 	}
+
+	if e.sequenceAlreadyIndexed(finalization.Finalization.Seq) {
+		e.Logger.Debug("Finalization already indexed, skipping restoration", zap.Uint64("Sequence", finalization.Finalization.Seq))
+		return nil
+	}
+
 	round, ok := e.rounds[finalization.Finalization.Round]
 	if !ok {
 		return fmt.Errorf("round not found for finalization")
@@ -308,14 +336,26 @@ func (e *Epoch) resumeFromWal(records [][]byte) error {
 		if err != nil {
 			return err
 		}
+
+		if e.sequenceAlreadyIndexed(block.BlockHeader().Seq) {
+			e.Logger.Debug("Block already indexed, skipping restoration", zap.Uint64("Sequence", block.BlockHeader().Seq))
+			return nil
+		}
+
+		round, exists := e.rounds[block.BlockHeader().Round]
+		if !exists {
+			// this should not happen, as we restored the block in `restoreBlockRecord`
+			return fmt.Errorf("could not find round %d for block", block.BlockHeader().Round)
+		}
+
 		if e.ID.Equals(LeaderForRound(e.nodes, block.BlockHeader().Round)) {
-			vote, err := e.voteOnBlock(block)
+			vote, err := e.voteOnBlock(round.block)
 			if err != nil {
 				return err
 			}
 			proposal := &Message{
 				VerifiedBlockMessage: &VerifiedBlockMessage{
-					VerifiedBlock: block,
+					VerifiedBlock: round.block,
 					Vote:          vote,
 				},
 			}
@@ -332,6 +372,12 @@ func (e *Epoch) resumeFromWal(records [][]byte) error {
 		}
 		lastMessage := Message{Notarization: &notarization}
 		e.Comm.Broadcast(&lastMessage)
+
+		if e.sequenceAlreadyIndexed(notarization.Vote.Seq) {
+			e.Logger.Debug("Notarization already indexed, skipping restoration", zap.Uint64("Sequence", notarization.Vote.Seq))
+			return nil
+		}
+
 		return e.doNotarized(notarization.Vote.Round)
 	case record.EmptyVoteRecordType:
 		ev, err := ParseEmptyVoteRecord(lastRecord)

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -708,7 +708,7 @@ func TestRecoveryReVerifiesBlocks(t *testing.T) {
 	}
 
 	deserializer := &blockDeserializer{
-		delayedVerification: make(chan struct{}),
+		delayedVerification: make(chan struct{}, 1),
 	}
 	wal := wal.NewMemWAL(t)
 	conf := EpochConfig{
@@ -735,11 +735,7 @@ func TestRecoveryReVerifiesBlocks(t *testing.T) {
 	record := BlockRecord(firstBlock.BlockHeader(), firstBlock.Bytes())
 	wal.Append(record)
 
-	var epochError error
-	go func() {
-		epochError = e.Start()
-	}()
-
-	deserializer.delayedVerification <- struct{}{} // unblock the expected verification
-	require.NoError(t, epochError)
+	deserializer.delayedVerification <- struct{}{}
+	require.NoError(t, e.Start())
+	require.Len(t, deserializer.delayedVerification, 0)
 }

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -589,6 +589,9 @@ func TestRecoveryBlocksIndexed(t *testing.T) {
 	require.NoError(t, err)
 	wal.Append(firstNotarizationRecord)
 
+	_, finalizationBytes := newFinalizationRecord(t, l, sigAggregrator, firstBlock, nodes[0:quorum])
+    wal.Append(finalizationBytes)
+
 	protocolMetadata.Round = 1
 	protocolMetadata.Seq = 1
 	secondBlock, ok := bb.BuildBlock(ctx, protocolMetadata)

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -590,7 +590,7 @@ func TestRecoveryBlocksIndexed(t *testing.T) {
 	wal.Append(firstNotarizationRecord)
 
 	_, finalizationBytes := newFinalizationRecord(t, l, sigAggregrator, firstBlock, nodes[0:quorum])
-    wal.Append(finalizationBytes)
+	wal.Append(finalizationBytes)
 
 	protocolMetadata.Round = 1
 	protocolMetadata.Seq = 1

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -553,9 +553,9 @@ func TestRecoverFromMultipleNotarizations(t *testing.T) {
 	require.Equal(t, finalization2, storage.data[1].Finalization)
 }
 
-// TestRecoversFromMultipleNotarizations tests that the epoch can recover from a wal
-// with its last notarization record being from a less recent round.
-func TestRecoveryWithoutNotarization(t *testing.T) {
+// TestRecoveryBlocksIndexed tests that the epoch properly skips
+// block records that are already indexed in the storage.
+func TestRecoveryBlocksIndexed(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	wal := wal.NewMemWAL(t)
@@ -691,4 +691,52 @@ func TestRecoveryAsLeader(t *testing.T) {
 	// ensure the round is properly set
 	require.Equal(t, uint64(4), e.Metadata().Round)
 	require.Equal(t, uint64(4), e.Metadata().Seq)
+}
+
+func TestRecoveryReVerifiesBlocks(t *testing.T) {
+	l := testutil.MakeLogger(t, 1)
+	ctx := context.Background()
+	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+	finalizedBlocks := createBlocks(t, nodes, bb, 4)
+	storage := newInMemStorage()
+	for _, finalizedBlock := range finalizedBlocks {
+		storage.Index(finalizedBlock.VerifiedBlock, finalizedBlock.Finalization)
+	}
+
+	deserializer := &blockDeserializer{
+		delayedVerification: make(chan struct{}),
+	}
+	wal := wal.NewMemWAL(t)
+	conf := EpochConfig{
+		MaxProposalWait:   DefaultMaxProposalWaitTime,
+		Logger:            l,
+		ID:                nodes[0],
+		Signer:            &testSigner{},
+		WAL:               wal,
+		Verifier:          &testVerifier{},
+		Storage:           storage,
+		Comm:              noopComm(nodes),
+		BlockBuilder:      bb,
+		BlockDeserializer: deserializer,
+		QCDeserializer:    &testQCDeserializer{t: t},
+	}
+
+	// Create first block and write to WAL
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+
+	protocolMetadata := e.Metadata()
+	firstBlock, ok := bb.BuildBlock(ctx, protocolMetadata)
+	require.True(t, ok)
+	record := BlockRecord(firstBlock.BlockHeader(), firstBlock.Bytes())
+	wal.Append(record)
+
+	var epochError error
+	go func() {
+		epochError = e.Start()
+	}()
+
+	deserializer.delayedVerification <- struct{}{} // unblock the expected verification
+	require.NoError(t, epochError)
 }


### PR DESCRIPTION
When a node crashes we should reverify the block on recovery, as verified blocks are stored in memory and should never be re-created from bytes. 