### PR TITLE
Add Context to Deserializer API

### DIFF
--- a/api.go
+++ b/api.go
@@ -99,7 +99,7 @@ type VerifiedBlock interface {
 type BlockDeserializer interface {
 	// DeserializeBlock parses the given bytes and initializes a VerifiedBlock.
 	// Returns an error upon failure.
-	DeserializeBlock(bytes []byte) (Block, error)
+	DeserializeBlock(ctx context.Context, bytes []byte) (Block, error)
 }
 
 // Signature encodes a signature and the node that signed it, without the message it was signed on.

--- a/encoding.go
+++ b/encoding.go
@@ -4,6 +4,7 @@
 package simplex
 
 import (
+	"context"
 	"encoding/asn1"
 	"encoding/binary"
 	"errors"
@@ -125,13 +126,13 @@ func BlockRecord(bh BlockHeader, blockData []byte) []byte {
 	return buff
 }
 
-func BlockFromRecord(blockDeserializer BlockDeserializer, record []byte) (Block, error) {
+func BlockFromRecord(ctx context.Context, blockDeserializer BlockDeserializer, record []byte) (Block, error) {
 	_, payload, err := ParseBlockRecord(record)
 	if err != nil {
 		return nil, err
 	}
 
-	return blockDeserializer.DeserializeBlock(payload)
+	return blockDeserializer.DeserializeBlock(ctx, payload)
 }
 
 func ParseBlockRecord(buff []byte) (BlockHeader, []byte, error) {

--- a/epoch.go
+++ b/epoch.go
@@ -216,7 +216,7 @@ func (e *Epoch) sequenceAlreadyIndexed(seq uint64) bool {
 }
 
 func (e *Epoch) restoreBlockRecord(r []byte) error {
-	block, err := BlockFromRecord(e.BlockDeserializer, r)
+	block, err := BlockFromRecord(e.finishCtx, e.BlockDeserializer, r)
 	if err != nil {
 		return err
 	}
@@ -333,7 +333,7 @@ func (e *Epoch) resumeFromWal(records [][]byte) error {
 
 	switch recordType {
 	case record.BlockRecordType:
-		block, err := BlockFromRecord(e.BlockDeserializer, lastRecord)
+		block, err := BlockFromRecord(e.finishCtx, e.BlockDeserializer, lastRecord)
 		if err != nil {
 			return err
 		}

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -1514,7 +1514,7 @@ type blockDeserializer struct {
 	delayedVerification chan struct{}
 }
 
-func (b *blockDeserializer) DeserializeBlock(buff []byte) (Block, error) {
+func (b *blockDeserializer) DeserializeBlock(ctx context.Context, buff []byte) (Block, error) {
 	blockLen := binary.BigEndian.Uint32(buff[:4])
 	bh := BlockHeader{}
 	if err := bh.FromBytes(buff[4+blockLen:]); err != nil {
@@ -1535,8 +1535,9 @@ func (b *blockDeserializer) DeserializeBlock(buff []byte) (Block, error) {
 func TestBlockDeserializer(t *testing.T) {
 	var blockDeserializer blockDeserializer
 
+	ctx := context.Background()
 	tb := newTestBlock(ProtocolMetadata{Seq: 1, Round: 2, Epoch: 3})
-	tb2, err := blockDeserializer.DeserializeBlock(tb.Bytes())
+	tb2, err := blockDeserializer.DeserializeBlock(ctx, tb.Bytes())
 	require.NoError(t, err)
 	require.Equal(t, tb, tb2)
 }

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -246,6 +246,7 @@ func TestRecoverFromWalWithStorage(t *testing.T) {
 // TestWalCreated tests that the epoch correctly writes to the WAL
 func TestWalCreatedProperly(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
+	ctx := context.Background()
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	storage := newInMemStorage()
 
@@ -284,7 +285,7 @@ func TestWalCreatedProperly(t *testing.T) {
 	records, err = e.WAL.ReadAll()
 	require.NoError(t, err)
 	require.Len(t, records, 1)
-	blockFromWal, err := BlockFromRecord(conf.BlockDeserializer, records[0])
+	blockFromWal, err := BlockFromRecord(ctx, conf.BlockDeserializer, records[0])
 	require.NoError(t, err)
 	block := <-bb.out
 	require.Equal(t, blockFromWal, block)
@@ -318,6 +319,7 @@ func TestWalCreatedProperly(t *testing.T) {
 // a block proposed by a node other than the epoch node
 func TestWalWritesBlockRecord(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
+	ctx := context.Background()
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	storage := newInMemStorage()
 	blockDeserializer := &blockDeserializer{}
@@ -372,13 +374,14 @@ func TestWalWritesBlockRecord(t *testing.T) {
 	records, err = e.WAL.ReadAll()
 	require.NoError(t, err)
 	require.Len(t, records, 1)
-	blockFromWal, err := BlockFromRecord(blockDeserializer, records[0])
+	blockFromWal, err := BlockFromRecord(ctx, blockDeserializer, records[0])
 	require.NoError(t, err)
 	require.Equal(t, block, blockFromWal)
 }
 
 func TestWalWritesFinalization(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
+	ctx := context.Background()
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	storage := newInMemStorage()
 	sigAggregrator := &testSignatureAggregator{}
@@ -412,7 +415,7 @@ func TestWalWritesFinalization(t *testing.T) {
 	records, err := e.WAL.ReadAll()
 	require.NoError(t, err)
 	require.Len(t, records, 2)
-	blockFromWal, err := BlockFromRecord(conf.BlockDeserializer, records[0])
+	blockFromWal, err := BlockFromRecord(ctx, conf.BlockDeserializer, records[0])
 	require.NoError(t, err)
 	require.Equal(t, firstBlock, blockFromWal)
 	expectedNotarizationRecord, err := newNotarizationRecord(l, sigAggregrator, firstBlock, nodes[0:quorum])
@@ -451,7 +454,7 @@ func TestWalWritesFinalization(t *testing.T) {
 	records, err = e.WAL.ReadAll()
 	require.NoError(t, err)
 	require.Len(t, records, 4)
-	blockFromWal, err = BlockFromRecord(conf.BlockDeserializer, records[2])
+	blockFromWal, err = BlockFromRecord(ctx, conf.BlockDeserializer, records[2])
 	require.NoError(t, err)
 	require.Equal(t, secondBlock, blockFromWal)
 	expectedNotarizationRecord, err = newNotarizationRecord(l, sigAggregrator, secondBlock, nodes[0:quorum])

--- a/replication_request_test.go
+++ b/replication_request_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestReplicationRequestIndexedBlocks tests replication requests for indexed blocks.
-func TestReplicationeRequestIndexedBlocks(t *testing.T) {
+func TestReplicationRequestIndexedBlocks(t *testing.T) {
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	nodes := []simplex.NodeID{{1}, {2}, {3}, {4}}
 	comm := NewListenerComm(nodes)


### PR DESCRIPTION
So that we can pass in a context into the [block parser](https://github.com/ava-labs/avalanchego/pull/4009#discussion_r2178717248)