### PR TITLE
Update Storage.Index API

### DIFF
--- a/api.go
+++ b/api.go
@@ -49,7 +49,7 @@ type Storage interface {
 	// Retrieve returns the block and finalization at [seq].
 	// If [seq] is not found, returns false.
 	Retrieve(seq uint64) (VerifiedBlock, Finalization, bool)
-	Index(block VerifiedBlock, certificate Finalization)
+	Index(ctx context.Context, block VerifiedBlock, certificate Finalization) error
 }
 
 type Communication interface {

--- a/epoch.go
+++ b/epoch.go
@@ -925,7 +925,10 @@ func (e *Epoch) persistFinalization(finalization Finalization) error {
 	startRound := e.round
 	nextSeqToCommit := e.Storage.Height()
 	if finalization.Finalization.Seq == nextSeqToCommit {
-		e.indexFinalizations(finalization.Finalization.Round)
+		if err := e.indexFinalizations(finalization.Finalization.Round); err != nil {
+			e.Logger.Error("Failed to index finalizations", zap.Error(err))
+			return err
+		}
 	} else {
 		recordBytes := NewQuorumRecord(finalization.QC.Bytes(), finalization.Finalization.Bytes(), record.FinalizationRecordType)
 		if err := e.WAL.Append(recordBytes); err != nil {
@@ -1030,7 +1033,7 @@ func (e *Epoch) minRoundInRoundsMap() uint64 {
 	return minRound
 }
 
-func (e *Epoch) indexFinalizations(startRound uint64) {
+func (e *Epoch) indexFinalizations(startRound uint64) error {
 	maxRound := e.maxRoundInRoundsMap()
 
 	for currentRound := startRound; currentRound <= maxRound; currentRound++ {
@@ -1045,12 +1048,14 @@ func (e *Epoch) indexFinalizations(startRound uint64) {
 		if round.finalization.Finalization.Seq != e.Storage.Height() {
 			e.Logger.Debug("Finalization does not correspond to the next sequence to commit",
 				zap.Uint64("seq", round.finalization.Finalization.Seq), zap.Uint64("height", e.Storage.Height()))
-			return
+			return nil
 		}
 
 		finalization := *round.finalization
 		block := round.block
-		e.indexFinalization(block, finalization)
+		if err := e.indexFinalization(block, finalization); err != nil {
+			return err
+		}
 
 		e.deleteRounds(round.num)
 		// Clean up the future messages - Remove all messages we may have stored for the round
@@ -1059,10 +1064,13 @@ func (e *Epoch) indexFinalizations(startRound uint64) {
 			delete(messagesFromNode, finalization.Finalization.Round)
 		}
 	}
+	return nil
 }
 
-func (e *Epoch) indexFinalization(block VerifiedBlock, finalization Finalization) {
-	e.Storage.Index(block, finalization)
+func (e *Epoch) indexFinalization(block VerifiedBlock, finalization Finalization) error {
+	if err := e.Storage.Index(e.finishCtx, block, finalization); err != nil {
+		return err
+	}
 	e.Logger.Info("Committed block",
 		zap.Uint64("round", finalization.Finalization.Round),
 		zap.Uint64("sequence", finalization.Finalization.Seq),
@@ -1076,6 +1084,7 @@ func (e *Epoch) indexFinalization(block VerifiedBlock, finalization Finalization
 	// However, we may have not witnessed a notarization.
 	// Regardless of that, we can safely progress to the round succeeding the finalization.
 	e.progressRoundsDueToCommit(finalization.Finalization.Round + 1)
+	return nil
 }
 
 func (e *Epoch) maybeAssembleEmptyNotarization() error {
@@ -1531,7 +1540,12 @@ func (e *Epoch) processFinalizedBlock(block Block, finalization Finalization) er
 			return e.processFinalizedBlock(block, finalization)
 		}
 		round.finalization = &finalization
-		e.indexFinalizations(round.num)
+		if err := e.indexFinalizations(round.num); err != nil {
+			e.Logger.Error("Failed to index finalization", zap.Error(err))
+			e.haltedError = err
+			return nil
+		}
+
 		return e.processReplicationState()
 	}
 
@@ -1734,7 +1748,11 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block Block, finalization F
 			return md.Digest
 		}
 
-		e.indexFinalization(verifiedBlock, finalization)
+		if err := e.indexFinalization(verifiedBlock, finalization); err != nil {
+			e.haltedError = err
+			e.Logger.Error("Failed to index finalization", zap.Error(err))
+			return md.Digest
+		}
 		err = e.processReplicationState()
 
 		if err != nil {

--- a/epoch_multinode_test.go
+++ b/epoch_multinode_test.go
@@ -171,7 +171,7 @@ func newSimplexNode(t *testing.T, nodeID NodeID, net *inMemNetwork, bb BlockBuil
 func updateEpochConfig(epochConfig *EpochConfig, testConfig *testNodeConfig) {
 	// set the initial storage
 	for _, data := range testConfig.initialStorage {
-		epochConfig.Storage.Index(data.VerifiedBlock, data.Finalization)
+		epochConfig.Storage.Index(context.Background(), data.VerifiedBlock, data.Finalization)
 	}
 
 	// TODO: remove optional replication flag

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -1454,7 +1454,7 @@ func (mem *InMemStorage) Clone() *InMemStorage {
 			panic(fmt.Sprintf("failed retrieving block %d", seq))
 		}
 		mem.lock.Unlock()
-		clone.Index(block, finalization)
+		clone.Index(context.Background(), block, finalization)
 	}
 	return clone
 }
@@ -1494,7 +1494,7 @@ func (mem *InMemStorage) Retrieve(seq uint64) (VerifiedBlock, Finalization, bool
 	return item.VerifiedBlock, item.Finalization, true
 }
 
-func (mem *InMemStorage) Index(block VerifiedBlock, certificate Finalization) {
+func (mem *InMemStorage) Index(ctx context.Context, block VerifiedBlock, certificate Finalization) error {
 	mem.lock.Lock()
 	defer mem.lock.Unlock()
 
@@ -1512,6 +1512,7 @@ func (mem *InMemStorage) Index(block VerifiedBlock, certificate Finalization) {
 	}
 
 	mem.signal.Signal()
+	return nil
 }
 
 type blockDeserializer struct {

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -206,7 +206,9 @@ func TestRecoverFromWalWithStorage(t *testing.T) {
 		QCDeserializer:      &testQCDeserializer{t: t},
 	}
 
-	storage.Index(newTestBlock(ProtocolMetadata{Seq: 0, Round: 0, Epoch: 0}), Finalization{})
+	err := storage.Index(ctx, newTestBlock(ProtocolMetadata{Seq: 0, Round: 0, Epoch: 0}), Finalization{})
+	require.NoError(t, err)
+
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), e.Metadata().Round)
@@ -641,9 +643,9 @@ func TestRecoveryBlocksIndexed(t *testing.T) {
 	finalization2, _ := newFinalizationRecord(t, l, sigAggregrator, secondBlock, nodes[0:quorum])
 	fCer3, _ := newFinalizationRecord(t, l, sigAggregrator, thirdBlock, nodes[0:quorum])
 
-	conf.Storage.Index(firstBlock, finalization1)
-	conf.Storage.Index(secondBlock, finalization2)
-	conf.Storage.Index(thirdBlock, fCer3)
+	conf.Storage.Index(ctx, firstBlock, finalization1)
+	conf.Storage.Index(ctx, secondBlock, finalization2)
+	conf.Storage.Index(ctx, thirdBlock, fCer3)
 
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)
@@ -658,6 +660,7 @@ func TestRecoveryBlocksIndexed(t *testing.T) {
 
 func TestEpochCorrectlyInitializesMetadataFromStorage(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
+	ctx := context.Background()
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	storage := newInMemStorage()
 	nodes := []NodeID{{1}, {2}, {3}, {4}}
@@ -676,7 +679,7 @@ func TestEpochCorrectlyInitializesMetadataFromStorage(t *testing.T) {
 	}
 
 	block := newTestBlock(ProtocolMetadata{Seq: 0, Round: 0, Epoch: 0})
-	conf.Storage.Index(block, Finalization{})
+	conf.Storage.Index(ctx, block, Finalization{})
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), e.Storage.Height())
@@ -691,11 +694,13 @@ func TestEpochCorrectlyInitializesMetadataFromStorage(t *testing.T) {
 func TestRecoveryAsLeader(t *testing.T) {
 	l := testutil.MakeLogger(t, 1)
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
+	ctx := context.Background()
 	nodes := []NodeID{{1}, {2}, {3}, {4}}
 	finalizedBlocks := createBlocks(t, nodes, bb, 4)
 	storage := newInMemStorage()
 	for _, finalizedBlock := range finalizedBlocks {
-		storage.Index(finalizedBlock.VerifiedBlock, finalizedBlock.Finalization)
+		err := storage.Index(ctx, finalizedBlock.VerifiedBlock, finalizedBlock.Finalization)
+		require.NoError(t, err)
 	}
 
 	conf := EpochConfig{
@@ -735,7 +740,8 @@ func TestRecoveryReVerifiesBlocks(t *testing.T) {
 	finalizedBlocks := createBlocks(t, nodes, bb, 4)
 	storage := newInMemStorage()
 	for _, finalizedBlock := range finalizedBlocks {
-		storage.Index(finalizedBlock.VerifiedBlock, finalizedBlock.Finalization)
+		err := storage.Index(ctx, finalizedBlock.VerifiedBlock, finalizedBlock.Finalization)
+		require.NoError(t, err)
 	}
 
 	deserializer := &blockDeserializer{

--- a/replication_request_test.go
+++ b/replication_request_test.go
@@ -2,6 +2,7 @@ package simplex_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/ava-labs/simplex"
@@ -14,13 +15,15 @@ func TestReplicationRequestIndexedBlocks(t *testing.T) {
 	bb := &testBlockBuilder{out: make(chan *testBlock, 1)}
 	nodes := []simplex.NodeID{{1}, {2}, {3}, {4}}
 	comm := NewListenerComm(nodes)
+	ctx := context.Background()
 	conf := defaultTestNodeEpochConfig(t, nodes[0], comm, bb)
 	conf.ReplicationEnabled = true
 
 	numBlocks := uint64(10)
 	seqs := createBlocks(t, nodes, bb, numBlocks)
 	for _, data := range seqs {
-		conf.Storage.Index(data.VerifiedBlock, data.Finalization)
+		err := conf.Storage.Index(ctx, data.VerifiedBlock, data.Finalization)
+		require.NoError(t, err)
 	}
 	e, err := simplex.NewEpoch(conf)
 	require.NoError(t, err)


### PR DESCRIPTION
adds a context as a parameter and sets an error as the return value. Indexing could fail during inserting into the DB, or erroring when calling `Accept` on a block(which is done in index). The context is needed since `block.Accept` takes in a context,