### PR TITLE
Blacklist implementation

### DIFF
--- a/blacklist.go
+++ b/blacklist.go
@@ -1,0 +1,242 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package simplex
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"math/big"
+	"math/bits"
+)
+
+type Blacklist struct {
+	NodeCount        uint16
+	BlacklistedNodes bitVec
+	RedeemedNodes    []struct {
+		redeemedNode uint16
+		reporters    *bitVec
+	}
+}
+
+func (bl *Blacklist) blacklistSize() int {
+	return bits.OnesCount16(uint16(bl.BlacklistedNodes))
+}
+
+func (bl *Blacklist) IsBlacklisted(i uint16) bool {
+	if i < 0 || i >= bl.NodeCount {
+		panic(fmt.Sprintf("index out of range [0, %d): %d", bl.NodeCount, i))
+	}
+
+	return bl.BlacklistedNodes.IsSet(i)
+}
+
+func (bl *Blacklist) BlacklistNode(i uint16) error {
+	if i < 0 || i >= bl.NodeCount {
+		return fmt.Errorf("index out of range [0, %d): %d", bl.NodeCount, i)
+	}
+
+	bl.BlacklistedNodes.Set(i)
+
+	threshold := (bl.NodeCount - 1) / 3 // f
+
+	// If we have too many blacklisted nodes, we should not allow more,
+	// as it would lead to a situation where we cannot reach consensus.
+	// So we pick a pseudo-random node to redeem.
+	if bits.OnesCount16(uint16(bl.BlacklistedNodes)) > int(threshold) {
+		bl.redeemRandomNode()
+	}
+
+	return nil
+}
+
+func (bl *Blacklist) redeemRandomNode() {
+	digest := sha256.Sum256(bl.Bytes())
+	for {
+		n := big.NewInt(0).SetBytes(digest[:])
+		n.Mod(n, big.NewInt(int64(bl.NodeCount)))
+		if bl.BlacklistedNodes.IsSet(uint16(n.Int64())) {
+			bl.BlacklistedNodes.Clear(uint16(n.Int64()))
+			bl.compactRedeemedNodes()
+			break
+		}
+		// Else, the node is not blacklisted, so we need to pick a different one.
+		digest = sha256.Sum256(digest[:])
+	}
+}
+
+func (bl *Blacklist) RedeemNode(redeemedNodeIndex uint16, reporterNodeIndex uint16) error {
+	if (bl.NodeCount) == 0 {
+		return fmt.Errorf("blacklist node count is zero")
+	}
+
+	threshold := (bl.NodeCount-1)/3 + 1 // f + 1
+
+	if redeemedNodeIndex < 0 || redeemedNodeIndex >= bl.NodeCount {
+		return fmt.Errorf("redeemed node index out of range [0, %d): %d", bl.NodeCount, redeemedNodeIndex)
+	}
+
+	if reporterNodeIndex < 0 || reporterNodeIndex >= bl.NodeCount {
+		return fmt.Errorf("reporter node index out of range [0, %d): %d", bl.NodeCount, reporterNodeIndex)
+	}
+
+	if !bl.BlacklistedNodes.IsSet(redeemedNodeIndex) {
+		return nil
+	}
+
+	bl.markNodeReportedRedeemed(redeemedNodeIndex, reporterNodeIndex)
+
+	if bl.isNodeRedeemed(int(threshold), redeemedNodeIndex) {
+		bl.BlacklistedNodes.Clear(redeemedNodeIndex)
+		bl.compactRedeemedNodes()
+	}
+
+	return nil
+}
+
+func (bl *Blacklist) isNodeRedeemed(threshold int, redeemedNodeIndex uint16) bool {
+	for _, rn := range bl.RedeemedNodes {
+		if rn.redeemedNode == redeemedNodeIndex {
+			if bits.OnesCount16(uint16(*rn.reporters)) >= threshold {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (bl *Blacklist) markNodeReportedRedeemed(redeemedNodeIndex uint16, reporterNodeIndex uint16) {
+	for _, rn := range bl.RedeemedNodes {
+		if rn.redeemedNode == redeemedNodeIndex {
+			rn.reporters.Set(reporterNodeIndex)
+			return
+		}
+	}
+
+	var zeroVec bitVec
+	bl.RedeemedNodes = append(bl.RedeemedNodes, struct {
+		redeemedNode uint16
+		reporters    *bitVec
+	}{
+		redeemedNode: redeemedNodeIndex,
+		reporters:    &zeroVec,
+	})
+
+	bl.RedeemedNodes[len(bl.RedeemedNodes)-1].reporters.Set(reporterNodeIndex)
+}
+
+func (bl *Blacklist) compactRedeemedNodes() {
+	newRedeemedNodes := make([]struct {
+		redeemedNode uint16
+		reporters    *bitVec
+	}, 0, len(bl.RedeemedNodes))
+	for _, rn := range bl.RedeemedNodes {
+		if bl.BlacklistedNodes.IsSet(rn.redeemedNode) {
+			newRedeemedNodes = append(newRedeemedNodes, rn)
+		}
+	}
+	bl.RedeemedNodes = newRedeemedNodes
+}
+
+func (bl *Blacklist) String() string {
+	redeemed := bytes.Buffer{}
+	for _, rn := range bl.RedeemedNodes {
+		redeemed.WriteString(fmt.Sprintf("{%d %d},", rn.redeemedNode, *rn.reporters))
+	}
+	redeemedStr := redeemed.String()
+	return fmt.Sprintf("NodeCount: %d, BlacklistedNodes: %d, RedeemedNodes: [%s]",
+		bl.NodeCount, bl.BlacklistedNodes, redeemedStr[0:len(redeemedStr)-1]) // remove trailing comma
+}
+
+func (bl *Blacklist) Bytes() []byte {
+	bytes := make([]byte, 4+4*len(bl.RedeemedNodes))
+	bytes[0] = byte(bl.NodeCount)
+	bytes[1] = byte(bl.NodeCount >> 8)
+	bytes[2] = byte(bl.BlacklistedNodes)
+	bytes[3] = byte(bl.BlacklistedNodes >> 8)
+
+	pos := 4
+
+	for _, bv := range bl.RedeemedNodes {
+		bytes[pos] = byte(bv.redeemedNode)
+		bytes[pos+1] = byte(bv.redeemedNode >> 8)
+		bytes[pos+2] = byte(*bv.reporters)
+		bytes[pos+3] = byte(*bv.reporters >> 8)
+		pos += 4
+	}
+
+	return bytes
+}
+
+func (bl *Blacklist) FromBytes(bytes []byte) error {
+	if len(bytes) < 4 {
+		return fmt.Errorf("blacklist bytes too short: %d < 4", len(bytes))
+	}
+
+	if len(bytes)%4 != 0 {
+		return fmt.Errorf("blacklist bytes length must be a factor of 4, got %d", len(bytes))
+	}
+
+	bl.NodeCount = uint16(bytes[0]) | uint16(bytes[1])<<8
+	bl.BlacklistedNodes = bitVec(uint16(bytes[2]) | uint16(bytes[3])<<8)
+
+	bytes = bytes[4:]
+
+	bl.RedeemedNodes = make([]struct {
+		redeemedNode uint16
+		reporters    *bitVec
+	}, 0, len(bytes)/4)
+
+	for len(bytes) > 0 {
+		reporters := bitVec(uint16(bytes[2]) | uint16(bytes[3])<<8)
+		bl.RedeemedNodes = append(bl.RedeemedNodes, struct {
+			redeemedNode uint16
+			reporters    *bitVec
+		}{
+			redeemedNode: uint16(bytes[0]) | uint16(bytes[1])<<8,
+			reporters:    &reporters,
+		})
+		bytes = bytes[4:]
+	}
+
+	return nil
+}
+
+type bitVec uint16
+
+// IsSet checks if bit i is set to 1
+func (bv *bitVec) IsSet(i uint16) bool {
+	if bv == nil {
+		panic("bitVec is nil")
+	}
+	if i < 0 || i >= 16 {
+		panic(fmt.Sprintf("index out of range (0-15): %d", i))
+	}
+
+	return (*bv & (1 << i)) != 0
+}
+
+// Set sets bit i to 1
+func (bv *bitVec) Set(i uint16) {
+	if bv == nil {
+		panic("bitVec is nil")
+	}
+	if i < 0 || i >= 16 {
+		panic(fmt.Sprintf("index out of range (0-15): %d", i))
+	}
+
+	*bv |= 1 << i
+}
+
+// Clear sets bit i to 0
+func (bv *bitVec) Clear(i uint16) {
+	if bv == nil {
+		panic("bitVec is nil")
+	}
+	if i < 0 || i >= 16 {
+		panic(fmt.Sprintf("index out of range (0-15): %d", i))
+	}
+
+	*bv &= ^(1 << i)
+}

--- a/blacklist_test.go
+++ b/blacklist_test.go
@@ -1,0 +1,157 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package simplex
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlacklist(t *testing.T) {
+	bl := Blacklist{
+		NodeCount: 7,
+	}
+
+	for i := uint16(0); i < bl.NodeCount; i++ {
+		require.False(t, bl.IsBlacklisted(i), "Node %d should not be blacklisted initially", i)
+	}
+
+	require.NoError(t, bl.BlacklistNode(2))
+	require.True(t, bl.IsBlacklisted(2))
+
+	require.NoError(t, bl.BlacklistNode(5))
+	require.True(t, bl.IsBlacklisted(5))
+
+	require.False(t, bl.IsBlacklisted(0))
+	require.False(t, bl.IsBlacklisted(1))
+	require.False(t, bl.IsBlacklisted(3))
+	require.False(t, bl.IsBlacklisted(4))
+	require.False(t, bl.IsBlacklisted(6))
+
+	bl.RedeemNode(2, 1)
+	require.True(t, bl.IsBlacklisted(2))
+	require.Len(t, bl.Bytes(), 8)
+
+	bl.RedeemNode(2, 3)
+	require.True(t, bl.IsBlacklisted(2))
+	require.Len(t, bl.Bytes(), 8)
+
+	bl.RedeemNode(3, 1)
+	require.Len(t, bl.Bytes(), 8)
+
+	bl.RedeemNode(2, 4)
+	require.False(t, bl.IsBlacklisted(2))
+	require.Len(t, bl.Bytes(), 4)
+}
+
+func TestBlacklistRedeemRandomNode(t *testing.T) {
+	bl := Blacklist{
+		NodeCount: 7,
+	}
+
+	bl.BlacklistNode(1)
+	require.Equal(t, bl.blacklistSize(), 1)
+	bl.BlacklistNode(3)
+	require.Equal(t, bl.blacklistSize(), 2)
+	bl.BlacklistNode(5)
+	require.Equal(t, bl.blacklistSize(), 2)
+	require.True(t, bl.IsBlacklisted(5))
+	require.True(t, bl.IsBlacklisted(1) || bl.IsBlacklisted(3))
+	require.False(t, bl.IsBlacklisted(1) && bl.IsBlacklisted(3))
+}
+
+func TestBitVec(t *testing.T) {
+	var bv bitVec
+	bv.Set(0)
+	require.Equal(t, bitVec(1), bv)
+
+	bv.Set(1)
+	require.Equal(t, bitVec(3), bv)
+
+	bv.Set(15)
+	require.Equal(t, bitVec(1+2+32768), bv)
+
+	require.Panics(t, func() {
+		bv.Set(16)
+	})
+
+	bv.Clear(1)
+	require.Equal(t, bitVec(1+32768), bv)
+
+	require.True(t, bv.IsSet(15))
+
+	bv.Clear(15)
+	require.Equal(t, bitVec(1), bv)
+	require.False(t, bv.IsSet(15))
+
+	require.Panics(t, func() {
+		bv.Clear(16)
+	})
+}
+
+func TestBlacklistString(t *testing.T) {
+	var reporters bitVec = 1 // 0001 in binary
+	bl := Blacklist{
+		NodeCount:        5,
+		BlacklistedNodes: 9, // 1001 in binary
+		RedeemedNodes: []struct {
+			redeemedNode uint16
+			reporters    *bitVec
+		}{
+			{redeemedNode: 4, reporters: &reporters}, // 0001 in binary
+		},
+	}
+
+	expectedString := "NodeCount: 5, BlacklistedNodes: 9, RedeemedNodes: [{4 1}]"
+
+	require.Equal(t, expectedString, bl.String())
+}
+
+func TestBlacklistBytes(t *testing.T) {
+	randInts := newRandUint16(t, 6)
+	bl := Blacklist{
+		NodeCount:        uint16(randInts[0]),
+		BlacklistedNodes: randInts[1],
+		RedeemedNodes: []struct {
+			redeemedNode uint16
+			reporters    *bitVec
+		}{
+			{redeemedNode: uint16(randInts[2]), reporters: &randInts[3]},
+			{redeemedNode: uint16(randInts[4]), reporters: &randInts[5]},
+		},
+	}
+
+	bytes := bl.Bytes()
+
+	expectedBytes := make([]byte, 12)
+	binary.LittleEndian.PutUint16(expectedBytes[:2], bl.NodeCount)
+	binary.LittleEndian.PutUint16(expectedBytes[2:4], uint16(bl.BlacklistedNodes))
+	binary.LittleEndian.PutUint16(expectedBytes[4:6], bl.RedeemedNodes[0].redeemedNode)
+	binary.LittleEndian.PutUint16(expectedBytes[6:8], uint16(*bl.RedeemedNodes[0].reporters))
+	binary.LittleEndian.PutUint16(expectedBytes[8:10], bl.RedeemedNodes[1].redeemedNode)
+	binary.LittleEndian.PutUint16(expectedBytes[10:12], uint16(*bl.RedeemedNodes[1].reporters))
+
+	require.Equal(t, expectedBytes, bytes)
+
+	var newBl Blacklist
+	require.NoError(t, newBl.FromBytes(bytes))
+	require.Equal(t, bl.NodeCount, newBl.NodeCount)
+	require.Equal(t, bl.BlacklistedNodes, newBl.BlacklistedNodes)
+	require.Equal(t, bl.RedeemedNodes, newBl.RedeemedNodes)
+}
+
+func newRandUint16(t *testing.T, n int) []bitVec {
+	buff := make([]byte, 2*n)
+	_, err := rand.Read(buff)
+	require.NoError(t, err)
+
+	nums := make([]bitVec, n)
+	for i := 0; i < n; i++ {
+		nums[i] = bitVec(binary.LittleEndian.Uint16(buff[i*2 : i*2+2]))
+	}
+	return nums
+}


### PR DESCRIPTION
This commit implements a blacklist that performs book-keeping of nodes that are blacklisted. The blacklist contains a node count, and a bit vector the size of the node count.

When a node is blacklisted, its corresponding bit is set to 1 in the bit vector.

A node can be removed from the blacklist by being voted to be redeemed by f+1 nodes.

The blacklist keeps track of redemptions via a bit vector per blacklisted node.

If a more than f nodes are blacklisted, a random node is removed from the blacklist.