### PR TITLE
Fix data race(s) in replication code and tests

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -183,7 +183,7 @@ func (e *Epoch) init() error {
 	e.maxPendingBlocks = DefaultMaxPendingBlocks
 	e.eligibleNodeIDs = make(map[string]struct{}, len(e.nodes))
 	e.futureMessages = make(messagesFromNode, len(e.nodes))
-	e.replicationState = NewReplicationState(e.Logger, e.Comm, e.ID, e.maxRoundWindow, e.ReplicationEnabled, e.StartTime)
+	e.replicationState = NewReplicationState(e.Logger, e.Comm, e.ID, e.maxRoundWindow, e.ReplicationEnabled, e.StartTime, &e.lock)
 	e.timeoutHandler = NewTimeoutHandler(e.Logger, e.StartTime, e.nodes)
 
 	for _, node := range e.nodes {

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -327,6 +327,9 @@ func (c *collectNotarizationComm) Broadcast(msg *simplex.Message) {
 }
 
 func (c *collectNotarizationComm) removeFinalizationsFromReplicationResponses(msg *simplex.Message, from, to simplex.NodeID) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
 	if msg.VerifiedReplicationResponse != nil || msg.ReplicationResponse != nil {
 		newData := make([]simplex.VerifiedQuorumRound, 0, len(msg.VerifiedReplicationResponse.Data))
 


### PR DESCRIPTION
This commit fixes two data races:

1. We send requests to nodes for blocks asynchronously but also process messages in parallel, without synchronization.

2. The 'collectNotarizationComm' communication mock can be invoked from the test without synchronizing with the communication goroutines.