### PR TITLE
Rename Storage.Height -> NumBlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Picking Simplex [1] as a consensus protocol of choice for Subnet only Validators
 - It has been peer-reviewed by the academic community (TCC 2023).
 - Its censorship-resistance relies on leader rotation, unlike timeouts which may suffer from false positives.
 
-
 The main counter-argument against choosing Simplex is that a single block proposer (leader) consensus protocol
 has limited throughput compared to a protocol that shards the transactions space
 across different nodes and proposes batches in parallel.
@@ -21,14 +20,12 @@ across different nodes and proposes batches in parallel.
 While the argument is correct, a fast consensus protocol isn't enough to guarantee a high end to end throughput for a blockchain.
 To fully utilize parallel block proposers, the VM should also support distributed transaction processing.
 
-The HyperSDK, Avalanche's "high throughput" VM of choice, 
-[plans to employ](https://hackmd.io/@patrickogrady/rys8mdl5p#Integrating-Vryx-with-the-HyperSDK-High-Level-Sketch) 
+The HyperSDK, Avalanche's "high throughput" VM of choice,
+[plans to employ](https://hackmd.io/@patrickogrady/rys8mdl5p#Integrating-Vryx-with-the-HyperSDK-High-Level-Sketch)
 techniques that totally order certificates of transaction chunk availability, which are of small size.
 
 Since the design of the HyperSDK does not require a high throughput consensus protocol,
 there is no need to invest development time in a parallel block proposer consensus protocol.
-
-
 
 ### Node membership: PoS vs PoA setting
 
@@ -37,9 +34,8 @@ For the sake of succinctness and simplicity, this document uses Proof of Authori
 
 A PoA setting can be thought of a PoS setting where all nodes have precisely the same stake,
 making each node have a "single vote". Similarly, a PoS setting can be thought of a PoA setting
-where the `N` nodes with the highest stake get to vote, and each node has a number of votes that is 
+where the `N` nodes with the highest stake get to vote, and each node has a number of votes that is
 proportional to the stake of the node with the lowest stake among the `N` nodes.
-
 
 ## Protocol high-level description as per the Simplex paper
 
@@ -47,7 +43,7 @@ proportional to the stake of the node with the lowest stake among the `N` nodes.
 
 The protocol assumes a static set of `n` nodes, out of which up to and not including a third, are faulty.
 
-A quorum of nodes is defined as the smallest set such that two such sets of nodes intersect in at least one correct node. 
+A quorum of nodes is defined as the smallest set such that two such sets of nodes intersect in at least one correct node.
 If `n=3f+1` where `f` is the upper bound on faulty nodes, then a quorum is any set of nodes of size `2f+1`.
 Each node has a private key used for signing.
 The corresponding public key used for verifying signatures is known to all other nodes.
@@ -58,12 +54,12 @@ A node progresses in monotonically increasing and successive rounds.
 Each round has a (different) leader node designated to propose blocks and disseminate them to the rest of the nodes.
 Nodes only respond to the first block they see from the leader of that round.
 Once a leader node proposes a block, it participates in the remaining steps of the round as if it was a non-leader node.
-Except from the step in which the leader broadcasts a block, every other step involves a node broadcasting a signed message. 
+Except from the step in which the leader broadcasts a block, every other step involves a node broadcasting a signed message.
 All nodes can verify whether a node indeed signed the message or not.
 
 There exists a time period `T` that is a system-wide parameter and is used by the protocol.
 
-For an  arbitrary length string `x`, we denote `H(x)` to be the hash of `x`,
+For an arbitrary length string `x`, we denote `H(x)` to be the hash of `x`,
 where `H` is a collision resistant hash function with an output size of at least 32 bytes.
 
 The flow of the protocol is as follows:
@@ -76,7 +72,6 @@ The flow of the protocol is as follows:
 4. Upon collecting a notarization or an empty notarization on `b` which consists of a quorum of votes of the form `<vote, i, ⊥>` or `<vote, i, H(b)>` respectively, the node broadcasts the notarization (or the empty notarization) before moving to round `i+1`.
 5. Starting from round `i+1`, each node that did not vote for `<vote, i, ⊥>` (due to a timeout) or collect a quorum of votes on `<vote, i, ⊥>` broadcasts a finalization message `<finalize, i, H(b)>`.
 6. Each node that collects a quorum of finalization messages considers the block `b` as finalized, and can deliver it to the application.
-
 
 ### Avoiding excessive block production
 
@@ -97,15 +92,15 @@ It is up to the application to ensure that transactions arrive to the leader and
 
 ## Reconfiguring Simplex
 
-The Simplex paper assumes a static set of nodes. 
-However, validator nodes of a blockchain network may be added or removed while the protocol totally orders transactions. 
+The Simplex paper assumes a static set of nodes.
+However, validator nodes of a blockchain network may be added or removed while the protocol totally orders transactions.
 The act of adding or removing a validator node from the members of a consensus protocol is called reconfiguration.
 
 When Simplex finalizes a block that causes the node membership to change, we say that block contains a reconfiguration event.
 
-A reconfiguration event can be either a transaction that changes the node membership in the chain governed by the chain itself, 
-or it can even be a proof originating from a chain not governed by the bespoken chain, which simply attests the new 
-set of nodes running the Simplex consensus protocol. 
+A reconfiguration event can be either a transaction that changes the node membership in the chain governed by the chain itself,
+or it can even be a proof originating from a chain not governed by the bespoken chain, which simply attests the new
+set of nodes running the Simplex consensus protocol.
 
 The only requirements for Simplex are:
 
@@ -114,52 +109,49 @@ The only requirements for Simplex are:
 
 Reconfiguring a Simplex protocol while it totally orders transactions poses several challenges:
 
-1. In Simplex, node `p` may collect a quorum of finalization messages at a different round than node `q` 
-(for example, block `b` was notarized by a quorum of nodes at round `i` but only node `p` 
-collected a quorum of finalization votes in round `i+1`, and the rest voted for the empty block in round `i+1`
-and then collected the finalization votes in round `i+2`). 
-It is therefore not safe to apply the new node membership whenever a node collects a quorum of finalization votes, 
-as nodes at the same round may end up having different opinions of which nodes are eligible to be part of a quorum.
+1. In Simplex, node `p` may collect a quorum of finalization messages at a different round than node `q`
+   (for example, block `b` was notarized by a quorum of nodes at round `i` but only node `p`
+   collected a quorum of finalization votes in round `i+1`, and the rest voted for the empty block in round `i+1`
+   and then collected the finalization votes in round `i+2`).
+   It is therefore not safe to apply the new node membership whenever a node collects a quorum of finalization votes,
+   as nodes at the same round may end up having different opinions of which nodes are eligible to be part of a quorum.
 2. In Simplex, blocks are proposed by alternating nodes.
-It may be the case that node `p` proposes a block in round `i` which contains a transaction which removes node `q`
-from the membership set, and the next node to propose a block is node `q`, in round `i+1`.
-If `q` proposes a block in round `i+1`, and it is notarized before the block in round `i` is finalized, 
-what is to become of the block proposed by `q` and other blocks built and notarized on top of it? 
-Block `q` should not have been notarized because it was proposed by a node that was removed in round `i`,
-and therefore conceptually, all transactions in successive blocks need to be returned into the mem-pool.
+   It may be the case that node `p` proposes a block in round `i` which contains a transaction which removes node `q`
+   from the membership set, and the next node to propose a block is node `q`, in round `i+1`.
+   If `q` proposes a block in round `i+1`, and it is notarized before the block in round `i` is finalized,
+   what is to become of the block proposed by `q` and other blocks built and notarized on top of it?
+   Block `q` should not have been notarized because it was proposed by a node that was removed in round `i`,
+   and therefore conceptually, all transactions in successive blocks need to be returned into the mem-pool.
 
 In order to be able to dynamically reconfigure the membership set of the Simplex protocol, two techniques will be employed:
 
-
-* `Epochs`: Each round will be associated with an epoch. An epoch starts either at genesis or in the round successive to a round containing a reconfiguration event. An epoch ends when a block containing a reconfiguration event is finalized.
+- `Epochs`: Each round will be associated with an epoch. An epoch starts either at genesis or in the round successive to a round containing a reconfiguration event. An epoch ends when a block containing a reconfiguration event is finalized.
 
   The epoch number is always the sequence number of the block that caused the epoch to end. Meaning, if a block with a sequence of `i` in epoch `e` contained a reconfiguration event, the next epoch would be epoch number `i` regardless of `e`.
 
-* `Parallel instances`: Once a node finalizes a block which contains a reconfiguration event, it starts a fresh new instance of Simplex for the new epoch, but still retains for a while the previous instance of the previous epoch, to respond to messages of straggler nodes in the previous epoch that haven’t finalized the last block of that epoch.
+- `Parallel instances`: Once a node finalizes a block which contains a reconfiguration event, it starts a fresh new instance of Simplex for the new epoch, but still retains for a while the previous instance of the previous epoch, to respond to messages of straggler nodes in the previous epoch that haven’t finalized the last block of that epoch.
 
 Given an old block `b` in epoch `e` and observing a block `b’` created in epoch `e+k` along with a set of finalization messages, it seems impossible to determine if `b’` is authentic or not, as there were reconfiguration events since the block `b` in epoch `e` was finalized. Therefore, the set of finalization messages on `b'` cannot be authenticated, as it’s not even clear how many nodes are there in epoch `e+k` in the first place.
 
-Fortunately, there is a way to check whether block `b’` is authentic or not: Let `{e, e+i, …, e+j, e+k}` be the series of epochs from block `b` to block `b’`, and let {`b, d, …, d’, b’`} be blocks where the sequence number of `d` and `d’` are `e+i` and `e+j` respectively. To be convinced of the authenticity of block `b’` one can just fetch the series of blocks {`b, d, …, d’, b’`} and validate them one by one. Since each block encodes its epoch number, and epoch numbers are block sequences that contain reconfiguration events, 
+Fortunately, there is a way to check whether block `b’` is authentic or not: Let `{e, e+i, …, e+j, e+k}` be the series of epochs from block `b` to block `b’`, and let {`b, d, …, d’, b’`} be blocks where the sequence number of `d` and `d’` are `e+i` and `e+j` respectively. To be convinced of the authenticity of block `b’` one can just fetch the series of blocks {`b, d, …, d’, b’`} and validate them one by one. Since each block encodes its epoch number, and epoch numbers are block sequences that contain reconfiguration events,
 then after validating the aforementioned series of blocks we are guaranteed whether `b’` is authentic or not.
-Hereafter we call the series of blocks  {`b, d, …, d’, b’`}  an *Epoch Change Series* (ECS).
+Hereafter we call the series of blocks {`b, d, …, d’, b’`} an _Epoch Change Series_ (ECS).
 
 In practice, reconfiguration would work as follows:
 
-1. For a block `b` containing a reconfiguration event, in round `i` at epoch `e`, any descendant block of `b` in epoch `e` are treated as regular blocks, but they must only contain the metadata and no block data. 
-Any descendant blocks that contain transactions are invalid.
+1. For a block `b` containing a reconfiguration event, in round `i` at epoch `e`, any descendant block of `b` in epoch `e` are treated as regular blocks, but they must only contain the metadata and no block data.
+   Any descendant blocks that contain transactions are invalid.
 2. Since it is impossible to hand over these blocks and their corresponding finalizations to the application, the finalizations are written to the Write-Ahead-Log (WAL) along with the metadata
    to ensure proper restoration of the protocol state in case of a crash.
 3. Once a node finalizes and commits block `b`, it terminates its previous Simplex instance for epoch `e` and instantiates a new Simplex instance for the new epoch.
-Any message regarding epoch `e` sent by a remote node is then responded by the finalization certificate for block `b`, which notifies the remote node about the existence of block `b`,
-assisting it to transition into the new epoch.
-
+   Any message regarding epoch `e` sent by a remote node is then responded by the finalization certificate for block `b`, which notifies the remote node about the existence of block `b`,
+   assisting it to transition into the new epoch.
 
 ### Structuring the blockchain:
 
 Unlike the official Simplex paper [1] where empty blocks end up as part of the blockchain, In our adaptation of it, the blockchain consists only of finalized blocks, and blocks are numbered consecutively but the round numbers in which these blocks were proposed, are not consecutive. Each block contains the corresponding protocol metadata for the round in which it was proposed.
 
 ![protocol metadata](docs/figures/blocks.png)
-
 
 As depicted above, in case of an empty block (in white) the protocol metadata for the round is the round and epoch numbers. For regular blocks, the block sequence and the previous block hash are also part of the protocol metadata.
 By looking at the sequence numbers and the round numbers of the two data blocks, it can be deduced that round 120 corresponds to an empty block.
@@ -170,15 +162,15 @@ Simplex will assume an abstract and pluggable block storage with two basic opera
 
 ```go
 type Storage interface {
-   // Height returns how many blocks have been accepted so far.
-   Height() uint64
-   
+   // NumBlocks returns how many blocks have been accepted so far.
+   NumBlocks() uint64
+
    // Retrieve retrieves the block and corresponding finalization
    // certificate from the storage, and returns false if it fails to do so.
-   Retrieve(seq uint64) (Block, FinalizationCertificate, bool, error) 
-   
+   Retrieve(seq uint64) (Block, FinalizationCertificate, bool, error)
+
    // Index persists the given block to stable storage and associates it with the given sequence.
-   Index(seq uint64, block Block, certificate FinalizationCertificate)   
+   Index(seq uint64, block Block, certificate FinalizationCertificate)
 }
 ```
 
@@ -188,10 +180,10 @@ The `FinalizationCertificate` message is defined later on, and `Block` is define
 type Block interface {
     // Metadata is the consensus specific metadata for the block
     Metadata() Metadata
-	
+
     // Bytes returns a byte encoding of the block
     Bytes() []byte
-	
+
 	// EndsEpoch returns whether the block causes an epoch change
 	EndsEpoch() bool
 }
@@ -224,7 +216,7 @@ type ProtocolMetadata struct {
    Version uint8
    // Epoch returns the epoch in which the block was proposed
    Epoch uint64
-   // Round returns the round number in which the block was proposed. 
+   // Round returns the round number in which the block was proposed.
    // Can also be an empty block.
    Round uint64
    // Seq is the order of the block among all blocks in the blockchain.
@@ -238,9 +230,9 @@ type ProtocolMetadata struct {
 
 ### Persisting protocol state to disk
 
-Besides long term persistent storage, Simplex will also utilize a Write-Ahead-Log (WAL). 
+Besides long term persistent storage, Simplex will also utilize a Write-Ahead-Log (WAL).
 
-A WAL is used to write intermediate steps in the consensus protocol’s operation. It’s needed for preserving consistency in the presence of crashes. 
+A WAL is used to write intermediate steps in the consensus protocol’s operation. It’s needed for preserving consistency in the presence of crashes.
 Essentially, each node uses the WAL to save its current step in the protocol execution before it moves to the next step. If the node crashes, it uses the WAL to find at which step in the protocol it crashed and knows how to resume its operation from that step.  
 The WAL will be implemented as an append-only file which will be pruned only upon a finalization of a data block. The WAL interface will be as follows:
 
@@ -249,54 +241,52 @@ type WriteAheadLog interface {
    // Append appends the given record to the WAL,
    // and if prune is true, then the content of the WAL
    // may contain only the given record afterward.
-   Append(record Record, prune bool)  
+   Append(record Record, prune bool)
    // ReadAll() returns all records in the WAL
-   ReadAll() []Record  
+   ReadAll() []Record
 }
 ```
 
 The `prune` parameter indicates to the WAL that it is safe to prune the content of the WAL.
-In practice, whether the WAL prunes the entire data is up to implementation. 
+In practice, whether the WAL prunes the entire data is up to implementation.
 Some implementations may only prune the WAL once it grows beyond a certain size,
 for efficiency reasons.
 It is important for the append operation to be atomic with high probability.
 Therefore, a checksum mechanism is employed to detect if Simplex crashed mid-write.
 
-
 A Record written by a WAL is defined as:
 
 ```protobuf
-Record {  
+Record {
    version uint8
-   size uint32  
-   type uint32  
-   payload bytes  
-   checksum bytes   
+   size uint32
+   type uint32
+   payload bytes
+   checksum bytes
 }
 ```
-
 
 The type corresponds to which message is recorded in the record, and each type corresponds to a serialization of one of the following messages:
 
 - The `Proposal` message is written to the WAL once a node receives a proposal from the leader. It contains the block in its raw form.
-It also contains the protocol metadata associated to that block.
+  It also contains the protocol metadata associated to that block.
 - Once a node collects a quorum of vote messages from distinct signers, it persists a `Notarization` message to the WAL.
 - Of course, it might be that it’s not possible to collect a quorum of Vote messages, and in that case the node times out until it collects a quorum of `EmptyVote` messages and persists an `EmptyNotarization` message to the WAL.
 - Finally, a node eventually collects a quorum of `Finalization` messages for a block. If all prior blocks have been indexed in the `Storage`,
-a `FinalizationCertificate` is passed to the application along with the corresponding `Block`. Otherwise, the `FinalizationCertificate` is written to the WAL to prevent it being lost.
+  a `FinalizationCertificate` is passed to the application along with the corresponding `Block`. Otherwise, the `FinalizationCertificate` is written to the WAL to prevent it being lost.
 
 The messages saved in the WAL and the messages they transitively contain are as follows:
 
 - [Proposal](#proposal): A proposal is a block received by a leader of some round. It is written to the WAL
-so that if the node crashes and recovers, it will never vote to a different block for that round. 
+  so that if the node crashes and recovers, it will never vote to a different block for that round.
 - [Notarization](#notarization): When a node collects a quorum of [SignedVote](#signedvote) messages on the same
   [Vote](#vote) message, it persists a notarization message to the WAL, so that when it recovers from a crash
-it will not vote for the empty block for that round.
+  it will not vote for the empty block for that round.
 - [EmptyNotarization](#emptyNotarization): Similarly to the notarization, a node also persists an empty notarization
-once it collects a quorum of [SignedEmptyVote](#signedEmptyVote) messages on the same [EmptyVote](#emptyVote) message.
+  once it collects a quorum of [SignedEmptyVote](#signedEmptyVote) messages on the same [EmptyVote](#emptyVote) message.
 - [FinalizationCertificate](#finalizationCertificate): Once a node collects a quorum of [SignedFinalization](#signedFinalization) messages
-on the same [Finalization](#finalization), it persists a finalization certificate to the WAL,
-in case the corresponding block cannot be written yet to the storage. 
+  on the same [Finalization](#finalization), it persists a finalization certificate to the WAL,
+  in case the corresponding block cannot be written yet to the storage.
 
 In case the signature algorithm allows aggregation of signatures, we define the aggregated messages below:
 
@@ -307,12 +297,11 @@ In case the signature algorithm allows aggregation of signatures, we define the 
 These messages then become part of the [Notarization](#notarization), [EmptyNotarization](#emptyNotarization), and [FinalizationCertificate](#finalizationCertificate)
 respectively.
 
-
 #### Finalization certificates and epoch changes
 
 A finalization certificate message of epoch `e` for sequence `i` is not written to the WAL if it corresponds to a block that is an ancestor of a block with sequence `f` that changes the current epoch,
 unless sequences previous to `i` have not been committed.
-If all sequences prior to `i` have been committed, and sequences `e, ..., i` are all not epoch change blocks, the finalization certificate for sequence `i` is written to the  storage atomically with the block.
+If all sequences prior to `i` have been committed, and sequences `e, ..., i` are all not epoch change blocks, the finalization certificate for sequence `i` is written to the storage atomically with the block.
 
 A finalization certificate message of any other block for that epoch, is written to the WAL.
 In other words, we persist to the WAL all finalizations of epoch `e` starting from the block that ends the epoch `e`.
@@ -320,18 +309,16 @@ The reason is that we may not be able to obtain a finalization for the block wit
 in epoch `e`, but as per our configuration protocol, these blocks contain no transactions, so they cannot be made part of the blockchain.
 Therefore, in order to retain crash fault tolerance, we persist these finalizations to the WAL.
 
-
-
 Two useful facts can be deduced from the structure of the messages written to the WAL:
 
 1. The WAL of a node is not unique to that node, and two nodes in the same round may have the same WAL content.
-2. Nodes can verify each other's WAL content. 
+2. Nodes can verify each other's WAL content.
 
 Combining the two above facts leads to a conclusion: Nodes can safely replicate the WAL from each other.
 
 ### Simplex and synchronization of disconnected nodes
 
-In a real internet wide deployment, nodes may experience message loss due to plenty of reasons.  A consensus protocol that relies on messages being broadcast once, needs to be able to withstand sudden and unexpected message loss or know how to recover when they occur.  Otherwise, a node that missed a message or two, may find itself stuck in a round as the rest of the nodes advance to higher rounds. While consistency is not impacted, degradation of liveness of a consensus protocol can be severely detrimental to end user experience.
+In a real internet wide deployment, nodes may experience message loss due to plenty of reasons. A consensus protocol that relies on messages being broadcast once, needs to be able to withstand sudden and unexpected message loss or know how to recover when they occur. Otherwise, a node that missed a message or two, may find itself stuck in a round as the rest of the nodes advance to higher rounds. While consistency is not impacted, degradation of liveness of a consensus protocol can be severely detrimental to end user experience.
 
 A node that has been disconnected or just missed messages can synchronize with other nodes.  
 The synchronization mechanism is divided into two independent aspects:
@@ -351,7 +338,7 @@ If a node discovers it is behind, there are two mutually exclusive scenarios:
 
 If the node is behind just in the round number, it reaches to the nodes it knows and fetches missing blocks (with finalizations) as well as notarizations and empty notarizations.
 
-However, if the node is behind also in the epoch number, it first reaches the nodes it knows in order to fetch an ECS, in order to discover the latest set of members.   
+However, if the node is behind also in the epoch number, it first reaches the nodes it knows in order to fetch an ECS, in order to discover the latest set of members.  
 Once it has established the latest membership of nodes it needs to interact with, it proceeds with synchronizing the blocks, notarizations and empty notarizations.
 
 The blocks and (empty) notarizations are replicated subject to the following rules:
@@ -363,23 +350,22 @@ The blocks and (empty) notarizations are replicated subject to the following rul
 5. If an empty notarization is fetched from a remote node, then the block for that round needs not to be fetched.
 6. A node that replicated a notarization, writes it to the WAL in the same manner it would have written it during its normal operation.
 7. A notarization for a block in round `i` is regarded as a notarization on a parent block in round `i-1` if the previous hash of the notarization
-of round `i` corresponds to the hash of the block of round `i-1`. This rule can be recursively applied to any block in round `j < i`.
+   of round `i` corresponds to the hash of the block of round `i-1`. This rule can be recursively applied to any block in round `j < i`.
 
 In order for a node to synchronize the WAL, we define the following messages:
 
 - [NotarizationRequest](#notarizationRequest): A request inquiring whether a given round has been notarized.
-or notarized via empty votes.
+  or notarized via empty votes.
 - [NotarizationResponse](#notarizationResponse): A response that contains either a notarization or an empty notarization.
 - [BlockRequest](#blockRequest): A request inquiring about a block for a given sequence.
 - [BlockResponse](#blockResponse): A response containing the block of the bespoken sequence.
 
-
 ## Simplex API
 
-In order for the consensus protocol to be part of an application, such as avalanchego, 
+In order for the consensus protocol to be part of an application, such as avalanchego,
 Simplex will both depend on APIs from the application, and also give APIs for the application to use it.
 
-Examples of APIs that Simplex would expect from the application, 
+Examples of APIs that Simplex would expect from the application,
 are APIs for sending and signing messages, an API that would be triggerred once a block has been finalized,
 and an API to build a block.
 
@@ -406,7 +392,7 @@ type Message struct {
 It is the responsibility of the application to properly handle authentication, marshalling and wire protocol,
 and to construct the `Message` properly.
 
-Compared to the snowman consensus, the Simplex API would be at the engine level. 
+Compared to the snowman consensus, the Simplex API would be at the engine level.
 The reason for that it would be possible to integrate Simplex into a toy application for early testing,
 and also in order to be able to structure tests to run an entire network of nodes.
 
@@ -416,10 +402,10 @@ and also in order to be able to structure tests to run an entire network of node
 type Consensus interface {
     // AdvanceTime hints the engine that the given amount of time has passed.
     AdvanceTime(time.Duration)
-    
+
     // HandleMessage notifies the engine about a reception of a message.
     HandleMessage(msg Message, from NodeID)
-	
+
     // Metadata returns the latest protocol metadata known to this instance.
     Metadata() ProtocolMetadata
 }
@@ -428,9 +414,8 @@ type Consensus interface {
 
 ### The application API to the Simplex engine consists of several objects:
 
-The two most important APIs that an application exposes to Simplex, 
+The two most important APIs that an application exposes to Simplex,
 are an API to build blocks and as mentioned before, an API to store and retrieve them:
-
 
 ```go
 type BlockBuilder interface {
@@ -438,14 +423,12 @@ type BlockBuilder interface {
     // in which case a block and true are returned.
     // When the given context is cancelled by the caller, returns false.
     BuildBlock(ctx Context, metadata ProtocolMetadata) (Block, bool)
-	
+
     // IncomingBlock returns when either the given context is cancelled,
     // or when the application signals that a block should be built.
     IncomingBlock(ctx Context)
 }
 ```
-
-
 
 ```go
 // BlockDeserializer deserializes blocks according to formatting
@@ -457,9 +440,8 @@ type BlockDeserializer interface {
 }
 ```
 
-
 Whenever a Simplex instance recognizes it is its turn to propose a block, it calls
-into the application in order to build a block via the `BlockBuilder`. 
+into the application in order to build a block via the `BlockBuilder`.
 Similarly, when it has collected enough finalizations for a block,
 it passes the block and the finalizations to the application layer, which in turn, is responsible
 not only for indexing the block, but also removing the transactions of the block from the memory pool.
@@ -485,9 +467,10 @@ type Verifier interface {
     // that is the result of committing this block.
     // If the block doesn't cause an epoch change, this is a no-op.
     SetEpochChange(Block) error
-	
+
 }
 ```
+
 Blocks are verified using a `BlockVerifier`. It is the responsibility of the application that every block
 is verified while taking into account ancestor blocks of the given block.
 
@@ -500,61 +483,57 @@ type BlockVerifier interface {
 In order to detect whether a commit of a `Block` would cause the current epoch to end,
 Simplex invokes its `EndsEpoch` method.
 
-
 In order to send messages to the members of the network, a communication object
 which also can be configured on an epoch basis, is defined:
 
 ```go
 type Communication interface {
-	
+
     // Nodes returns all nodes known to the application.
     Nodes() []NodeID
-	
+
     // Send sends a message to the given destination node
     Send(msg Message, destination NodeID)
-    
-    // Broadcast broadcasts the given message to all nodes 
+
+    // Broadcast broadcasts the given message to all nodes
     Broadcast(msg Message)
 
     // SetEpochChange sets the epoch to correspond with the epoch
     // that is the result of committing this block.
     // If the block doesn't cause an epoch change, this is a no-op.
     SetEpochChange(Block) error
-	
+
 }
 ```
 
 [1] https://eprint.iacr.org/2023/463
 
-
 ## Acknowledgements
 
 Thanks to Stephen Buttolph for invaluable feedback on this specification.
 
-
 # Appendix
-
 
 ## Messages persisted to the Write-Ahead-Log
 
 <a name="proposal"></a>
+
 ```protobuf
-Proposal {  
-  block bytes  
+Proposal {
+  block bytes
 }
 ```
-
 
 <a name="vote"></a>
 
 ```protobuf
-Vote {  
-   version uint8  
-   digest bytes  
-   digest_algorithm uint32  
-   seq uint64  
-   round uint64  
-   epoch uint64  
+Vote {
+   version uint8
+   digest bytes
+   digest_algorithm uint32
+   seq uint64
+   round uint64
+   epoch uint64
    prev_hash bytes
 }
 ```
@@ -567,7 +546,7 @@ SignedVote {
     signature_algorithm uint32
     signer bytes
     signature bytes
-} 
+}
 ```
 
 <a name="notarization"></a>
@@ -584,9 +563,9 @@ Notarization {
 <a name="emptyVote"></a>
 
 ```protobuf
-EmptyVote {  
-   version uint8  
-   round uint64  
+EmptyVote {
+   version uint8
+   round uint64
    epoch uint64
 }
 ```
@@ -594,14 +573,13 @@ EmptyVote {
 <a name="signedEmptyVote"></a>
 
 ```protobuf
-SignedEmptyVote {  
-   empty_vote EmptyVote  
-   signature_algorithm uint16  
-   signer bytes  
-   signature bytes  
+SignedEmptyVote {
+   empty_vote EmptyVote
+   signature_algorithm uint16
+   signer bytes
+   signature bytes
 }
 ```
-
 
 <a name="emptyNotarization"></a>
 
@@ -610,32 +588,32 @@ EmptyNotarization {
         empty_vote EmptyVote
         signature_algorithm uint32
         repeated signer bytes
-        repeated signature bytes  
+        repeated signature bytes
 }
 ```
 
 <a name="finalization"></a>
 
 ```protobuf
-Finalization {  
-   version uint8  
-   digest bytes  
-   digest_algorithm uint32  
-   seq uint64  
-   round uint64  
-   epoch uint64  
-   prev bytes  
+Finalization {
+   version uint8
+   digest bytes
+   digest_algorithm uint32
+   seq uint64
+   round uint64
+   epoch uint64
+   prev bytes
 }
 ```
 
 <a name="signedFinalization"></a>
 
 ```protobuf
-SignedFinalization {  
-   finalization Finalization  
-   signature_algorithm uint16  
-   signer bytes  
-   signature bytes  
+SignedFinalization {
+   finalization Finalization
+   signature_algorithm uint16
+   signer bytes
+   signature bytes
 }
 ```
 
@@ -650,42 +628,40 @@ type FinalizationCertificate struct {
 }
 ```
 
-
 <a name="aggregatedSignedVote"></a>
 
 ```protobuf
-AggregatedSignedVote {  
-    vote Vote  
-    signature_algorithm uint16  
+AggregatedSignedVote {
+    vote Vote
+    signature_algorithm uint16
     signers repeated bytes
-    signature bytes  
+    signature bytes
 }
 ```
 
 <a name="aggregatedSignedEmptyVote"></a>
 
 ```protobuf
-AggregatedSignedEmptyVote {  
-    empty_vote EmptyVote  
+AggregatedSignedEmptyVote {
+    empty_vote EmptyVote
     signature_algorithm uint32
-    signers repeated bytes  
-    signature bytes  
+    signers repeated bytes
+    signature bytes
 }
 ```
 
 <a name="aggregatedSignedFinalization"></a>
 
 ```protobuf
-AggregatedSignedFinalization {  
-    finalization Finalization  
-    signature_algorithm uint16  
-    signers repeated bytes  
-    signature bytes  
+AggregatedSignedFinalization {
+    finalization Finalization
+    signature_algorithm uint16
+    signers repeated bytes
+    signature bytes
 }
 ```
 
 ## Messages intended for peer-to-peer replication
-
 
 <a name="notarizationRequest"></a>
 

--- a/api.go
+++ b/api.go
@@ -48,7 +48,7 @@ type BlockBuilder interface {
 var ErrBlockNotFound = fmt.Errorf("block not found")
 
 type Storage interface {
-	Height() uint64
+	NumBlocks() uint64
 	// Retrieve returns the block and finalization at [seq].
 	// If [seq] the block cannot be found, returns ErrBlockNotFound.
 	Retrieve(seq uint64) (VerifiedBlock, Finalization, error)

--- a/epoch.go
+++ b/epoch.go
@@ -2470,6 +2470,11 @@ func (e *Epoch) handleReplicationRequest(req *ReplicationRequest, from NodeID) e
 	}
 
 	response.Data = data
+	if len(data) == 0 && latestRound == nil {
+		e.Logger.Debug("No data found for replication request", zap.Stringer("from", from))
+		return nil
+	}
+
 	msg := &Message{VerifiedReplicationResponse: response}
 	e.Comm.Send(msg, from)
 	return nil

--- a/epoch_failover_test.go
+++ b/epoch_failover_test.go
@@ -111,7 +111,7 @@ func TestEpochLeaderFailoverWithEmptyNotarization(t *testing.T) {
 		block, _ := notarizeAndFinalizeRound(t, e, bb)
 		require.Equal(t, nextBlockSeqToCommit, block.BlockHeader().Seq)
 		require.Equal(t, nextRoundToCommit, block.BlockHeader().Round)
-		require.Equal(t, uint64(3), storage.Height())
+		require.Equal(t, uint64(3), storage.NumBlocks())
 	})
 }
 
@@ -172,7 +172,7 @@ func TestEpochLeaderFailoverReceivesEmptyVotesEarly(t *testing.T) {
 		notarizeAndFinalizeRound(t, e, bb)
 	}
 
-	lastBlock, _, err := storage.Retrieve(storage.Height() - 1)
+	lastBlock, _, err := storage.Retrieve(storage.NumBlocks() - 1)
 	require.NoError(t, err)
 
 	prev := lastBlock.BlockHeader().Digest
@@ -212,7 +212,7 @@ func TestEpochLeaderFailoverReceivesEmptyVotesEarly(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
 		require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
-		require.Equal(t, uint64(3), storage.Height())
+		require.Equal(t, uint64(3), storage.NumBlocks())
 
 		header, _, err := ParseBlockRecord(rawProposal)
 		require.NoError(t, err)
@@ -228,7 +228,7 @@ func TestEpochLeaderFailoverReceivesEmptyVotesEarly(t *testing.T) {
 
 		block2 := storage.waitForBlockCommit(3)
 		require.Equal(t, block, block2)
-		require.Equal(t, uint64(4), storage.Height())
+		require.Equal(t, uint64(4), storage.NumBlocks())
 		require.Equal(t, uint64(4), block2.BlockHeader().Round)
 		require.Equal(t, uint64(3), block2.BlockHeader().Seq)
 	})
@@ -317,7 +317,7 @@ func TestEpochLeaderFailover(t *testing.T) {
 	waitForBlockProposerTimeout(t, e, &start, e.Metadata().Round)
 
 	runCrashAndRestartExecution(t, e, bb, wal, storage, func(t *testing.T, e *Epoch, bb *testBlockBuilder, storage *InMemStorage, wal *testWAL) {
-		lastBlock, _, err := storage.Retrieve(storage.Height() - 1)
+		lastBlock, _, err := storage.Retrieve(storage.NumBlocks() - 1)
 		require.NoError(t, err)
 
 		prev := lastBlock.BlockHeader().Digest
@@ -352,7 +352,7 @@ func TestEpochLeaderFailover(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
 		require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
-		require.Equal(t, uint64(3), storage.Height())
+		require.Equal(t, uint64(3), storage.NumBlocks())
 
 		nextBlockSeqToCommit := uint64(3)
 		nextRoundToCommit := uint64(4)
@@ -362,7 +362,7 @@ func TestEpochLeaderFailover(t *testing.T) {
 		require.Equal(t, nextRoundToCommit, block.BlockHeader().Round)
 		require.Equal(t, nextBlockSeqToCommit, block.BlockHeader().Seq)
 
-		require.Equal(t, uint64(4), storage.Height())
+		require.Equal(t, uint64(4), storage.NumBlocks())
 	})
 }
 
@@ -525,7 +525,7 @@ func TestEpochLeaderFailoverAfterProposal(t *testing.T) {
 
 	runCrashAndRestartExecution(t, e, bb, wal, storage, func(t *testing.T, e *Epoch, bb *testBlockBuilder, storage *InMemStorage, wal *testWAL) {
 
-		lastBlock, _, err := storage.Retrieve(storage.Height() - 1)
+		lastBlock, _, err := storage.Retrieve(storage.NumBlocks() - 1)
 		require.NoError(t, err)
 
 		prev := lastBlock.BlockHeader().Digest
@@ -569,7 +569,7 @@ func TestEpochLeaderFailoverAfterProposal(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
 		require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
-		require.Equal(t, uint64(4), storage.Height())
+		require.Equal(t, uint64(4), storage.NumBlocks())
 	})
 }
 
@@ -614,7 +614,7 @@ func TestEpochLeaderFailoverTwice(t *testing.T) {
 	waitForBlockProposerTimeout(t, e, &start, e.Metadata().Round)
 
 	runCrashAndRestartExecution(t, e, bb, wal, storage, func(t *testing.T, e *Epoch, bb *testBlockBuilder, storage *InMemStorage, wal *testWAL) {
-		lastBlock, _, err := storage.Retrieve(storage.Height() - 1)
+		lastBlock, _, err := storage.Retrieve(storage.NumBlocks() - 1)
 		require.NoError(t, err)
 
 		prev := lastBlock.BlockHeader().Digest
@@ -684,7 +684,7 @@ func TestEpochLeaderFailoverTwice(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, emptyVoteFrom1.Vote, emptyNotarization.Vote)
 			require.Equal(t, uint64(3), emptyNotarization.Vote.Round)
-			require.Equal(t, uint64(3), storage.Height())
+			require.Equal(t, uint64(3), storage.NumBlocks())
 		})
 	})
 }

--- a/epoch_multinode_test.go
+++ b/epoch_multinode_test.go
@@ -111,7 +111,7 @@ func TestSplitVotes(t *testing.T) {
 	splitNode3.wal.assertNotarization(0)
 
 	for _, n := range net.instances {
-		require.Equal(t, uint64(0), n.e.Storage.Height())
+		require.Equal(t, uint64(0), n.e.Storage.NumBlocks())
 		require.Equal(t, uint64(1), n.e.Metadata().Round)
 		require.Equal(t, uint64(1), n.e.Metadata().Seq)
 	}
@@ -123,7 +123,7 @@ func TestSplitVotes(t *testing.T) {
 	for _, n := range net.instances {
 		n.storage.waitForBlockCommit(0)
 		n.storage.waitForBlockCommit(1)
-		require.Equal(t, uint64(2), n.e.Storage.Height())
+		require.Equal(t, uint64(2), n.e.Storage.NumBlocks())
 		require.Equal(t, uint64(2), n.e.Metadata().Round)
 		require.Equal(t, uint64(2), n.e.Metadata().Seq)
 	}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -107,7 +107,7 @@ func TestRecoverFromWALProposed(t *testing.T) {
 		require.Equal(t, block, block2)
 	}
 
-	require.Equal(t, rounds, e.Storage.Height())
+	require.Equal(t, rounds, e.Storage.NumBlocks())
 }
 
 // TestRecoverFromWALNotarized tests that the epoch can recover from a wal
@@ -177,7 +177,7 @@ func TestRecoverFromNotarization(t *testing.T) {
 	bBytes, err = block.Bytes()
 	require.NoError(t, err)
 	require.Equal(t, bBytes, committedData)
-	require.Equal(t, uint64(1), e.Storage.Height())
+	require.Equal(t, uint64(1), e.Storage.NumBlocks())
 }
 
 // TestRecoverFromWALFinalized tests that the epoch can recover from a wal
@@ -253,7 +253,7 @@ func TestRecoverFromWalWithStorage(t *testing.T) {
 	require.NoError(t, err)
 	bBytes, err = block.Bytes()
 	require.Equal(t, bBytes, committedData)
-	require.Equal(t, uint64(2), e.Storage.Height())
+	require.Equal(t, uint64(2), e.Storage.NumBlocks())
 }
 
 // TestWalCreated tests that the epoch correctly writes to the WAL
@@ -448,7 +448,7 @@ func TestWalWritesFinalization(t *testing.T) {
 
 	// increase the round but don't index storage
 	require.Equal(t, uint64(1), e.Metadata().Round)
-	require.Equal(t, uint64(0), e.Storage.Height())
+	require.Equal(t, uint64(0), e.Storage.NumBlocks())
 
 	vote, err := newTestVote(secondBlock, nodes[1])
 	require.NoError(t, err)
@@ -493,7 +493,7 @@ func TestWalWritesFinalization(t *testing.T) {
 
 	// ensure the finalization is not indexed
 	require.Equal(t, uint64(2), e.Metadata().Round)
-	require.Equal(t, uint64(0), e.Storage.Height())
+	require.Equal(t, uint64(0), e.Storage.NumBlocks())
 }
 
 // Appends to the wal -> block, notarization, second block, notarization block 2, finalization for block 2.
@@ -559,7 +559,7 @@ func TestRecoverFromMultipleNotarizations(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, uint64(2), e.Metadata().Round)
-	require.Equal(t, uint64(0), e.Storage.Height())
+	require.Equal(t, uint64(0), e.Storage.NumBlocks())
 
 	// now if we send finalization for block 1, we should index both 1 & 2
 	finalization1, _ := newFinalizationRecord(t, l, sigAggregrator, firstBlock, nodes[0:quorum])
@@ -568,7 +568,7 @@ func TestRecoverFromMultipleNotarizations(t *testing.T) {
 	}, nodes[1])
 	require.NoError(t, err)
 
-	require.Equal(t, uint64(2), e.Storage.Height())
+	require.Equal(t, uint64(2), e.Storage.NumBlocks())
 	storageBytes, err := storage.data[0].VerifiedBlock.Bytes()
 	require.NoError(t, err)
 	require.Equal(t, fBytes, storageBytes)
@@ -649,7 +649,7 @@ func TestRecoveryBlocksIndexed(t *testing.T) {
 
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)
-	require.Equal(t, uint64(3), e.Storage.Height())
+	require.Equal(t, uint64(3), e.Storage.NumBlocks())
 	require.NoError(t, e.Start())
 
 	// ensure the round is properly set to 3
@@ -682,7 +682,7 @@ func TestEpochCorrectlyInitializesMetadataFromStorage(t *testing.T) {
 	conf.Storage.Index(ctx, block, Finalization{})
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)
-	require.Equal(t, uint64(1), e.Storage.Height())
+	require.Equal(t, uint64(1), e.Storage.NumBlocks())
 	require.NoError(t, e.Start())
 
 	// ensure the round is properly set
@@ -719,7 +719,7 @@ func TestRecoveryAsLeader(t *testing.T) {
 
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)
-	require.Equal(t, uint64(4), e.Storage.Height())
+	require.Equal(t, uint64(4), e.Storage.NumBlocks())
 	require.NoError(t, e.Start())
 
 	<-bb.out

--- a/replication_test.go
+++ b/replication_test.go
@@ -56,10 +56,10 @@ func testReplication(t *testing.T, startSeq uint64, nodes []simplex.NodeID) {
 		replicationEnabled: true,
 	})
 
-	require.Equal(t, startSeq, normalNode1.storage.Height())
-	require.Equal(t, startSeq, normalNode2.storage.Height())
-	require.Equal(t, startSeq, normalNode3.storage.Height())
-	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	require.Equal(t, startSeq, normalNode1.storage.NumBlocks())
+	require.Equal(t, startSeq, normalNode2.storage.NumBlocks())
+	require.Equal(t, startSeq, normalNode3.storage.NumBlocks())
+	require.Equal(t, uint64(0), laggingNode.storage.NumBlocks())
 
 	net.startInstances()
 	bb.triggerNewBlock()
@@ -95,10 +95,10 @@ func TestReplicationAdversarialNode(t *testing.T) {
 		replicationEnabled: true,
 	})
 
-	require.Equal(t, uint64(0), doubleBlockProposalNode.storage.Height())
-	require.Equal(t, uint64(0), normalNode2.storage.Height())
-	require.Equal(t, uint64(0), normalNode3.storage.Height())
-	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	require.Equal(t, uint64(0), doubleBlockProposalNode.storage.NumBlocks())
+	require.Equal(t, uint64(0), normalNode2.storage.NumBlocks())
+	require.Equal(t, uint64(0), normalNode3.storage.NumBlocks())
+	require.Equal(t, uint64(0), laggingNode.storage.NumBlocks())
 
 	net.startInstances()
 	doubleBlock := newTestBlock(doubleBlockProposalNode.e.Metadata())
@@ -126,7 +126,7 @@ func TestReplicationAdversarialNode(t *testing.T) {
 	}
 
 	// lagging node should not have commited the block
-	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	require.Equal(t, uint64(0), laggingNode.storage.NumBlocks())
 	require.Equal(t, uint64(0), laggingNode.e.Metadata().Round)
 	net.Connect(laggingNode.e.ID)
 
@@ -166,7 +166,7 @@ func TestRebroadcastingWithReplication(t *testing.T) {
 	laggingNode := newSimplexNode(t, nodes[3], net, laggingBb, newNodeConfig(nodes[3]))
 
 	for _, n := range net.instances {
-		require.Equal(t, uint64(0), n.storage.Height())
+		require.Equal(t, uint64(0), n.storage.NumBlocks())
 	}
 
 	epochTimes := make([]time.Time, 0, len(nodes))
@@ -209,14 +209,14 @@ func TestRebroadcastingWithReplication(t *testing.T) {
 
 	for _, n := range net.instances {
 		if n.e.ID.Equals(laggingNode.e.ID) {
-			require.Equal(t, uint64(0), n.storage.Height())
+			require.Equal(t, uint64(0), n.storage.NumBlocks())
 			require.Equal(t, uint64(0), n.e.Metadata().Round)
 			continue
 		}
 
 		// assert metadata
 		require.Equal(t, uint64(numNotarizations), n.e.Metadata().Round)
-		require.Equal(t, uint64(1), n.e.Storage.Height())
+		require.Equal(t, uint64(1), n.e.Storage.NumBlocks())
 	}
 
 	net.setAllNodesMessageFilter(allowAllMessages)
@@ -271,7 +271,7 @@ func testReplicationEmptyNotarizations(t *testing.T, nodes []simplex.NodeID, end
 	laggingNode := newSimplexNode(t, nodes[5], net, laggingBb, newNodeConfig(nodes[5]))
 
 	for _, n := range net.instances {
-		require.Equal(t, uint64(0), n.storage.Height())
+		require.Equal(t, uint64(0), n.storage.NumBlocks())
 		startTimes = append(startTimes, n.e.StartTime)
 	}
 
@@ -301,7 +301,7 @@ func testReplicationEmptyNotarizations(t *testing.T, nodes []simplex.NodeID, end
 
 	for _, n := range net.instances {
 		if n.e.ID.Equals(laggingNode.e.ID) {
-			require.Equal(t, uint64(0), n.storage.Height())
+			require.Equal(t, uint64(0), n.storage.NumBlocks())
 			require.Equal(t, uint64(0), n.e.Metadata().Round)
 			continue
 		}
@@ -309,7 +309,7 @@ func testReplicationEmptyNotarizations(t *testing.T, nodes []simplex.NodeID, end
 		// assert metadata
 		require.Equal(t, uint64(endRound), n.e.Metadata().Round)
 		require.Equal(t, uint64(1), n.e.Metadata().Seq)
-		require.Equal(t, uint64(1), n.e.Storage.Height())
+		require.Equal(t, uint64(1), n.e.Storage.NumBlocks())
 	}
 
 	net.setAllNodesMessageFilter(allowAllMessages)
@@ -319,7 +319,7 @@ func testReplicationEmptyNotarizations(t *testing.T, nodes []simplex.NodeID, end
 		n.storage.waitForBlockCommit(1)
 	}
 
-	require.Equal(t, uint64(2), laggingNode.storage.Height())
+	require.Equal(t, uint64(2), laggingNode.storage.NumBlocks())
 	require.Equal(t, uint64(endRound+1), laggingNode.e.Metadata().Round)
 	require.Equal(t, uint64(2), laggingNode.e.Metadata().Seq)
 }
@@ -364,10 +364,10 @@ func TestReplicationStartsBeforeCurrentRound(t *testing.T) {
 	require.NoError(t, err)
 	laggingNode.wal.Append(secondNotarizationRecord)
 
-	require.Equal(t, startSeq, normalNode1.storage.Height())
-	require.Equal(t, startSeq, normalNode2.storage.Height())
-	require.Equal(t, startSeq, normalNode3.storage.Height())
-	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	require.Equal(t, startSeq, normalNode1.storage.NumBlocks())
+	require.Equal(t, startSeq, normalNode2.storage.NumBlocks())
+	require.Equal(t, startSeq, normalNode3.storage.NumBlocks())
+	require.Equal(t, uint64(0), laggingNode.storage.NumBlocks())
 
 	net.startInstances()
 
@@ -438,7 +438,7 @@ func TestReplicationFutureFinalization(t *testing.T) {
 	block.verificationDelay <- struct{}{} // unblock the block verification
 
 	storedBlock := storage.waitForBlockCommit(0)
-	require.Equal(t, uint64(1), storage.Height())
+	require.Equal(t, uint64(1), storage.NumBlocks())
 	require.Equal(t, block, storedBlock)
 }
 
@@ -481,10 +481,10 @@ func testReplicationAfterNodeDisconnects(t *testing.T, nodes []simplex.NodeID, s
 	normalNode3 := newSimplexNode(t, nodes[2], net, bb, testConfig)
 	laggingNode := newSimplexNode(t, nodes[3], net, laggingBb, testConfig)
 
-	require.Equal(t, uint64(0), normalNode1.storage.Height())
-	require.Equal(t, uint64(0), normalNode2.storage.Height())
-	require.Equal(t, uint64(0), normalNode3.storage.Height())
-	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	require.Equal(t, uint64(0), normalNode1.storage.NumBlocks())
+	require.Equal(t, uint64(0), normalNode2.storage.NumBlocks())
+	require.Equal(t, uint64(0), normalNode3.storage.NumBlocks())
+	require.Equal(t, uint64(0), laggingNode.storage.NumBlocks())
 
 	epochTimes := make([]time.Time, 0, 4)
 	for _, n := range net.instances {
@@ -506,7 +506,7 @@ func testReplicationAfterNodeDisconnects(t *testing.T, nodes []simplex.NodeID, s
 
 	// all nodes have commited `startDisconnect` blocks
 	for _, n := range net.instances {
-		require.Equal(t, startDisconnect, n.storage.Height())
+		require.Equal(t, startDisconnect, n.storage.NumBlocks())
 	}
 
 	// lagging node disconnects
@@ -533,9 +533,9 @@ func testReplicationAfterNodeDisconnects(t *testing.T, nodes []simplex.NodeID, s
 	}
 	// all nodes excpet for lagging node have progressed and commited [endDisconnect - missedSeqs] blocks
 	for _, n := range net.instances[:3] {
-		require.Equal(t, endDisconnect-missedSeqs, n.storage.Height())
+		require.Equal(t, endDisconnect-missedSeqs, n.storage.NumBlocks())
 	}
-	require.Equal(t, startDisconnect, laggingNode.storage.Height())
+	require.Equal(t, startDisconnect, laggingNode.storage.NumBlocks())
 	require.Equal(t, startDisconnect, laggingNode.e.Metadata().Round)
 	// lagging node reconnects
 	net.Connect(nodes[3])
@@ -545,7 +545,7 @@ func testReplicationAfterNodeDisconnects(t *testing.T, nodes []simplex.NodeID, s
 	}
 
 	for _, n := range net.instances {
-		require.Equal(t, endDisconnect-missedSeqs, n.storage.Height()-1)
+		require.Equal(t, endDisconnect-missedSeqs, n.storage.NumBlocks()-1)
 		require.Equal(t, endDisconnect+1, n.e.Metadata().Round)
 	}
 
@@ -620,7 +620,7 @@ func TestReplicationNodeDiverges(t *testing.T) {
 
 	startTimes := make([]time.Time, 0, len(nodes))
 	for _, n := range net.instances {
-		require.Equal(t, uint64(0), n.storage.Height())
+		require.Equal(t, uint64(0), n.storage.NumBlocks())
 		startTimes = append(startTimes, n.e.StartTime)
 	}
 
@@ -747,7 +747,7 @@ func testReplicationNotarizationWithoutFinalizations(t *testing.T, numBlocks uin
 	laggingNode := newSimplexNode(t, nodes[3], net, bb, nodeConfig(nodes[3]))
 
 	for _, n := range net.instances {
-		require.Equal(t, uint64(0), n.storage.Height())
+		require.Equal(t, uint64(0), n.storage.NumBlocks())
 	}
 
 	net.startInstances()
@@ -762,7 +762,7 @@ func testReplicationNotarizationWithoutFinalizations(t *testing.T, numBlocks uin
 	}
 
 	laggingNode.wal.assertNotarization(numBlocks - 1)
-	require.Equal(t, uint64(0), laggingNode.storage.Height())
+	require.Equal(t, uint64(0), laggingNode.storage.NumBlocks())
 	require.Equal(t, uint64(numBlocks), laggingNode.e.Metadata().Round)
 
 	net.setAllNodesMessageFilter(allowAllMessages)

--- a/util.go
+++ b/util.go
@@ -15,13 +15,13 @@ import (
 // Returns an error if it cannot be retrieved but the storage has some block.
 // Returns (nil, nil) if the storage is empty.
 func RetrieveLastIndexFromStorage(s Storage) (*VerifiedFinalizedBlock, error) {
-	height := s.Height()
-	if height == 0 {
+	numBlocks := s.NumBlocks()
+	if numBlocks == 0 {
 		return nil, nil
 	}
-	lastBlock, finalization, err := s.Retrieve(height - 1)
+	lastBlock, finalization, err := s.Retrieve(numBlocks - 1)
 	if err != nil {
-		return nil, fmt.Errorf("failed retrieving last block from storage with seq %d: %w", height-1, err)
+		return nil, fmt.Errorf("failed retrieving last block from storage with seq %d: %w", numBlocks-1, err)
 	}
 	return &VerifiedFinalizedBlock{
 		VerifiedBlock: lastBlock,


### PR DESCRIPTION
In avalanchego, `Height` refers to the last accepted height. Renaming it could help avoid confusion between avalanchego's `height` semantics and simplex's