### PR TITLE
Resend replication requests for finalized blocks that fail to verify

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -1746,6 +1746,7 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block Block, finalization F
 
 		verifiedBlock, err := block.Verify(context.Background())
 		if err != nil {
+			e.Logger.Debug("Failed verifying block", zap.Error(err))
 			// if we fail to verify the block, we should re-add to request timeout
 			index := int(md.Round) % len(finalization.QC.Signers())
 			e.replicationState.sendRequestToNode(md.Seq, md.Seq, finalization.QC.Signers(), index)
@@ -1769,7 +1770,6 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block Block, finalization F
 			e.Logger.Error("Failed to index finalization", zap.Error(err))
 			return md.Digest
 		}
-		e.Logger.Info("Finalized block", zap.Uint64("round", md.Round), zap.Uint64("seq", md.Seq))
 		err = e.processReplicationState()
 
 		if err != nil {

--- a/epoch.go
+++ b/epoch.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -1747,8 +1748,8 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block Block, finalization F
 		verifiedBlock, err := block.Verify(context.Background())
 		if err != nil {
 			e.Logger.Debug("Failed verifying block", zap.Error(err))
-			// if we fail to verify the block, we should re-add to request timeout
-			index := int(md.Round) % len(finalization.QC.Signers())
+			// if we fail to verify the block, we re-add to request timeout
+			index := rand.Int() % len(e.nodes)
 			e.replicationState.sendRequestToNode(md.Seq, md.Seq, finalization.QC.Signers(), index)
 			return md.Digest
 		}

--- a/epoch.go
+++ b/epoch.go
@@ -1749,7 +1749,7 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block Block, finalization F
 		if err != nil {
 			e.Logger.Debug("Failed verifying block", zap.Error(err))
 			// if we fail to verify the block, we re-add to request timeout
-			index := rand.Int() % len(e.nodes)
+			index := rand.Int() % len(finalization.QC.Signers())
 			e.replicationState.sendRequestToNode(md.Seq, md.Seq, finalization.QC.Signers(), index)
 			return md.Digest
 		}

--- a/epoch.go
+++ b/epoch.go
@@ -1746,7 +1746,9 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block Block, finalization F
 
 		verifiedBlock, err := block.Verify(context.Background())
 		if err != nil {
-			e.Logger.Debug("Failed verifying block", zap.Error(err))
+			// if we fail to verify the block, we should re-add to request timeout
+			index := int(md.Round) % len(finalization.QC.Signers())
+			e.replicationState.sendRequestToNode(md.Seq, md.Seq, finalization.QC.Signers(), index)
 			return md.Digest
 		}
 
@@ -1767,6 +1769,7 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block Block, finalization F
 			e.Logger.Error("Failed to index finalization", zap.Error(err))
 			return md.Digest
 		}
+		e.Logger.Info("Finalized block", zap.Uint64("round", md.Round), zap.Uint64("seq", md.Seq))
 		err = e.processReplicationState()
 
 		if err != nil {

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -578,20 +578,20 @@ func TestReplicationResendsFinalizedBlocksThatFailedVerification(t *testing.T) {
 	signatureAggregator := &testSignatureAggregator{}
 	sentMessages := make(chan *simplex.Message, 100)
 	conf := simplex.EpochConfig{
-		MaxProposalWait:     simplex.DefaultMaxProposalWaitTime,
-		Logger:              l,
-		ID:                  nodes[1],
-		Signer:              &testSigner{},
-		WAL:                 wal.NewMemWAL(t),
-		Verifier:            &testVerifier{},
-		Storage:             storage,
-		Comm:                &recordingComm{
+		MaxProposalWait: simplex.DefaultMaxProposalWaitTime,
+		Logger:          l,
+		ID:              nodes[1],
+		Signer:          &testSigner{},
+		WAL:             wal.NewMemWAL(t),
+		Verifier:        &testVerifier{},
+		Storage:         storage,
+		Comm: &recordingComm{
 			Communication: noopComm(nodes),
 			SentMessages:  sentMessages,
 		},
 		BlockBuilder:        bb,
 		SignatureAggregator: signatureAggregator,
-		ReplicationEnabled: true,
+		ReplicationEnabled:  true,
 	}
 
 	e, err := simplex.NewEpoch(conf)
@@ -607,7 +607,7 @@ func TestReplicationResendsFinalizedBlocksThatFailedVerification(t *testing.T) {
 	block.verificationError = errors.New("block verification failed")
 
 	finalization, _ := newFinalizationRecord(t, l, signatureAggregator, block, nodes[0:quorum])
-	
+
 	// send the finalization to start the replication process
 	e.HandleMessage(&simplex.Message{
 		Finalization: &finalization,


### PR DESCRIPTION
I could add this for notarizations, but it seems like we are not planning on re[-requesting notarizations](https://github.com/ava-labs/Simplex/issues/214#issuecomment-3232314089)?

This solves #187 

