### PR TITLE
Skip fuzz tests in most CI runs

### DIFF
--- a/fuzz.sh
+++ b/fuzz.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env -euxo pipefail bash
 
+rand=$RANDOM
+x=$(( $rand % 5 ))
+if [[ $x -ne 0 ]]; then
+  echo "Skipping fuzz run"
+  exit 0
+fi
+
 grep -ore "Fuzz.*(f \*" * | cut -d\( -f1 | while read line; do
   file=$( echo $line | cut -d: -f1 )
   testName=$( echo $line | cut -d: -f2  )


### PR DESCRIPTION
This commit makes the fuzz tests be skipped in 4 out of 5 runs.