### PR TITLE
Comment out flakey code

### DIFF
--- a/replication_test.go
+++ b/replication_test.go
@@ -832,12 +832,12 @@ func TestReplicationNodeDiverges(t *testing.T) {
 		}
 	}
 
-	net.Connect(laggingNode.e.ID)
-	net.triggerLeaderBlockBuilder(numBlocks + 1)
-	for _, n := range net.instances {
-		n.storage.waitForBlockCommit(numBlocks - missedSeqs + 1)
-	}
-	assertEqualLedgers(t, net)
+	// net.Connect(laggingNode.e.ID)
+	// net.triggerLeaderBlockBuilder(numBlocks + 1)
+	// for _, n := range net.instances {
+	// 	n.storage.waitForBlockCommit(numBlocks - missedSeqs + 1)
+	// }
+	// assertEqualLedgers(t, net)
 }
 
 func assertEqualLedgers(t *testing.T, net *inMemNetwork) {


### PR DESCRIPTION
Should uncomment with the fix for this issue https://github.com/ava-labs/Simplex/issues/262

This test has 6 nodes. node 1 and node 4 notarize a block for round 0. Then node 4 gets disconnected.

While node 1 is still connected, it is blacklisted and only is unblacklisted by round 5. However it is a leader in round 6 and will therefore propose a block. Occasionally, nodes will still view node 1 as blacklisted(since they have not finalized the block for round `5`) and will therefore timeout.  This is the main cause of the flake, and I've commented it out until the proposed solution in #262 is implemented.