### PR TITLE
Blacklist: Prevent redeeming a node suspected in the same orbit

### DIFF
--- a/blacklist.go
+++ b/blacklist.go
@@ -315,6 +315,10 @@ func (bl *Blacklist) setNodeRedeemed(orbit uint64, nodeIndex uint16) {
 		sn := &bl.SuspectedNodes[i]
 		// Only increment the count if the orbit is the same.
 		if sn.NodeIndex == nodeIndex {
+			if sn.OrbitSuspected == orbit {
+				// It is too early to redeem a node that was suspected in the current orbit.
+				return
+			}
 			if sn.OrbitToRedeem == 0 {
 				// This is the first time the node is redeemed.
 				sn.OrbitToRedeem = orbit

--- a/blacklist_test.go
+++ b/blacklist_test.go
@@ -45,6 +45,21 @@ func TestBlacklistVerifyProposedBlacklist(t *testing.T) {
 			expectedErr: errBlacklistInvalidUpdates,
 		},
 		{
+			name: "node redeemed in the same orbit it was suspected in",
+			blacklist: Blacklist{
+				NodeCount:      4,
+				SuspectedNodes: SuspectedNodes{{NodeIndex: 3, SuspectingCount: 2, OrbitSuspected: 7, RedeemingCount: 0, OrbitToRedeem: 0}},
+			},
+			nodeCount: 4,
+			round:     29,
+			proposedBlacklist: Blacklist{
+				NodeCount:      4,
+				SuspectedNodes: SuspectedNodes{{NodeIndex: 3, SuspectingCount: 2, OrbitSuspected: 7, RedeemingCount: 1, OrbitToRedeem: 7}},
+				Updates:        []BlacklistUpdate{{Type: BlacklistOpType_NodeRedeemed, NodeIndex: 3}},
+			},
+			expectedErr: errBlacklistInvalidBlacklist,
+		},
+		{
 			name: "blacklist mismatch",
 			blacklist: Blacklist{
 				NodeCount:      4,


### PR DESCRIPTION
This commit prevents to redeem a node in a given orbit if the node has been lastly suspected in the same orbit.

The intent is to prevent a situation where a node momentarily loses connection in the round it is supposed to propose a block, it is then blacklisted after a few rounds, and the nodes then redeem it when they build blocks notarized on top of the blocks where it is redeemed in. However, since the nodes use the finalized blocks and not the notarized blocks to know whether to time out immediately on a blacklisted node or not, they might have not finalized the block where it has been redeemed in by time, and therefore they immediately time out. Since they immediately time out, the node is then blacklisted again, as it has been redeemed right before it had a chance to propose a block.

This commit prevents this problem, by preventing a node to be redeemed in the same round it was blacklisted in.

This prevents the node from being blacklisted in the orbit successive to the orbit it has been blacklisted in, because a blacklisted node cannot be blacklisted again, and once a node is redeemed in an orbit, it will not be blacklisted in that orbit again:

For example, node 2 out of 0,1,2,3 is supposed to propose a block in round 6, and then in round 10. If round 6 times out, it will not be redeemed in rounds 7 to 9, and it can start be redeemed in round 11. It won't be blacklisted in the orbit corresponding to round 10, because it is already blacklisted in that orbit, and we only vote to blacklist a node if it was not blacklisted in the round it was supposed to propose a block in.