### PR TITLE
Send Finalization When Received a Finalize Vote for a Previous Round

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -663,6 +663,14 @@ func (e *Epoch) handleFinalizeVoteMessage(message *FinalizeVote, from NodeID) er
 
 	if round.finalization != nil {
 		e.Logger.Debug("Received finalize vote for an already finalized round", zap.Uint64("round", vote.Round))
+
+		if from.Equals(e.ID) {
+			return nil
+		}
+		// send the finalization to the sender in case they missed it
+		e.Comm.Send(&Message{
+			Finalization: round.finalization,
+		}, from)
 		return nil
 	}
 
@@ -1113,7 +1121,7 @@ func (e *Epoch) rebroadcastPastFinalizeVotes() error {
 			}
 			finalizeVoteMessage = msg
 		}
-		e.Logger.Debug("Rebroadcasting finalization", zap.Uint64("round", r), zap.Uint64("seq", finalizeVoteMessage.FinalizeVote.Finalization.Seq))
+		e.Logger.Debug("Rebroadcasting finalize vote", zap.Uint64("round", r), zap.Uint64("seq", finalizeVoteMessage.FinalizeVote.Finalization.Seq))
 		e.Comm.Broadcast(finalizeVoteMessage)
 	}
 

--- a/testutil/node.go
+++ b/testutil/node.go
@@ -49,7 +49,7 @@ func NewSimplexNode(t *testing.T, nodeID simplex.NodeID, net *InMemNetwork, conf
 		ingress: make(chan struct {
 			msg  *simplex.Message
 			from simplex.NodeID
-		}, 100)}
+		}, 1000)}
 
 	ti.currentTime.Store(epochConfig.StartTime.UnixMilli())
 


### PR DESCRIPTION
1. A node fails to produce a finalization for a round.  
2. The node does not advance to the next round(maybe there are no blocks to be built)
3. The node triggers `rebroadcastFinalizeVotes` to try to make progress.  
4. All other nodes have already finalized that round. So they drop the finalize vote message.
5. The node still sees no progress and keeps rebroadcasting.  
8. With no new blocks being built, the node remains stuck in this loop using unnecessary network bandwidth.
