### PR TITLE
Store Block Proposal Before Writing to WAL

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -1820,7 +1820,6 @@ func (e *Epoch) createBlockVerificationTask(block Block, from NodeID, vote Vote)
 			zap.Uint64("round", md.Round),
 			zap.Stringer("digest", md.Digest))
 
-
 		// We might have received votes and finalizations from future rounds before we received this block.
 		// So load the messages into our round data structure now that we have created it.
 		err = e.maybeLoadFutureMessages()
@@ -2490,14 +2489,7 @@ func (e *Epoch) startRound() error {
 	// We're not the leader, make sure if a block is not notarized within a timely manner,
 	// we will agree on an empty block.
 	e.monitorProgress(e.round)
-
-	// If we're not the leader, check if we have received a proposal earlier for this round
-	msgsForRound, exists := e.futureMessages[string(leaderForCurrentRound)][e.round]
-	if !exists || msgsForRound.proposal == nil {
-		return nil
-	}
-
-	return e.handleBlockMessage(msgsForRound.proposal, leaderForCurrentRound)
+	return nil
 }
 
 func (e *Epoch) doProposed(block VerifiedBlock) error {


### PR DESCRIPTION
Logs from a ten node network.


```
[12-10|15:26:06.842] DEBUG Simplex/epoch.go:2233 Wrote block to WAL {"test": "TestLongRunningProcess", "myNodeID": 82, "round": 4, "size": 67, "digest": "642b3be865d7762ddc3b..."}
Broadcasting proposal message from 527faee73290a003 to 1c6c8e76e438f5cf
Broadcasting proposal message from 527faee73290a003 to 20ac90fedf552476
Broadcasting proposal message from 527faee73290a003 to 31ca8f75bb094c50
Broadcasting proposal message from 527faee73290a003 to 4d1e385acb250b64
Broadcasting proposal message from 527faee73290a003 to 6beab2eb7328f7a1
Broadcasting proposal message from 527faee73290a003 to a31e35078437147e
Broadcasting proposal message from 527faee73290a003 to c618c205d0415a3f
Broadcasting proposal message from 527faee73290a003 to e2f8bb2e7cc838db
Broadcasting proposal message from 527faee73290a003 to f6544302d944754a
[12-10|15:26:06.842] DEBUG Simplex/epoch.go:2246 Proposal broadcast {"test": "TestLongRunningProcess", "myNodeID": 82, "round": 4, "size": 67, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 32, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 198, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG Simplex/epoch.go:1821 Persisted block to WAL {"test": "TestLongRunningProcess", "myNodeID": 32, "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 28, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 107, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG Simplex/epoch.go:1821 Persisted block to WAL {"test": "TestLongRunningProcess", "myNodeID": 28, "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 49, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 77, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG Simplex/epoch.go:1821 Persisted block to WAL {"test": "TestLongRunningProcess", "myNodeID": 49, "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG Simplex/epoch.go:1821 Persisted block to WAL {"test": "TestLongRunningProcess", "myNodeID": 198, "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 226, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG Simplex/epoch.go:1821 Persisted block to WAL {"test": "TestLongRunningProcess", "myNodeID": 107, "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG Simplex/epoch.go:1821 Persisted block to WAL {"test": "TestLongRunningProcess", "myNodeID": 226, "round": 3, "digest": "16d2d8f9d19276f43a78..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 226, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 226, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG Simplex/epoch.go:1821 Persisted block to WAL {"test": "TestLongRunningProcess", "myNodeID": 77, "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 226, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG Simplex/epoch.go:1821 Persisted block to WAL {"test": "TestLongRunningProcess", "myNodeID": 226, "round": 4, "digest": "642b3be865d7762ddc3b..."}
[12-10|15:26:06.842] DEBUG testutil/logger.go:66 Received block message {"test": "TestLongRunningProcess", "myNodeID": 163, "from": "527faee73290a003", "round": 4, "digest": "642b3be865d7762ddc3b..."}
panic: unable to store proposed block for round 4. node id 527faee73290a003. our node id 226
```


Explanation:  We call handleBlockMessage() twice, which creates two block verification tasks and since we write to the `wal` before checking if we can store the proposal we end up double storing in the wal.
 
1. startRound() 
2. maybeLoadFutureMessages()
  a. handleBlockMessage()
  b. async block verification task()
3. check futureMsgForRound later in startRound.
  a. call handle block message
  b. async block verification task()

2b and 3b lead to two block verification tasks being run at the same time. 
