### PR TITLE
Silence Nodes in testReplicationEmptyNotarization 

### DIFF
--- a/replication_test.go
+++ b/replication_test.go
@@ -1261,10 +1261,8 @@ func testReplicationEmptyNotarizationsTail(t *testing.T, nodes []simplex.NodeID,
 	for _, n := range net.Instances {
 		n.Silence()
 	}
-	
+
 	net.StartInstances()
-
-
 
 	net.Disconnect(laggingNode.E.ID)
 	net.SetAllNodesMessageFilter(onlyAllowEmptyRoundMessages)

--- a/replication_test.go
+++ b/replication_test.go
@@ -285,6 +285,10 @@ func testReplicationEmptyNotarizations(t *testing.T, nodes []simplex.NodeID, end
 	NewSimplexNode(t, nodes[4], net, newNodeConfig(nodes[4]))
 	laggingNode := NewSimplexNode(t, nodes[5], net, newNodeConfig(nodes[5]))
 
+	for _, n := range net.Instances {
+		n.Silence()
+	}
+
 	net.StartInstances()
 
 	net.Disconnect(laggingNode.E.ID)
@@ -1254,7 +1258,13 @@ func testReplicationEmptyNotarizationsTail(t *testing.T, nodes []simplex.NodeID,
 	NewSimplexNode(t, nodes[4], net, newNodeConfig(nodes[4]))
 	laggingNode := NewSimplexNode(t, nodes[5], net, newNodeConfig(nodes[5]))
 
+	for _, n := range net.Instances {
+		n.Silence()
+	}
+	
 	net.StartInstances()
+
+
 
 	net.Disconnect(laggingNode.E.ID)
 	net.SetAllNodesMessageFilter(onlyAllowEmptyRoundMessages)


### PR DESCRIPTION
I presume github ci  flakes because these tests use up too much memory. Not sure if silencing the nodes will reduce the memory usage but could be worth a try