### PR TITLE
Fix haveNotFinalizedNotarizedRound method

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -2879,7 +2879,7 @@ func (e *Epoch) haveNotFinalizedNotarizedRound() (uint64, bool) {
 		if round.finalization != nil || round.notarization == nil {
 			continue
 		}
-		
+
 		if !found {
 			minRoundNum = round.num
 			found = true


### PR DESCRIPTION
Updates the method `haveNotFinalizedNotarizedRound` to actually check if the round is notarized but not finalized. Without this check, we essentially always return true here https://github.com/ava-labs/Simplex/blob/3779d0753a74033325b5122c8cf52df9813d9588/util.go#L317

and end up unnecessarily calling `rebroadcastFinalizationVotes` which is wasteful. 