### PR TITLE
Set Log Level to Info in CI

### DIFF
--- a/testutil/logger_test.go
+++ b/testutil/logger_test.go
@@ -28,10 +28,9 @@ func TestSilence(t *testing.T) {
 		return nil
 	})
 
-	l1.Debug("Debug message")
 	l1.Info("Info message")
+	l1.Info("Second info message")
 
-	l2.Debug("Debug message")
 	l2.Info("Info message")
 
 	require.Equal(t, 2, c)

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -2,6 +2,8 @@
 
 set -o pipefail
 
+export LOG_LEVEL=info
+
 go test -v -race ./... | tee out.log
 
 if [[ $? -ne 0 ]];then


### PR DESCRIPTION
Added an optional env variable that our logger can read from.  
Example usage

```
LOG_LEVEL=warn go test -timeout 30s -run ^TestReplicationEmptyNotarizationsTail$ github.com/ava-labs/simplex -v 
```