### PR TITLE
Fix Double Start Round Bug

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -1276,11 +1276,11 @@ func (e *Epoch) persistEmptyNotarization(emptyVotes *EmptyVoteSet, shouldBroadca
 	emptyNotarization := emptyVotes.emptyNotarization
 	emptyNotarizationRecord := NewEmptyNotarizationRecord(emptyNotarization)
 	if err := e.WAL.Append(emptyNotarizationRecord); err != nil {
-		e.Logger.Error("Failed to append empty block record to WAL", zap.Error(err))
+		e.Logger.Error("Failed to append empty notarization record to WAL", zap.Error(err))
 		return err
 	}
 
-	e.Logger.Debug("Persisted empty block to WAL",
+	e.Logger.Debug("Persisted empty notarization to WAL",
 		zap.Int("size", len(emptyNotarizationRecord)),
 		zap.Uint64("round", emptyNotarization.Vote.Round))
 

--- a/epoch.go
+++ b/epoch.go
@@ -899,8 +899,8 @@ func (e *Epoch) handleVoteMessage(message *Vote, from NodeID) error {
 		return nil
 	}
 
-	if round.notarization != nil {
-		e.Logger.Debug("Round already notarized", zap.Uint64("round", vote.Round))
+	if round.notarization != nil || round.finalization != nil {
+		e.Logger.Debug("Round already notarized or finalized", zap.Uint64("round", vote.Round))
 		return nil
 	}
 
@@ -1510,8 +1510,8 @@ func (e *Epoch) handleNotarizationMessage(message *Notarization, from NodeID) er
 	// Can we handle this notarization right away or should we handle it later?
 	round, exists := e.rounds[vote.Round]
 	// If we have already notarized the round, no need to continue
-	if exists && round.notarization != nil {
-		e.Logger.Debug("Received a notarization for an already notarized round")
+	if exists && (round.notarization != nil || round.finalization != nil) {
+		e.Logger.Debug("Received a notarization for an already notarized or finalized round")
 		return nil
 	}
 

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -1517,7 +1517,7 @@ func TestRejectsOldNotarizationAndVotes(t *testing.T) {
 	ctx := context.Background()
 	nodes := []NodeID{{1}, {2}, {3}, {4}}
 	initialBlock := createBlocks(t, nodes, 1)[0]
-	conf, wal, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[1], testutil.NewNoopComm(nodes), bb)
+	conf, wal, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[3], testutil.NewNoopComm(nodes), bb)
 	storage.Index(ctx, initialBlock.VerifiedBlock, initialBlock.Finalization)
 
 	e, err := NewEpoch(conf)


### PR DESCRIPTION
After merging in the replication code we updated our `handleNotarizationMessage` to accept messages for previous rounds. This can be dangerous because `handleNotarization` processes the notarization and can call `startRound` in `doNotarization`. This is problematic because if we have already called `startRound` we may run into idompotency issues such as

-- calling `monitorProgress` twice on a round, potentially causing us to save many duplicate empty votes & empty notarizations to the wal.
-- calling build block twice(not an issue since we guard for this when trying to persist the block, but we do end up building two blocks)