### PR TITLE
Pass In round to `maybeAssembleEmptyNotarization`

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -2328,6 +2328,12 @@ func (e *Epoch) metadata() ProtocolMetadata {
 }
 
 func (e *Epoch) triggerEmptyBlockNotarization(round uint64) {
+	if e.round > round {
+		e.Logger.Debug("Not triggering empty block notarization because we advanced to a higher round",
+			zap.Uint64("round", round), zap.Uint64("currentRound", e.round))
+		return
+	}
+
 	emptyVote := ToBeSignedEmptyVote{EmptyVoteMetadata: EmptyVoteMetadata{
 		Round: round,
 		Epoch: e.Epoch,


### PR DESCRIPTION
`createBlockVerificationTask` is run and scheduled asynchronously from the main Epoch thread. This is leads to a potential error if we have advanced the round in between scheduling the task and running it.

This scenario leads to us halting the epoch. 

1. schedule block verification for round 0.
2. advance round (say from empty notarization for round 0)
3. begin block verification for round 0.
4. block verification fails so we call `triggerEmptyBlockNotarization`.
5. `triggerEmptyBlockNotarization` adds the empty vote for round 0, but then calls `maybeAssembleEmptyNotarization`.
6. `maybeAssembleEmptyNotarization` uses the epoch round and tries to assemble an empty notarization for round 1.
7. round 1 does not exist in the empty round map so we error.