### PR TITLE
Start Round During Replication

### DIFF
--- a/replication_state.go
+++ b/replication_state.go
@@ -318,6 +318,25 @@ func (r *ReplicationState) GetLowestRound() *QuorumRound {
 	return lowestRound
 }
 
+// GetHighestRound returns the highest round known to the replicator.
+func (r *ReplicationState) GetHighestRound() uint64 {
+	var highestRound uint64
+
+	for round, qr := range r.rounds {
+		if highestRound < round {
+			highestRound = qr.GetRound()
+		}
+	}
+
+	for _, qr := range r.seqs {
+		if qr.block.BlockHeader().Round > highestRound {
+			highestRound = qr.block.BlockHeader().Round
+		}
+	}
+
+	return highestRound
+}
+
 func (r *ReplicationState) GetBlockWithSeq(seq uint64) Block {
 	block, _, _ := r.GetFinalizedBlockForSequence(seq)
 	if block != nil {


### PR DESCRIPTION
After replicating the most recent finalization we need to advance the round and monitor that rounds progress. Other nodes may be relying on our node for an empty vote to complete a quorum, but since we are not monitoring the round we will never send one.

This PR fixes that bug which could have potentially halted our chain. It does so by checking if the round has advanced after processing a finalization, and if the advanced round is the highest round then we can call monitor progress.