### PR TITLE
Broadcast Replication Request On Startup

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -273,6 +273,7 @@ func (e *Epoch) Start() error {
 	}
 	// Only init receiving messages once you have initialized the data structures required for it.
 	defer func() {
+		e.broadcastReplicationSync()
 		e.canReceiveMessages.Store(true)
 	}()
 	return e.restoreFromWal()
@@ -500,8 +501,6 @@ func (e *Epoch) broadcastReplicationSync() {
 // resumeFromWal resumes the epoch from the records of the write ahead log.
 func (e *Epoch) resumeFromWal(highestRoundRecord *walRound) error {
 	e.Logger.Info("Most relevant record recovered from WAL", zap.Uint64("round", highestRoundRecord.round), zap.Stringer("relevant", highestRoundRecord))
-
-	e.broadcastReplicationSync()
 
 	// Handle the most relevant record based on priority: finalization > notarization > emptyNotarization > emptyVote > block
 	if highestRoundRecord.finalization != nil {

--- a/epoch.go
+++ b/epoch.go
@@ -478,7 +478,10 @@ func (e *Epoch) loadFinalizationRecord(r []byte) error {
 // in case we are behind and need to catch up. Potentially, there are no more messages being sent in the network,
 // so this method triggers other nodes to send us the messages we missed while we were down.
 func (e *Epoch) broadcastReplicationSync() {
+	e.lock.Lock()
 	latestQR := e.getLatestVerifiedQuorumRound()
+	defer e.lock.Unlock()
+
 	var latestRound uint64
 	if latestQR != nil {
 		latestRound = latestQR.GetRound()

--- a/epoch.go
+++ b/epoch.go
@@ -273,8 +273,8 @@ func (e *Epoch) Start() error {
 	}
 	// Only init receiving messages once you have initialized the data structures required for it.
 	defer func() {
-		e.broadcastReplicationSync()
 		e.canReceiveMessages.Store(true)
+		e.broadcastReplicationSync()
 	}()
 	return e.restoreFromWal()
 }

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -957,11 +957,8 @@ func TestRecoveryAndBroadcast(t *testing.T) {
 		ReplicationEnabled: true,
 	}
 	normalNode1 := testutil.NewControlledSimplexNode(t, nodes[0], net, testEpochConfig)
-	normalNode1.Silence()
 	normalNode2 := testutil.NewControlledSimplexNode(t, nodes[1], net, testEpochConfig)
-	normalNode2.Silence()
 	normalNode3 := testutil.NewControlledSimplexNode(t, nodes[2], net, testEpochConfig)
-	// normalNode3.Silence()
 	laggingNode := testutil.NewControlledSimplexNode(t, nodes[3], net, &testutil.TestNodeConfig{
 		ReplicationEnabled: true,
 		InitialStorage:     storageData[:2],

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -969,14 +969,6 @@ func TestRecoveryAndBroadcast(t *testing.T) {
 	require.Equal(t, startSeq, normalNode3.Storage.NumBlocks())
 	require.Equal(t, uint64(2), laggingNode.Storage.NumBlocks())
 
-	blockBytes, err := storageData[0].VerifiedBlock.Bytes()
-	require.NoError(t, err)
-	blockRecord := BlockRecord(storageData[0].VerifiedBlock.BlockHeader(), blockBytes)
-	_, finalizationRecord := testutil.NewFinalizationRecord(t, laggingNode.E.EpochConfig.Logger, laggingNode.E.EpochConfig.SignatureAggregator, storageData[0].VerifiedBlock, nodes)
-
-	laggingNode.WAL.Append(blockRecord)
-	laggingNode.WAL.Append(finalizationRecord)
-
 	normalNode1.Start()
 	normalNode2.Start()
 	normalNode3.Start()


### PR DESCRIPTION
This PR adds a broadcasting a replication request when a node starts in order to check if it has synced up with the network. If we are behind, we will get a replication response that will kick start the replication process. If we are not behind, then other nodes will disregard our request. 