### PR TITLE
Remove Lock In Basic Scheduler

### DIFF
--- a/sched.go
+++ b/sched.go
@@ -16,7 +16,6 @@ type BasicScheduler struct {
 	closed  atomic.Bool
 	running sync.WaitGroup
 	tasks   chan Task
-	lock    sync.RWMutex
 }
 
 func NewScheduler(logger Logger, maxTasks uint64) *BasicScheduler {
@@ -38,9 +37,6 @@ func (as *BasicScheduler) Size() int {
 }
 
 func (as *BasicScheduler) Close() {
-	as.lock.RLock()
-	defer as.lock.RUnlock()
-
 	as.closed.Store(true)
 	close(as.tasks)
 	defer as.running.Wait()
@@ -59,9 +55,6 @@ func (as *BasicScheduler) run() {
 }
 
 func (as *BasicScheduler) Schedule(task Task) {
-	as.lock.RLock()
-	defer as.lock.RUnlock()
-
 	if as.closed.Load() {
 		return
 	}


### PR DESCRIPTION
otherwise we may deadlock when calling `Close`. 

one thread has the scheduler locked in `Close`, while waiting for `as.running.Wait()`, the other thread is simultaneously trying to schedule a task in `func (as *BasicScheduler) Schedule(task Task) {` but it cannot acquire the lock since its being held by `Close`


Update: This lock isn't even used so i am removing it