### PR TITLE
Fix Flake In TestReplicationNodeDiverges

### DIFF
--- a/replication_test.go
+++ b/replication_test.go
@@ -742,12 +742,6 @@ func TestReplicationNodeDiverges(t *testing.T) {
 			if msg.Notarization != nil && msg.Notarization.Vote.Round == 0 {
 				return false
 			}
-			if msg.FinalizeVote != nil && msg.FinalizeVote.Finalization.Round == 0 {
-				return false
-			}
-			if msg.Finalization != nil && msg.Finalization.Finalization.Round == 0 {
-				return false
-			}
 			return true
 		},
 	)

--- a/replication_test.go
+++ b/replication_test.go
@@ -733,9 +733,22 @@ func TestReplicationNodeDiverges(t *testing.T) {
 	// we disconnect lagging node first so that it doesn't send the notarized block to any other nodes
 	net.Disconnect(laggingNode.E.ID)
 	net.SetAllNodesMessageFilter(
-		// block sending votes from round 0 to ensure all nodes will timeout
-		func(msg *simplex.Message, _, to simplex.NodeID) bool {
-			return !(msg.VoteMessage != nil && msg.VoteMessage.Vote.Round == 0)
+		// Block all round-0 messages: lagging node's in-flight notarization
+		// broadcast can race past Disconnect, so blocking only votes is unsafe.
+		func(msg *simplex.Message, _, _ simplex.NodeID) bool {
+			if msg.VoteMessage != nil && msg.VoteMessage.Vote.Round == 0 {
+				return false
+			}
+			if msg.Notarization != nil && msg.Notarization.Vote.Round == 0 {
+				return false
+			}
+			if msg.FinalizeVote != nil && msg.FinalizeVote.Finalization.Round == 0 {
+				return false
+			}
+			if msg.Finalization != nil && msg.Finalization.Finalization.Round == 0 {
+				return false
+			}
+			return true
 		},
 	)
 

--- a/replication_test.go
+++ b/replication_test.go
@@ -733,8 +733,7 @@ func TestReplicationNodeDiverges(t *testing.T) {
 	// we disconnect lagging node first so that it doesn't send the notarized block to any other nodes
 	net.Disconnect(laggingNode.E.ID)
 	net.SetAllNodesMessageFilter(
-		// Block all round-0 messages: lagging node's in-flight notarization
-		// broadcast can race past Disconnect, so blocking only votes is unsafe.
+		// block in-flight votes & notarization from round 0 to ensure all nodes will timeout
 		func(msg *simplex.Message, _, _ simplex.NodeID) bool {
 			if msg.VoteMessage != nil && msg.VoteMessage.Vote.Round == 0 {
 				return false


### PR DESCRIPTION
After the lagging node persists the notarization in the WAL, it will broadcast it to the network. The test blocks votes from being sent in order for the nodes to not have notarizations, but it doesn't block notarizations from the lagging node. 

```
 === RUN   TestReplicationNodeDiverges                                                                                                                          
  [04-19|22:33:04.110] INFO Simplex/epoch.go:223 Starting Simplex Epoch {"ID": "0100000000000000", "nodes": "[0100000000000000 0200000000000000 0300000000000000 
  0400000000000000 0500000000000000 0600000000000000]"}                                                                                                          
  [04-19|22:33:04.110] INFO Simplex/epoch.go:223 Starting Simplex Epoch {"ID": "0200000000000000", "nodes": "[…]"}                                               
  [04-19|22:33:04.110] INFO Simplex/epoch.go:223 Starting Simplex Epoch {"ID": "0300000000000000", "nodes": "[…]"}                                               
  [04-19|22:33:04.110] INFO Simplex/epoch.go:223 Starting Simplex Epoch {"ID": "0400000000000000", "nodes": "[…]"}                                               
  [04-19|22:33:04.111] INFO Simplex/epoch.go:223 Starting Simplex Epoch {"ID": "0500000000000000", "nodes": "[…]"}                                               
  [04-19|22:33:04.111] INFO Simplex/epoch.go:223 Starting Simplex Epoch {"ID": "0600000000000000", "nodes": "[…]"}                                               
  [04-19|22:33:04.113] INFO Simplex/notarization.go:47 Collected Quorum of votes {"round": 0, "votes": 4}                                                        
  [04-19|22:33:04.113] INFO Simplex/epoch.go:2801 Moving to a new round {"prev round": 0, "next round": 1, "prev leader": "0100000000000000", "next leader":     
  "0200000000000000"}                                                                                                                                            
  [04-19|22:33:04.113] INFO Simplex/epoch.go:2664 It is time to build a block {"round": 0}                                                                       
  [04-19|22:33:04.113] INFO Simplex/epoch.go:2664 It is time to build a block {"round": 0}                                                                       
  [04-19|22:33:04.114] INFO Simplex/epoch.go:2664 It is time to build a block {"round": 0}
  [04-19|22:33:04.114] INFO Simplex/epoch.go:2664 It is time to build a block {"round": 0}                                                                       
  [04-19|22:33:04.114] INFO Simplex/epoch.go:2664 It is time to build a block {"round": 0}                                                                       
  [04-19|22:33:04.114] INFO Simplex/epoch.go:2801 Moving to a new round {"prev round": 0, "next round": 1, "prev leader": "0100000000000000", "next leader":     
  "0200000000000000"}                                                                                                                                            
  [04-19|22:33:04.114] INFO Simplex/epoch.go:2801 Moving to a new round {"prev round": 0, "next round": 1, "prev leader": "0100000000000000", "next leader":
  "0200000000000000"}                                                                                                                                            
  [04-19|22:33:04.114] INFO Simplex/epoch.go:2801 Moving to a new round {"prev round": 0, "next round": 1, "prev leader": "0100000000000000", "next leader":
  "0200000000000000"}                                                                                                                                            
  [04-19|22:33:04.114] INFO Simplex/epoch.go:2664 It is time to build a block {"round": 1}
  [04-19|22:33:04.114] INFO Simplex/epoch.go:2801 Moving to a new round {"prev round": 0, "next round": 1, "prev leader": "0100000000000000", "next leader":     
  "0200000000000000"}                                                                                                                                            
  [04-19|22:33:04.114] INFO Simplex/epoch.go:2801 Moving to a new round {"prev round": 0, "next round": 1, "prev leader": "0100000000000000", "next leader":     
  "0200000000000000"}                                                                                                                                            
  [04-19|22:33:04.115] INFO Simplex/epoch.go:1365 Committed block {"round": 0, "sequence": 0, "digest": "20922b5461e2b791fc45..."}
  [04-19|22:33:04.116] INFO Simplex/epoch.go:1365 Committed block {"round": 0, "sequence": 0, "digest": "20922b5461e2b791fc45..."}                               
  [04-19|22:33:04.116] INFO testutil/comm.go:78 Enqueuing message                                                                                                
  [04-19|22:33:04.116] INFO Simplex/epoch.go:1365 Committed block {"round": 0, "sequence": 0, "digest": "20922b5461e2b791fc45..."}                               
  [04-19|22:33:04.116] INFO Simplex/epoch.go:1365 Committed block {"round": 0, "sequence": 0, "digest": "20922b5461e2b791fc45..."}                               
  [04-19|22:33:04.116] INFO Simplex/epoch.go:1365 Committed block {"round": 0, "sequence": 0, "digest": "20922b5461e2b791fc45..."}                               
  [04-19|22:33:04.116] INFO testutil/comm.go:78 Enqueuing message                                                                                                
  [04-19|22:33:04.116] INFO testutil/comm.go:78 Enqueuing message                                                                                                
      util.go:230:                                                                                                                                               
                Error Trace:    /home/runner/work/Simplex/Simplex/testutil/util.go:230                                                                           
                                                        /home/runner/work/Simplex/Simplex/testutil/controlled.go:80                                              
                                                        /home/runner/work/Simplex/Simplex/replication_test.go:744                                                
                Error:          Should be false                                                                                                                  
                Test:           TestReplicationNodeDiverges                                                                                                      
                Messages:       should not have notarized 0 for node 0200000000000000                                                                            
  --- FAIL: TestReplicationNodeDiverges (0.02s)
```