### PR TITLE
check if blacklist is empty when retrieving from storage

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -2238,6 +2238,10 @@ func (e *Epoch) verifyProposalMetadataAndBlacklist(block Block) bool {
 		expectedPrevDigest = bh.Prev
 
 		prevBlacklist = prevBlock.Blacklist()
+
+		if prevBlacklist.IsEmpty() {
+			prevBlacklist = NewBlacklist(uint16(len(e.nodes)))
+		}
 	}
 
 	if err := prevBlacklist.VerifyProposedBlacklist(block.Blacklist(), e.round); err != nil {


### PR DESCRIPTION
we may be retrieving the genesis or a snowman block with an empty blacklist, ensure it is properly initialized

https://github.com/ava-labs/avalanchego/pull/5317#discussion_r3153905362