### PR TITLE
Rename BlockType.String receiver from state to bt

### DIFF
--- a/msm/block_type.go
+++ b/msm/block_type.go
@@ -14,8 +14,8 @@ const (
 	BlockTypeNewEpoch
 )
 
-func (state BlockType) String() string {
-	switch state {
+func (bt BlockType) String() string {
+	switch bt {
 	case BlockTypeNormal:
 		return "Normal"
 	case BlockTypeTelock:
@@ -25,7 +25,7 @@ func (state BlockType) String() string {
 	case BlockTypeNewEpoch:
 		return "NewEpoch"
 	default:
-		return fmt.Sprintf("UnknownBlockType(%d)", state)
+		return fmt.Sprintf("UnknownBlockType(%d)", bt)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Renames the `BlockType.String()` receiver from `state` to `bt` to match the type, per the suggestion in #378.

Fixes #378

## Test plan
- [x] `go build ./msm/...`
- [x] `go test ./msm/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)