### PR TITLE
Potential Block Decision Cleanup?

### DIFF
--- a/msm/build_decision.go
+++ b/msm/build_decision.go
@@ -14,31 +14,12 @@ import (
 
 // blockBuildingDecision represents the decision of whether we should build a block at the current time,
 // and if so, whether we should also transition to a new epoch along the way.
-type blockBuildingDecision int8
-
-const (
-	decisionUndefined               blockBuildingDecision = iota
-	decisionBuild                                         // We should build a block, and we don't need to transition to a new epoch.
-	decisionTransitionEpoch                               // We should transition to a new epoch immediately, but we don't need to build a block.
-	decisionBuildAndTransitionEpoch                       // We should build a block and transition to a new epoch along the way.
-	decisionContextCanceled
-)
-
-func (bbd blockBuildingDecision) String() string {
-	switch bbd {
-	case decisionUndefined:
-		return "undefined"
-	case decisionBuild:
-		return "build block"
-	case decisionTransitionEpoch:
-		return "transition epoch"
-	case decisionBuildAndTransitionEpoch:
-		return "build block and transition epoch"
-	case decisionContextCanceled:
-		return "context canceled"
-	default:
-		return "unknown"
-	}
+// pChainHeight is the P-chain height sampled at the time of the decision; sampling it later
+// might be inconsistent with the decision that was made.
+type blockBuildingDecision struct {
+	buildInnerBlock bool
+	transitionEpoch bool
+	pChainHeight    uint64
 }
 
 // PChainProgressListener listens for changes in the P-chain height.
@@ -60,23 +41,22 @@ type blockBuildingDecider struct {
 
 // shouldBuildBlock determines whether we should build a block at the current time,
 // based on the current P-chain height and whether we should transition to a new epoch.
-// It returns a blockBuildingDecision, the P-chain height sampled at the time of deciding,
-// and an error if the decision cannot be made.
-// The P-chain height is returned because sampling the P-chain height afterwards might be inconsistent with the decision that was made.
+// It returns a blockBuildingDecision describing what to do, or an error (including
+// ctx.Err() if the context is cancelled while waiting).
 func (bbd *blockBuildingDecider) shouldBuildBlock(
 	ctx context.Context,
-) (blockBuildingDecision, uint64, error) {
+) (blockBuildingDecision, error) {
 	for {
 		pChainHeight := bbd.getPChainHeight()
 
 		shouldTransitionEpoch, err := bbd.hasValidatorSetChanged(pChainHeight)
 		if err != nil {
-			return decisionUndefined, 0, err
+			return blockBuildingDecision{}, err
 		}
 
 		if shouldTransitionEpoch {
 			// If we should transition to a new epoch, maybe we can also build a block along the way.
-			return bbd.buildBlockWithEpochTransition(ctx), pChainHeight, nil
+			return bbd.buildBlockWithEpochTransition(ctx, pChainHeight)
 		}
 
 		// Else, we don't need to transition to a new epoch, but maybe we should build a block.
@@ -85,7 +65,7 @@ func (bbd *blockBuildingDecider) shouldBuildBlock(
 
 		// If the context was cancelled in the meantime, abandon evaluation.
 		if ctx.Err() != nil {
-			return decisionContextCanceled, 0, nil
+			return blockBuildingDecision{}, ctx.Err()
 		}
 
 		// If we've reached here, either the P-chain height has changed, or a block is ready to be built.
@@ -99,7 +79,10 @@ func (bbd *blockBuildingDecider) shouldBuildBlock(
 		// Else, we have reached here because a block is ready to be built, and the P-chain height has not changed,
 		// which means we should build a block.
 
-		return decisionBuild, pChainHeight, nil
+		return blockBuildingDecision{
+			buildInnerBlock: true,
+			pChainHeight:    pChainHeight,
+		}, nil
 	}
 }
 
@@ -130,7 +113,7 @@ func (bbd *blockBuildingDecider) waitForPChainChangeOrPendingBlock(ctx context.C
 // It waits up to a limited amount of time (bbd.maxBlockBuildingWaitTime) for a block to be ready to be built,
 // and if no block is ready by then, it returns the decision to transition epoch without building a block.
 // Otherwise, it returns the decision to build a block and transition epoch along the way.
-func (bbd *blockBuildingDecider) buildBlockWithEpochTransition(ctx context.Context) blockBuildingDecision {
+func (bbd *blockBuildingDecider) buildBlockWithEpochTransition(ctx context.Context, pChainHeight uint64) (blockBuildingDecision, error) {
 	impatientContext, cancel := context.WithTimeout(ctx, bbd.maxBlockBuildingWaitTime)
 	defer cancel()
 
@@ -139,15 +122,19 @@ func (bbd *blockBuildingDecider) buildBlockWithEpochTransition(ctx context.Conte
 	bbd.waitForPendingBlock(impatientContext)
 
 	if ctx.Err() != nil {
-		return decisionContextCanceled
+		return blockBuildingDecision{}, ctx.Err()
 	}
 
-	if impatientContext.Err() != nil {
-		// We have returned from waitForPendingBlock because impatientContext has timed out,
-		// which means we don't need to build a block.
-		return decisionTransitionEpoch
+	decision := blockBuildingDecision{
+		transitionEpoch: true,
+		pChainHeight:    pChainHeight,
 	}
 
-	// Block is ready to be built
-	return decisionBuildAndTransitionEpoch
+	// If impatientContext timed out, no block is ready and we only transition epoch.
+	// Otherwise, waitForPendingBlock returned because a block is ready to be built.
+	if impatientContext.Err() == nil {
+		decision.buildInnerBlock = true
+	}
+
+	return decision, nil
 }

--- a/msm/build_decision_test.go
+++ b/msm/build_decision_test.go
@@ -35,10 +35,9 @@ func TestShouldBuildBlock_VMSignalsBlock(t *testing.T) {
 		getPChainHeight:        func() uint64 { return 100 },
 	}
 
-	result, pChainHeight, err := bbd.shouldBuildBlock(t.Context())
+	decision, err := bbd.shouldBuildBlock(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, decisionBuild, result)
-	require.Equal(t, uint64(100), pChainHeight)
+	require.Equal(t, blockBuildingDecision{buildInnerBlock: true, pChainHeight: 100}, decision)
 }
 
 func TestShouldBuildBlock_ContextCanceled(t *testing.T) {
@@ -60,9 +59,8 @@ func TestShouldBuildBlock_ContextCanceled(t *testing.T) {
 		getPChainHeight:        func() uint64 { return 100 },
 	}
 
-	result, _, err := bbd.shouldBuildBlock(ctx)
-	require.NoError(t, err)
-	require.Equal(t, decisionContextCanceled, result)
+	_, err := bbd.shouldBuildBlock(ctx)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestShouldBuildBlock_PChainHeightChangeTriggersEpochTransition(t *testing.T) {
@@ -92,10 +90,9 @@ func TestShouldBuildBlock_PChainHeightChangeTriggersEpochTransition(t *testing.T
 		getPChainHeight: func() uint64 { return pChainHeight.Load() },
 	}
 
-	result, resultPChainHeight, err := bbd.shouldBuildBlock(t.Context())
+	decision, err := bbd.shouldBuildBlock(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, decisionTransitionEpoch, result)
-	require.Equal(t, uint64(200), resultPChainHeight)
+	require.Equal(t, blockBuildingDecision{transitionEpoch: true, pChainHeight: 200}, decision)
 }
 
 func TestShouldBuildBlock_PChainHeightChangeButNoEpochTransition(t *testing.T) {
@@ -128,10 +125,9 @@ func TestShouldBuildBlock_PChainHeightChangeButNoEpochTransition(t *testing.T) {
 		getPChainHeight:        func() uint64 { return pChainHeight.Load() },
 	}
 
-	result, resultPChainHeight, err := bbd.shouldBuildBlock(t.Context())
+	decision, err := bbd.shouldBuildBlock(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, decisionBuild, result)
-	require.Equal(t, uint64(200), resultPChainHeight)
+	require.Equal(t, blockBuildingDecision{buildInnerBlock: true, pChainHeight: 200}, decision)
 }
 
 func TestShouldBuildBlock_EpochTransitionWithVMBlock(t *testing.T) {
@@ -148,10 +144,9 @@ func TestShouldBuildBlock_EpochTransitionWithVMBlock(t *testing.T) {
 		getPChainHeight:        func() uint64 { return 100 },
 	}
 
-	result, pChainHeight, err := bbd.shouldBuildBlock(t.Context())
+	decision, err := bbd.shouldBuildBlock(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, decisionBuildAndTransitionEpoch, result)
-	require.Equal(t, uint64(100), pChainHeight)
+	require.Equal(t, blockBuildingDecision{buildInnerBlock: true, transitionEpoch: true, pChainHeight: 100}, decision)
 }
 
 func TestShouldBuildBlock_EpochTransitionWithoutVMBlock(t *testing.T) {
@@ -170,10 +165,9 @@ func TestShouldBuildBlock_EpochTransitionWithoutVMBlock(t *testing.T) {
 		getPChainHeight:        func() uint64 { return 100 },
 	}
 
-	result, pChainHeight, err := bbd.shouldBuildBlock(t.Context())
+	decision, err := bbd.shouldBuildBlock(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, decisionTransitionEpoch, result)
-	require.Equal(t, uint64(100), pChainHeight)
+	require.Equal(t, blockBuildingDecision{transitionEpoch: true, pChainHeight: 100}, decision)
 }
 
 func TestShouldBuildBlock_EpochTransitionContextCanceled(t *testing.T) {
@@ -196,7 +190,6 @@ func TestShouldBuildBlock_EpochTransitionContextCanceled(t *testing.T) {
 		getPChainHeight:        func() uint64 { return 100 },
 	}
 
-	result, _, err := bbd.shouldBuildBlock(ctx)
-	require.NoError(t, err)
-	require.Equal(t, decisionContextCanceled, result)
+	_, err := bbd.shouldBuildBlock(ctx)
+	require.ErrorIs(t, err, context.Canceled)
 }

--- a/msm/msm.go
+++ b/msm/msm.go
@@ -290,36 +290,35 @@ func (sm *StateMachine) buildBlockNormalOp(ctx context.Context, parentBlock Stat
 		PrevVMBlockSeq:        computePrevVMBlockSeq(parentBlock, prevBlockSeq),
 	}
 
-	blockBuildingDecider := sm.createBlockBuildingDecider(parentBlock)
-	decisionToBuildBlock, pChainHeight, err := blockBuildingDecider.shouldBuildBlock(ctx)
+	decision, err := sm.createBlockBuildingDecider(parentBlock).shouldBuildBlock(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	sm.Logger.Debug("Block building decision", zap.Stringer("decision", decisionToBuildBlock))
+	sm.Logger.Debug("Block building decision",
+		zap.Bool("buildInnerBlock", decision.buildInnerBlock),
+		zap.Bool("transitionEpoch", decision.transitionEpoch),
+		zap.Uint64("pChainHeight", decision.pChainHeight),
+	)
 
-	var childBlock VMBlock
-
-	switch decisionToBuildBlock {
-	case decisionBuild, decisionBuildAndTransitionEpoch:
-		// If we reached here, we need to build a new block, and maybe also transition to a new epoch.
-		return sm.buildBlockAndMaybeTransitionEpoch(ctx, parentBlock, simplexMetadata, simplexBlacklist, childBlock, decisionToBuildBlock, newSimplexEpochInfo, pChainHeight)
-	case decisionTransitionEpoch:
-		// If we reached here, we don't need to build an inner block, yet we need to transition to a new epoch.
-		// Initiate the epoch transition by setting the next P-chain reference height for the new epoch info,
-		// and build a block without an inner block.
-		newSimplexEpochInfo.NextPChainReferenceHeight = pChainHeight
-		sm.Logger.Debug("Transitioning epoch without building block", zap.Uint64("newPChainRefHeight", pChainHeight))
-		return sm.wrapBlock(parentBlock, nil, newSimplexEpochInfo, pChainHeight, simplexMetadata, simplexBlacklist), nil
-	case decisionContextCanceled:
-		return nil, ctx.Err()
-	default:
-		return nil, fmt.Errorf("unknown block building decision %d", decisionToBuildBlock)
+	var innerBlock VMBlock
+	if decision.buildInnerBlock {
+		// TODO: This P-chain height should be taken from the ICM epoch
+		innerBlock, err = sm.BlockBuilder.BuildBlock(ctx, decision.pChainHeight)
+		if err != nil {
+			return nil, err
+		}
 	}
+
+	if decision.transitionEpoch {
+		newSimplexEpochInfo.NextPChainReferenceHeight = decision.pChainHeight
+	}
+
+	return sm.wrapBlock(parentBlock, innerBlock, newSimplexEpochInfo, decision.pChainHeight, simplexMetadata, simplexBlacklist), nil
 }
 
-func (sm *StateMachine) createBlockBuildingDecider(parentBlock StateMachineBlock) blockBuildingDecider {
-	blockBuildingDecider := blockBuildingDecider{
+func (sm *StateMachine) createBlockBuildingDecider(parentBlock StateMachineBlock) *blockBuildingDecider {
+	return &blockBuildingDecider{
 		logger:                   sm.Logger,
 		maxBlockBuildingWaitTime: sm.MaxBlockBuildingWaitTime,
 		pChainListener:           sm.PChainProgressListener,
@@ -352,31 +351,6 @@ func (sm *StateMachine) createBlockBuildingDecider(parentBlock StateMachineBlock
 			return false, nil
 		},
 	}
-	return blockBuildingDecider
-}
-
-func (sm *StateMachine) buildBlockAndMaybeTransitionEpoch(ctx context.Context,
-	parentBlock StateMachineBlock,
-	simplexMetadata []byte,
-	simplexBlacklist []byte,
-	childBlock VMBlock,
-	decisionToBuildBlock blockBuildingDecision,
-	newSimplexEpochInfo SimplexEpochInfo,
-	pChainHeight uint64) (*StateMachineBlock, error) {
-	// TODO: This P-chain height should be taken from the ICM epoch
-	childBlock, err := sm.BlockBuilder.BuildBlock(ctx, pChainHeight)
-	if err != nil {
-		return nil, err
-	}
-
-	if decisionToBuildBlock == decisionBuildAndTransitionEpoch {
-		// We need to also transition to a new epoch, in addition to building an inner block,
-		// so set the next P-chain reference height for the new epoch info.
-		newSimplexEpochInfo.NextPChainReferenceHeight = pChainHeight
-		sm.Logger.Debug("Transitioning epoch after building block", zap.Uint64("newPChainRefHeight", pChainHeight))
-	}
-
-	return sm.wrapBlock(parentBlock, childBlock, newSimplexEpochInfo, pChainHeight, simplexMetadata, simplexBlacklist), nil
 }
 
 // buildBlockZero builds the first ever block for Simplex,


### PR DESCRIPTION
While review `reconfig-3` i was going to comment on a way i thought we could simplify this. instead had claude run through and implement my idea and am creating this PR to visualize the diff.

The main change as summarized by claude

> Replace the blockBuildingDecision enum with a struct (buildInnerBlock, transitionEpoch, pChainHeight) so callers can act on the decision's components directly instead of decoding an
  opaque value. buildBlockNormalOp collapses to straight-line code, dropping the buildBlockAndMaybeTransitionEpoch helper, and context cancellation is now returned as a plain ctx.Err()
   rather than a sentinel enum value.


Lemme know if you think this is a nice cleanup(feel free to close the pr too)