### PR TITLE
Transition epochs if needed even if no transaction occurs

### DIFF
--- a/msm/fake_node_test.go
+++ b/msm/fake_node_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -44,13 +43,7 @@ func TestFakeNodeEpochChangesDespiteEmptyMempool(t *testing.T) {
 		node.tryFinalizeNextBlock()
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-
-	defer wg.Wait()
-
 	go func() {
-		defer wg.Done()
 		pChainHeight.Store(200)
 	}()
 
@@ -71,7 +64,6 @@ func TestFakeNodeEpochChangesDespiteEmptyMempool(t *testing.T) {
 
 		if node.isLastBlockSealing() {
 			go func() {
-				defer wg.Done()
 				pChainHeight.Store(300)
 			}()
 		}

--- a/msm/fake_node_test.go
+++ b/msm/fake_node_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,6 +15,68 @@ import (
 	"github.com/ava-labs/simplex"
 	"github.com/stretchr/testify/require"
 )
+
+func TestFakeNodeEpochChangesDespiteEmptyMempool(t *testing.T) {
+	validatorSetRetriever := validatorSetRetriever{
+		resultMap: map[uint64]NodeBLSMappings{
+			0:   {{BLSKey: []byte{1}, Weight: 1, NodeID: [20]byte{1}}, {BLSKey: []byte{2}, Weight: 1, NodeID: [20]byte{2}}},
+			100: {{BLSKey: []byte{1}, Weight: 1, NodeID: [20]byte{1}}, {BLSKey: []byte{2}, Weight: 1, NodeID: [20]byte{2}}},
+			200: {{BLSKey: []byte{1}, Weight: 1, NodeID: [20]byte{1}}, {BLSKey: []byte{2}, Weight: 2, NodeID: [20]byte{2}},
+				{BLSKey: []byte{3}, Weight: 1, NodeID: [20]byte{3}}},
+			300: {{BLSKey: []byte{1}, Weight: 1, NodeID: [20]byte{1}}, {BLSKey: []byte{2}, Weight: 2, NodeID: [20]byte{2}},
+				{BLSKey: []byte{3}, Weight: 3, NodeID: [20]byte{3}}, {BLSKey: []byte{4}, Weight: 1, NodeID: [20]byte{4}}},
+		},
+	}
+
+	var pChainHeight atomic.Uint64
+	pChainHeight.Store(100)
+	node := newFakeNode(t)
+	node.sm.GetValidatorSet = validatorSetRetriever.getValidatorSet
+	node.sm.GetPChainHeight = func() uint64 {
+		return pChainHeight.Load()
+	}
+	node.mempoolEmpty = true
+	node.sm.MaxBlockBuildingWaitTime = 100 * time.Millisecond
+
+	// This will be the zero block
+	node.buildAndNotarizeBlock()
+	if node.canFinalize() {
+		node.tryFinalizeNextBlock()
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	defer wg.Wait()
+
+	go func() {
+		defer wg.Done()
+		pChainHeight.Store(200)
+	}()
+
+	for node.Epoch() == 1 {
+		node.buildAndNotarizeBlock()
+		if node.canFinalize() {
+			node.tryFinalizeNextBlock()
+		}
+		if flipCoin() {
+			node.sm.ApprovalsRetriever = &approvalsRetriever{
+				result: []ValidatorSetApproval{{NodeID: [20]byte{1}, PChainHeight: 200, Signature: []byte{1}, AuxInfoSeqDigest: [32]byte{}}},
+			}
+		} else {
+			node.sm.ApprovalsRetriever = &approvalsRetriever{
+				result: []ValidatorSetApproval{{NodeID: [20]byte{2}, PChainHeight: 200, Signature: []byte{2}, AuxInfoSeqDigest: [32]byte{}}},
+			}
+		}
+
+		if node.isLastBlockSealing() {
+			go func() {
+				defer wg.Done()
+				pChainHeight.Store(300)
+			}()
+		}
+	}
+}
 
 func TestFakeNode(t *testing.T) {
 	validatorSetRetriever := validatorSetRetriever{
@@ -337,6 +400,14 @@ func (fn *fakeNode) isNextBlockTelock(nextIndex int) bool {
 	return fn.blocks[nextIndex].block.Metadata.SimplexEpochInfo.SealingBlockSeq > 0
 }
 
+func (fn *fakeNode) isLastBlockSealing() bool {
+	if len(fn.blocks) == 0 {
+		return false
+	}
+	last := fn.blocks[len(fn.blocks)-1]
+	return last.block.Metadata.SimplexEpochInfo.BlockValidationDescriptor != nil
+}
+
 func (fn *fakeNode) buildAndNotarizeBlock() {
 	vmBlock, block := fn.buildBlock()
 	require.NoError(fn.t, fn.sm.VerifyBlock(context.Background(), block))
@@ -386,7 +457,12 @@ func (fn *fakeNode) prepareMetadataAndPrevBlockDigest() (*simplex.ProtocolMetada
 	return lastMD, lastBlockDigest
 }
 
-func (fn *fakeNode) BuildBlock(context.Context, uint64) (VMBlock, error) {
+func (fn *fakeNode) BuildBlock(ctx context.Context, _ uint64) (VMBlock, error) {
+	if fn.mempoolEmpty {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
 	// Count the number of inner blocks in the chain
 	var count int
 	for _, bs := range fn.blocks {

--- a/msm/fake_node_test.go
+++ b/msm/fake_node_test.go
@@ -43,9 +43,7 @@ func TestFakeNodeEpochChangesDespiteEmptyMempool(t *testing.T) {
 		node.tryFinalizeNextBlock()
 	}
 
-	go func() {
-		pChainHeight.Store(200)
-	}()
+	pChainHeight.Store(200)
 
 	for node.Epoch() == 1 {
 		node.buildAndNotarizeBlock()
@@ -63,9 +61,7 @@ func TestFakeNodeEpochChangesDespiteEmptyMempool(t *testing.T) {
 		}
 
 		if node.isLastBlockSealing() {
-			go func() {
-				pChainHeight.Store(300)
-			}()
+			pChainHeight.Store(300)
 		}
 	}
 }

--- a/msm/msm.go
+++ b/msm/msm.go
@@ -285,7 +285,7 @@ func (sm *StateMachine) verifyNonZeroBlock(ctx context.Context, block *StateMach
 	return block.InnerBlock.Verify(ctx)
 }
 
-// buildBlockNormalOp builds a block while not trying to transition to a new epoch.
+// buildBlockNormalOp builds a block while potentially also transitioning to a new epoch, depending on the P-chain.
 func (sm *StateMachine) buildBlockNormalOp(ctx context.Context, parentBlock StateMachineBlock, simplexMetadata, simplexBlacklist []byte, prevBlockSeq uint64) (*StateMachineBlock, error) {
 	// Since in the previous block, we were not transitioning to a new epoch,
 	// the P-chain reference height and epoch of the new block should remain the same.
@@ -295,7 +295,12 @@ func (sm *StateMachine) buildBlockNormalOp(ctx context.Context, parentBlock Stat
 		PrevVMBlockSeq:        computePrevVMBlockSeq(parentBlock, prevBlockSeq),
 	}
 
-	blockBuildingDecider := sm.createBlockBuildingDecider(parentBlock)
+	return sm.buildBlockOrTransitionEpoch(ctx, parentBlock, simplexMetadata, simplexBlacklist, newSimplexEpochInfo)
+}
+
+// buildBlockOrTransitionEpoch builds a block and decides whether to transition to a new epoch based on the P-chain height and validator set changes.
+func (sm *StateMachine) buildBlockOrTransitionEpoch(ctx context.Context, parentBlock StateMachineBlock, simplexMetadata, simplexBlacklist []byte, newSimplexEpochInfo SimplexEpochInfo) (*StateMachineBlock, error) {
+	blockBuildingDecider := sm.createBlockBuildingDecider(newSimplexEpochInfo.PChainReferenceHeight)
 	decisionToBuildBlock, err := blockBuildingDecider.shouldBuildBlock(ctx)
 	if err != nil {
 		return nil, err
@@ -324,7 +329,7 @@ func (sm *StateMachine) buildBlockNormalOp(ctx context.Context, parentBlock Stat
 	return sm.wrapBlock(parentBlock, innerBlock, newSimplexEpochInfo, decisionToBuildBlock.pChainHeight, simplexMetadata, simplexBlacklist), nil
 }
 
-func (sm *StateMachine) createBlockBuildingDecider(parentBlock StateMachineBlock) blockBuildingDecider {
+func (sm *StateMachine) createBlockBuildingDecider(pChainReferenceHeight uint64) blockBuildingDecider {
 	blockBuildingDecider := blockBuildingDecider{
 		logger:                   sm.Logger,
 		maxBlockBuildingWaitTime: sm.MaxBlockBuildingWaitTime,
@@ -337,7 +342,7 @@ func (sm *StateMachine) createBlockBuildingDecider(parentBlock StateMachineBlock
 			// and the new validator set defined by the given pChainHeight.
 			// If they are different, then we should transition to a new epoch.
 
-			currentValidatorSet, err := sm.GetValidatorSet(parentBlock.Metadata.SimplexEpochInfo.PChainReferenceHeight)
+			currentValidatorSet, err := sm.GetValidatorSet(pChainReferenceHeight)
 			if err != nil {
 				return false, err
 			}
@@ -351,7 +356,7 @@ func (sm *StateMachine) createBlockBuildingDecider(parentBlock StateMachineBlock
 				sm.Logger.Debug("Validator set has changed, should transition epoch",
 					zap.String("currentValidatorSet", fmt.Sprintf("%v", currentValidatorSet.NodeWeights())),
 					zap.String("newValidatorSet", fmt.Sprintf("%v", newValidatorSet.NodeWeights())),
-					zap.Uint64("currentPChainRefHeight", parentBlock.Metadata.SimplexEpochInfo.PChainReferenceHeight),
+					zap.Uint64("currentPChainRefHeight", pChainReferenceHeight),
 					zap.Uint64("newPChainHeight", pChainHeight))
 				return true, nil
 			}
@@ -636,7 +641,7 @@ func (sm *StateMachine) buildBlockEpochSealed(ctx context.Context, parentBlock S
 		PrevVMBlockSeq:            computePrevVMBlockSeq(parentBlock, prevBlockSeq),
 	}
 
-	_, finalization, err := sm.GetBlock(sealingBlockSeq, [32]byte{})
+	sealingBlock, finalization, err := sm.GetBlock(sealingBlockSeq, [32]byte{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve sealing block at sequence %d: %w", sealingBlockSeq, err)
 	}
@@ -658,12 +663,7 @@ func (sm *StateMachine) buildBlockEpochSealed(ctx context.Context, parentBlock S
 	}
 
 	// TODO: This P-chain height should be taken from the ICM epoch
-	childBlock, err := sm.BlockBuilder.BuildBlock(ctx, sm.GetPChainHeight())
-	if err != nil {
-		return nil, err
-	}
-
-	return sm.wrapBlock(parentBlock, childBlock, newSimplexEpochInfo, parentBlock.Metadata.PChainHeight, simplexMetadata, simplexBlacklist), nil
+	return sm.buildBlockOrTransitionEpoch(ctx, sealingBlock, simplexMetadata, simplexBlacklist, newSimplexEpochInfo)
 }
 
 // constructSimplexZeroBlockSimplexEpochInfo constructs the SimplexEpochInfo for the zero block, which is the first ever block built by Simplex.


### PR DESCRIPTION
This commit makes the MSM monitor the P-chain height when building the first block of a new epoch, right after an epoch transition.

This is needed so that if we have no transaction traffic, but a need to transition to a new epoch, we won't get stuck in the old epoch.