### PR TITLE
Remove Logger from NewFinalization

### DIFF
--- a/epoch.go
+++ b/epoch.go
@@ -1178,7 +1178,11 @@ func (e *Epoch) maybeCollectFinalization(round *Round) error {
 }
 
 func (e *Epoch) assembleFinalization(round *Round, finalizationVotes []*FinalizeVote) error {
-	finalization, err := NewFinalization(e.Logger, e.signatureAggregator, finalizationVotes)
+	for _, vote := range finalizationVotes {
+		e.Logger.Debug("Collected a finalize vote from node", zap.Stringer("NodeID", vote.Signature.Signer), zap.Uint64("round", vote.Finalization.Round))
+	}
+
+	finalization, err := NewFinalization(e.signatureAggregator, finalizationVotes)
 	if err != nil {
 		return err
 	}

--- a/epoch.go
+++ b/epoch.go
@@ -1179,7 +1179,7 @@ func (e *Epoch) maybeCollectFinalization(round *Round) error {
 
 func (e *Epoch) assembleFinalization(round *Round, finalizationVotes []*FinalizeVote) error {
 	for _, vote := range finalizationVotes {
-		e.Logger.Debug("Collected a finalize vote from node", zap.Stringer("NodeID", vote.Signature.Signer), zap.Uint64("round", vote.Finalization.Round))
+		e.Logger.Debug("Collected a finalize vote from node", zap.Stringer("NodeID", vote.Signature.Signer), zap.Uint64("round", vote.Finalization.Round), zap.Uint64("seq", vote.Finalization.Seq))
 	}
 
 	finalization, err := NewFinalization(e.signatureAggregator, finalizationVotes)

--- a/epoch_test.go
+++ b/epoch_test.go
@@ -446,7 +446,7 @@ func TestEpochIndexFinalization(t *testing.T) {
 	// 1 & 2
 
 	sigAggr := e.SignatureAggregatorCreator(conf.Comm.Nodes())
-	finalization, _ := testutil.NewFinalizationRecord(t, conf.Logger, sigAggr, firstBlock, e.Comm.Nodes().NodeIDs())
+	finalization, _ := testutil.NewFinalizationRecord(t, sigAggr, firstBlock, e.Comm.Nodes().NodeIDs())
 	testutil.InjectTestFinalization(t, e, &finalization, nodes[1])
 
 	storage.WaitForBlockCommit(2)
@@ -525,8 +525,6 @@ func TestEpochConsecutiveProposalsDoNotGetVerified(t *testing.T) {
 // TestEpochIncreasesRoundAfterFinalization ensures that the epochs round is incremented
 // if we receive a finalization for the current round(even if it is not the next seq to commit)
 func TestEpochIncreasesRoundAfterFinalization(t *testing.T) {
-	l := testutil.MakeLogger(t, 1)
-
 	bb := testutil.NewTestBlockBuilder()
 	nodes := []NodeID{{1}, {2}, {3}, {4}, {5}, {6}}
 
@@ -544,7 +542,7 @@ func TestEpochIncreasesRoundAfterFinalization(t *testing.T) {
 
 	// create the finalized block
 	sigAggr := e.SignatureAggregatorCreator(conf.Comm.Nodes())
-	finalization, _ := testutil.NewFinalizationRecord(t, l, sigAggr, block, nodes)
+	finalization, _ := testutil.NewFinalizationRecord(t, sigAggr, block, nodes)
 	testutil.InjectTestFinalization(t, e, &finalization, nodes[1])
 
 	storage.WaitForBlockCommit(1)
@@ -1088,7 +1086,7 @@ func TestEpochQCSignedByNonExistentNodes(t *testing.T) {
 	})
 
 	t.Run("finalization with unknown signer isn't taken into account", func(t *testing.T) {
-		finalization, _ := testutil.NewFinalizationRecord(t, conf.Logger, sigAggr, block, []NodeID{{2}, {3}, {5}})
+		finalization, _ := testutil.NewFinalizationRecord(t, sigAggr, block, []NodeID{{2}, {3}, {5}})
 
 		err = e.HandleMessage(&Message{
 			Finalization: &finalization,
@@ -1099,7 +1097,7 @@ func TestEpochQCSignedByNonExistentNodes(t *testing.T) {
 	})
 
 	t.Run("finalization with double signer isn't taken into account", func(t *testing.T) {
-		finalization, _ := testutil.NewFinalizationRecord(t, conf.Logger, sigAggr, block, []NodeID{{2}, {3}, {3}})
+		finalization, _ := testutil.NewFinalizationRecord(t, sigAggr, block, []NodeID{{2}, {3}, {3}})
 
 		err = e.HandleMessage(&Message{
 			Finalization: &finalization,

--- a/notarization.go
+++ b/notarization.go
@@ -80,7 +80,7 @@ func NewNotarization(logger Logger, signatureAggregator SignatureAggregator, vot
 }
 
 // NewFinalization builds a Finalization from [finalizeVotes].
-func NewFinalization(logger Logger, signatureAggregator SignatureAggregator, finalizeVotes []*FinalizeVote) (Finalization, error) {
+func NewFinalization(signatureAggregator SignatureAggregator, finalizeVotes []*FinalizeVote) (Finalization, error) {
 	voteCount := len(finalizeVotes)
 	if voteCount == 0 {
 		return Finalization{}, ErrorNoVotes
@@ -92,7 +92,6 @@ func NewFinalization(logger Logger, signatureAggregator SignatureAggregator, fin
 		if vote.Finalization.Digest != expectedDigest {
 			return Finalization{}, ErrorInvalidFinalizationDigest
 		}
-		logger.Debug("Collected a finalize vote from node", zap.Stringer("NodeID", vote.Signature.Signer), zap.Uint64("round", vote.Finalization.Round))
 		signatures = append(signatures, vote.Signature)
 	}
 

--- a/notarization_test.go
+++ b/notarization_test.go
@@ -110,7 +110,6 @@ func TestNewNotarization(t *testing.T) {
 }
 
 func TestNewFinalization(t *testing.T) {
-	l := MakeLogger(t, 1)
 	tests := []struct {
 		name                 string
 		finalizeVotes        []*simplex.FinalizeVote
@@ -169,7 +168,7 @@ func TestNewFinalization(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			finalization, err := simplex.NewFinalization(l, tt.signatureAggregator, tt.finalizeVotes)
+			finalization, err := simplex.NewFinalization(tt.signatureAggregator, tt.finalizeVotes)
 			require.ErrorIs(t, err, tt.expectError, "expected error, got nil")
 
 			if tt.expectError == nil {

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -402,7 +402,7 @@ func TestWalWritesFinalization(t *testing.T) {
 	recordType := binary.BigEndian.Uint16(records[4])
 	require.Equal(t, record.FinalizationRecordType, recordType)
 	_, err = FinalizationFromRecord(records[4], e.QCDeserializer)
-	_, expectedFinalizationRecord := testutil.NewFinalizationRecord(t, conf.Logger, sigAggregrator, secondBlock, nodes[0:quorum])
+	_, expectedFinalizationRecord := testutil.NewFinalizationRecord(t, sigAggregrator, secondBlock, nodes[0:quorum])
 	require.NoError(t, err)
 	require.Equal(t, expectedFinalizationRecord, records[4])
 
@@ -453,7 +453,7 @@ func TestRecoverFromMultipleNotarizations(t *testing.T) {
 	wal.Append(secondNotarizationRecord)
 
 	// Create finalization record for second block
-	finalization2, finalizationRecord := testutil.NewFinalizationRecord(t, conf.Logger, sigAggr, secondBlock, nodes[0:quorum])
+	finalization2, finalizationRecord := testutil.NewFinalizationRecord(t, sigAggr, secondBlock, nodes[0:quorum])
 	wal.Append(finalizationRecord)
 
 	err = e.Start()
@@ -463,7 +463,7 @@ func TestRecoverFromMultipleNotarizations(t *testing.T) {
 	require.Equal(t, uint64(0), e.Storage.NumBlocks())
 
 	// now if we send finalization for block 1, we should index both 1 & 2
-	finalization1, _ := testutil.NewFinalizationRecord(t, conf.Logger, sigAggr, firstBlock, nodes[0:quorum])
+	finalization1, _ := testutil.NewFinalizationRecord(t, sigAggr, firstBlock, nodes[0:quorum])
 	err = e.HandleMessage(&Message{
 		Finalization: &finalization1,
 	}, nodes[1])
@@ -507,7 +507,7 @@ func TestRecoveryBlocksIndexed(t *testing.T) {
 	require.NoError(t, err)
 	wal.Append(firstNotarizationRecord)
 
-	_, finalizationBytes := testutil.NewFinalizationRecord(t, conf.Logger, sigAggr, firstBlock, nodes[0:quorum])
+	_, finalizationBytes := testutil.NewFinalizationRecord(t, sigAggr, firstBlock, nodes[0:quorum])
 	wal.Append(finalizationBytes)
 
 	protocolMetadata.Round = 1
@@ -528,9 +528,9 @@ func TestRecoveryBlocksIndexed(t *testing.T) {
 	record = BlockRecord(thirdBlock.BlockHeader(), tBytes)
 	wal.Append(record)
 
-	finalization1, _ := testutil.NewFinalizationRecord(t, conf.Logger, sigAggr, firstBlock, nodes[0:quorum])
-	finalization2, _ := testutil.NewFinalizationRecord(t, conf.Logger, sigAggr, secondBlock, nodes[0:quorum])
-	fCer3, _ := testutil.NewFinalizationRecord(t, conf.Logger, sigAggr, thirdBlock, nodes[0:quorum])
+	finalization1, _ := testutil.NewFinalizationRecord(t, sigAggr, firstBlock, nodes[0:quorum])
+	finalization2, _ := testutil.NewFinalizationRecord(t, sigAggr, secondBlock, nodes[0:quorum])
+	fCer3, _ := testutil.NewFinalizationRecord(t, sigAggr, thirdBlock, nodes[0:quorum])
 
 	conf.Storage.Index(ctx, firstBlock, finalization1)
 	conf.Storage.Index(ctx, secondBlock, finalization2)
@@ -784,7 +784,7 @@ func TestWalRecoverySetsRoundCorrectly(t *testing.T) {
 				require.NoError(t, err)
 				blockRecord1 := BlockRecord(block1.BlockHeader(), bBytes1)
 
-				_, finalizationRecord1 := testutil.NewFinalizationRecord(t, conf.Logger, conf.SignatureAggregatorCreator(conf.Comm.Nodes()), block1, nodes[0:quorum])
+				_, finalizationRecord1 := testutil.NewFinalizationRecord(t, conf.SignatureAggregatorCreator(conf.Comm.Nodes()), block1, nodes[0:quorum])
 
 				// Create empty notarization for round 0
 				emptyNotarization0 := testutil.NewEmptyNotarization(nodes[0:quorum], 0)
@@ -848,7 +848,7 @@ func TestWalRecoverySetsRoundCorrectly(t *testing.T) {
 				bBytes3, err := block3.Bytes()
 				require.NoError(t, err)
 				blockRecord3 := BlockRecord(block3.BlockHeader(), bBytes3)
-				_, finalizationRecord3 := testutil.NewFinalizationRecord(t, conf.Logger, conf.SignatureAggregatorCreator(conf.Comm.Nodes()), block3, nodes[0:quorum])
+				_, finalizationRecord3 := testutil.NewFinalizationRecord(t, conf.SignatureAggregatorCreator(conf.Comm.Nodes()), block3, nodes[0:quorum])
 
 				// Create empty notarization for round 2
 				emptyNotarization2 := testutil.NewEmptyNotarization(nodes[0:quorum], 2)
@@ -892,7 +892,7 @@ func TestWalRecoverySetsRoundCorrectly(t *testing.T) {
 				bBytes10, err := block10.Bytes()
 				require.NoError(t, err)
 				blockRecord10 := BlockRecord(block10.BlockHeader(), bBytes10)
-				_, finalizationRecord10 := testutil.NewFinalizationRecord(t, conf.Logger, conf.SignatureAggregatorCreator(conf.Comm.Nodes()), block10, nodes[0:quorum])
+				_, finalizationRecord10 := testutil.NewFinalizationRecord(t, conf.SignatureAggregatorCreator(conf.Comm.Nodes()), block10, nodes[0:quorum])
 
 				// Create empty notarization for round 5
 				emptyNotarization5 := testutil.NewEmptyNotarization(nodes[0:quorum], 5)
@@ -921,7 +921,7 @@ func TestWalRecoverySetsRoundCorrectly(t *testing.T) {
 				notarizationRecord2, err := testutil.NewNotarizationRecord(conf.Logger, conf.SignatureAggregatorCreator(conf.Comm.Nodes()), block2, nodes[0:quorum])
 				require.NoError(t, err)
 
-				_, finalizationRecord2 := testutil.NewFinalizationRecord(t, conf.Logger, conf.SignatureAggregatorCreator(conf.Comm.Nodes()), block2, nodes[0:quorum])
+				_, finalizationRecord2 := testutil.NewFinalizationRecord(t, conf.SignatureAggregatorCreator(conf.Comm.Nodes()), block2, nodes[0:quorum])
 
 				// All records for same round
 				return [][]byte{

--- a/replication_test.go
+++ b/replication_test.go
@@ -133,7 +133,7 @@ func TestReplicationAdversarialNode(t *testing.T) {
 	net.Connect(laggingNode.E.ID)
 
 	sigAggr := laggingNode.E.SignatureAggregatorCreator(laggingNode.E.Comm.Nodes())
-	finalization, _ := NewFinalizationRecord(t, laggingNode.E.Logger, sigAggr, blocks[1], nodes[:quorum])
+	finalization, _ := NewFinalizationRecord(t, sigAggr, blocks[1], nodes[:quorum])
 	finalizationMsg := &simplex.Message{
 		Finalization: &finalization,
 	}
@@ -444,7 +444,7 @@ func TestReplicationFutureFinalization(t *testing.T) {
 	require.NoError(t, err)
 
 	sigAggr := e.SignatureAggregatorCreator(conf.Comm.Nodes())
-	finalization, _ := NewFinalizationRecord(t, e.Logger, sigAggr, block, nodes[0:quorum])
+	finalization, _ := NewFinalizationRecord(t, sigAggr, block, nodes[0:quorum])
 	// send finalization
 	err = e.HandleMessage(&simplex.Message{
 		Finalization: &finalization,
@@ -631,7 +631,7 @@ func TestReplicationStuckInProposingBlock(t *testing.T) {
 	highBlock, _ := blocks[3].VerifiedBlock.(*TestBlock)
 
 	sigAggr := e.SignatureAggregatorCreator(conf.Comm.Nodes())
-	highFinalization, _ := NewFinalizationRecord(t, e.Logger, sigAggr, highBlock, nodes[0:quorum])
+	highFinalization, _ := NewFinalizationRecord(t, sigAggr, highBlock, nodes[0:quorum])
 
 	// Trigger the replication process to start by sending a finalization for a block we do not have
 	e.HandleMessage(&simplex.Message{
@@ -906,7 +906,6 @@ func testReplicationNotarizationWithoutFinalizations(t *testing.T, numBlocks uin
 
 func createBlocks(t *testing.T, nodes []simplex.NodeID, seqCount uint64) []simplex.VerifiedFinalizedBlock {
 	bb := NewTestBlockBuilder()
-	logger := MakeLogger(t, int(0))
 	ctx := context.Background()
 	data := make([]simplex.VerifiedFinalizedBlock, 0, seqCount)
 	var prev simplex.Digest
@@ -920,7 +919,7 @@ func createBlocks(t *testing.T, nodes []simplex.NodeID, seqCount uint64) []simpl
 		block, ok := bb.BuildBlock(ctx, protocolMetadata, emptyBlacklist)
 		require.True(t, ok)
 		prev = block.BlockHeader().Digest
-		finalization, _ := NewFinalizationRecord(t, logger, &TestSignatureAggregator{N: len(nodes)}, block, nodes)
+		finalization, _ := NewFinalizationRecord(t, &TestSignatureAggregator{N: len(nodes)}, block, nodes)
 		data = append(data, simplex.VerifiedFinalizedBlock{
 			VerifiedBlock: block,
 			Finalization:  finalization,
@@ -978,7 +977,7 @@ func TestReplicationVerifyNotarization(t *testing.T) {
 	block := bb.GetBuiltBlock()
 
 	sigAggr := e.SignatureAggregatorCreator(conf.Comm.Nodes())
-	finalization, _ := NewFinalizationRecord(t, e.Logger, sigAggr, block, nodes[0:quorum])
+	finalization, _ := NewFinalizationRecord(t, sigAggr, block, nodes[0:quorum])
 
 	// Trigger the replication process to start by sending a finalization for a block we do not have
 	e.HandleMessage(&simplex.Message{
@@ -1066,7 +1065,7 @@ func TestReplicationVerifyEmptyNotarization(t *testing.T) {
 	block := bb.GetBuiltBlock()
 
 	sigAggr := e.SignatureAggregatorCreator(conf.Comm.Nodes())
-	finalization, _ := NewFinalizationRecord(t, e.Logger, sigAggr, block, nodes[0:quorum])
+	finalization, _ := NewFinalizationRecord(t, sigAggr, block, nodes[0:quorum])
 
 	// Trigger the replication process to start by sending a finalization for a block we do not have
 	e.HandleMessage(&simplex.Message{

--- a/replication_timeout_test.go
+++ b/replication_timeout_test.go
@@ -595,7 +595,6 @@ func TestReplicationMalformedQuorumRound(t *testing.T) {
 func TestReplicationResendsFinalizedBlocksThatFailedVerification(t *testing.T) {
 
 	// send a block, then simultaneously send a finalization for the block
-	l := testutil.MakeLogger(t, 1)
 	bb := testutil.NewTestBlockBuilder()
 
 	nodes := []simplex.NodeID{{1}, {2}, {3}, {4}}
@@ -623,7 +622,7 @@ func TestReplicationResendsFinalizedBlocksThatFailedVerification(t *testing.T) {
 	block.VerificationError = errors.New("block verification failed")
 
 	sigAggr := e.SignatureAggregatorCreator(conf.Comm.Nodes())
-	finalization, _ := testutil.NewFinalizationRecord(t, l, sigAggr, block, nodes[0:quorum])
+	finalization, _ := testutil.NewFinalizationRecord(t, sigAggr, block, nodes[0:quorum])
 
 	// send the finalization to start the replication process
 	e.HandleMessage(&simplex.Message{
@@ -659,7 +658,7 @@ func TestReplicationResendsFinalizedBlocksThatFailedVerification(t *testing.T) {
 	block.Data = append(block.Data, 0)
 	block.ComputeDigest()
 
-	finalization, _ = testutil.NewFinalizationRecord(t, l, sigAggr, block, nodes[0:quorum])
+	finalization, _ = testutil.NewFinalizationRecord(t, sigAggr, block, nodes[0:quorum])
 	replicationResponse = &simplex.ReplicationResponse{
 		Data: []simplex.QuorumRound{
 			{

--- a/testutil/record.go
+++ b/testutil/record.go
@@ -54,13 +54,13 @@ func NewNotarizationRecord(logger simplex.Logger, signatureAggregator simplex.Si
 }
 
 // creates a new finalization
-func NewFinalizationRecord(t *testing.T, logger simplex.Logger, signatureAggregator simplex.SignatureAggregator, block simplex.VerifiedBlock, ids []simplex.NodeID) (simplex.Finalization, []byte) {
+func NewFinalizationRecord(t *testing.T, signatureAggregator simplex.SignatureAggregator, block simplex.VerifiedBlock, ids []simplex.NodeID) (simplex.Finalization, []byte) {
 	finalizations := make([]*simplex.FinalizeVote, len(ids))
 	for i, id := range ids {
 		finalizations[i] = NewTestFinalizeVote(t, block, id)
 	}
 
-	finalization, err := simplex.NewFinalization(logger, signatureAggregator, finalizations)
+	finalization, err := simplex.NewFinalization(signatureAggregator, finalizations)
 	require.NoError(t, err)
 
 	record := simplex.NewQuorumRecord(finalization.QC.Bytes(), finalization.Finalization.Bytes(), record.FinalizationRecordType)

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -122,12 +122,6 @@ func (t *testQCDeserializer) DeserializeQuorumCertificate(bytes []byte) (simplex
 	return TestQC(qc), err
 }
 
-type TestSignatureAggregatorCreator struct {
-	Err          error
-	N            int
-	IsQuorumFunc func(signatures []simplex.NodeID) bool
-}
-
 type TestSignatureAggregator struct {
 	Err          error
 	N            int

--- a/util_test.go
+++ b/util_test.go
@@ -95,7 +95,7 @@ func TestVerifyQC(t *testing.T) {
 			name: "valid finalization",
 			finalization: func() Finalization {
 				block := testutil.NewTestBlock(ProtocolMetadata{}, emptyBlacklist)
-				finalization, _ := testutil.NewFinalizationRecord(t, l, signatureAggregator, block, nodes[:quorumSize])
+				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, nodes[:quorumSize])
 				return finalization
 			}(),
 			quorumSize: quorumSize,
@@ -103,7 +103,7 @@ func TestVerifyQC(t *testing.T) {
 			name: "not enough signers",
 			finalization: func() Finalization {
 				block := testutil.NewTestBlock(ProtocolMetadata{}, emptyBlacklist)
-				finalization, _ := testutil.NewFinalizationRecord(t, l, signatureAggregator, block, nodes[:quorumSize-1])
+				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, nodes[:quorumSize-1])
 				return finalization
 			}(),
 			quorumSize:  quorumSize,
@@ -114,7 +114,7 @@ func TestVerifyQC(t *testing.T) {
 			finalization: func() Finalization {
 				block := testutil.NewTestBlock(ProtocolMetadata{}, emptyBlacklist)
 				doubleNodes := []NodeID{{1}, {2}, {3}, {4}, {4}}
-				finalization, _ := testutil.NewFinalizationRecord(t, l, signatureAggregator, block, doubleNodes)
+				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, doubleNodes)
 				return finalization
 			}(),
 			quorumSize:  quorumSize,
@@ -131,7 +131,7 @@ func TestVerifyQC(t *testing.T) {
 			finalization: func() Finalization {
 				block := testutil.NewTestBlock(ProtocolMetadata{}, emptyBlacklist)
 				signers := []NodeID{{1}, {2}, {3}, {4}, {6}}
-				finalization, _ := testutil.NewFinalizationRecord(t, l, signatureAggregator, block, signers)
+				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, signers)
 				return finalization
 			}(), quorumSize: quorumSize,
 			expectedErr: fmt.Errorf("finalization quorum certificate contains an unknown signer (0600000000000000)"),
@@ -140,7 +140,7 @@ func TestVerifyQC(t *testing.T) {
 			name: "invalid QC",
 			finalization: func() Finalization {
 				block := testutil.NewTestBlock(ProtocolMetadata{}, emptyBlacklist)
-				finalization, _ := testutil.NewFinalizationRecord(t, l, signatureAggregator, block, nodes[:quorumSize])
+				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, nodes[:quorumSize])
 				return finalization
 			}(),
 			quorumSize:  quorumSize,
@@ -182,7 +182,7 @@ func TestGetHighestQuorumRound(t *testing.T) {
 	}, emptyBlacklist)
 	notarization1, err := testutil.NewNotarization(l, signatureAggregator, block1, nodes)
 	require.NoError(t, err)
-	finalization1, _ := testutil.NewFinalizationRecord(t, l, signatureAggregator, block1, nodes)
+	finalization1, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block1, nodes)
 
 	// seq 10
 	block10 := testutil.NewTestBlock(ProtocolMetadata{Seq: 10, Round: 10}, emptyBlacklist)


### PR DESCRIPTION
i don't think we should be passing in a logger into `NewFinalization` just for one log. 