### PR TITLE
Pass validator membership to QuorumCertificate.Verify()

### DIFF
--- a/common/api.go
+++ b/common/api.go
@@ -147,15 +147,16 @@ type Nodes []Node
 func (nws Nodes) NodeIDs() []NodeID {
 	nodes := make([]NodeID, len(nws))
 	for i, nw := range nws {
-		nodes[i] = nw.Node
+		nodes[i] = nw.Id
 	}
 	return nodes
 }
 
-// Node is a struct that pairs a node with its weight in the signature aggregator.
+// Node is a struct that pairs a node ID with its weight and public key.
 type Node struct {
-	Node   NodeID
+	Id     NodeID
 	Weight uint64
+	PK     []byte
 }
 
 // SignatureAggregatorCreator creates a SignatureAggregator from a list of nodes and their weights.

--- a/common/global.go
+++ b/common/global.go
@@ -56,7 +56,7 @@ func (nodes NodeIDs) EqualWeightedNodes() Nodes {
 	weights := make(Nodes, len(nodes))
 	for i, node := range nodes {
 		weights[i] = Node{
-			Node:   node,
+			Id:     node,
 			Weight: 1,
 		}
 	}

--- a/common/msg.go
+++ b/common/msg.go
@@ -124,14 +124,14 @@ func verifyContext(signature []byte, verifier SignatureVerifier, msg []byte, con
 	return verifier.Verify(toBeSigned, signature, signers)
 }
 
-func verifyContextQC(qc QuorumCertificate, msg []byte, context string) error {
+func verifyContextQC(qc QuorumCertificate, msg []byte, context string, nodes Nodes) error {
 	sm := SignedMessage{Payload: msg, Context: context}
 	toBeSigned, err := asn1.Marshal(sm)
 	if err != nil {
 		return err
 	}
 
-	return qc.Verify(toBeSigned)
+	return qc.Verify(toBeSigned, nodes)
 }
 
 // Vote represents a signed vote for a block.
@@ -171,9 +171,9 @@ type Finalization struct {
 	QC           QuorumCertificate
 }
 
-func (f *Finalization) Verify() error {
+func (f *Finalization) Verify(nodes Nodes) error {
 	context := "ToBeSignedFinalization"
-	return verifyContextQC(f.QC, f.Finalization.Bytes(), context)
+	return verifyContextQC(f.QC, f.Finalization.Bytes(), context, nodes)
 }
 
 // Notarization represents a block that has reached a quorum of votes.
@@ -182,9 +182,9 @@ type Notarization struct {
 	QC   QuorumCertificate
 }
 
-func (n *Notarization) Verify() error {
+func (n *Notarization) Verify(nodes Nodes) error {
 	context := "ToBeSignedVote"
-	return verifyContextQC(n.QC, n.Vote.Bytes(), context)
+	return verifyContextQC(n.QC, n.Vote.Bytes(), context, nodes)
 }
 
 type BlockMessage struct {
@@ -202,9 +202,9 @@ type EmptyNotarization struct {
 	QC   QuorumCertificate
 }
 
-func (en *EmptyNotarization) Verify() error {
+func (en *EmptyNotarization) Verify(nodes Nodes) error {
 	context := "ToBeSignedEmptyVote"
-	return verifyContextQC(en.QC, en.Vote.Bytes(), context)
+	return verifyContextQC(en.QC, en.Vote.Bytes(), context, nodes)
 }
 
 type SignedMessage struct {
@@ -218,7 +218,7 @@ type QuorumCertificate interface {
 	Signers() []NodeID
 	// Verify checks whether the nodes participated in creating this QuorumCertificate,
 	// signed the given message.
-	Verify(msg []byte) error
+	Verify(msg []byte, nodes Nodes) error
 	// Bytes returns a raw representation of the given QuorumCertificate.
 	Bytes() []byte
 }

--- a/msm/encoding.go
+++ b/msm/encoding.go
@@ -259,7 +259,7 @@ func (nbms NodeBLSMappings) NodeWeights() common.Nodes {
 	nodeWeights := make(common.Nodes, len(nbms))
 	for i, nbm := range nbms {
 		nodeWeights[i] = common.Node{
-			Node:   nbm.NodeID[:],
+			Id:     nbm.NodeID[:],
 			Weight: nbm.Weight,
 		}
 	}

--- a/msm/util_test.go
+++ b/msm/util_test.go
@@ -125,7 +125,7 @@ func newSignatureAggregatorCreator() common.SignatureAggregatorCreator {
 	return func(weights []common.Node) common.SignatureAggregator {
 		s := &signatureAggregator{weightByNodeID: make(map[string]uint64, len(weights))}
 		for _, nw := range weights {
-			s.weightByNodeID[string(nw.Node)] = nw.Weight
+			s.weightByNodeID[string(nw.Id)] = nw.Weight
 			s.totalWeight += nw.Weight
 		}
 		return s

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -744,7 +744,7 @@ func (e *Epoch) handleFinalizationMessage(message *common.Finalization, from com
 		return nil
 	}
 
-	if err := VerifyQC(message.QC, e.Logger, "Finalization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, message, from); err != nil {
+	if err := VerifyQC(message.QC, e.Logger, "Finalization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, message, from, e.nodes); err != nil {
 		e.Logger.Debug("Received an invalid finalization",
 			zap.Int("round", int(message.Finalization.Round)),
 			zap.Stringer("NodeID", from))
@@ -1603,7 +1603,7 @@ func (e *Epoch) handleEmptyNotarizationMessage(emptyNotarization *common.EmptyNo
 	}
 
 	// Otherwise, this round is not notarized or finalized yet, so verify the empty notarization and store it.
-	if err := VerifyQC(emptyNotarization.QC, e.Logger, "Empty notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, emptyNotarization, from); err != nil {
+	if err := VerifyQC(emptyNotarization.QC, e.Logger, "Empty notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, emptyNotarization, from, e.nodes); err != nil {
 		return nil
 	}
 
@@ -1659,7 +1659,7 @@ func (e *Epoch) handleNotarizationMessage(message *common.Notarization, from com
 		return nil
 	}
 
-	if err := VerifyQC(message.QC, e.Logger, "Notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, message, from); err != nil {
+	if err := VerifyQC(message.QC, e.Logger, "Notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, message, from, e.nodes); err != nil {
 		return nil
 	}
 
@@ -3211,20 +3211,20 @@ func (e *Epoch) verifyQuorumRound(q common.QuorumRound, from common.NodeID) erro
 
 	if q.Finalization != nil {
 		// extra check needed if we have a finalized block
-		err := VerifyQC(q.Finalization.QC, e.Logger, "Finalization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.Finalization, from)
+		err := VerifyQC(q.Finalization.QC, e.Logger, "Finalization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.Finalization, from, e.nodes)
 		if err != nil {
 			return errors.New("invalid finalization")
 		}
 	}
 
 	if q.Notarization != nil {
-		if err := VerifyQC(q.Notarization.QC, e.Logger, "Notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.Notarization, from); err != nil {
+		if err := VerifyQC(q.Notarization.QC, e.Logger, "Notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.Notarization, from, e.nodes); err != nil {
 			return fmt.Errorf("invalid notarization: %v", err)
 		}
 	}
 
 	if q.EmptyNotarization != nil {
-		err := VerifyQC(q.EmptyNotarization.QC, e.Logger, "Empty notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.EmptyNotarization, from)
+		err := VerifyQC(q.EmptyNotarization.QC, e.Logger, "Empty notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.EmptyNotarization, from, e.nodes)
 		if err != nil {
 			return fmt.Errorf("invalid empty notarization QC: %v", err)
 		}
@@ -3428,7 +3428,7 @@ func (e *Epoch) nextSeqToCommit() uint64 {
 // SortNodes sorts the nodes in place by their byte representations.
 func SortNodes(nodes common.Nodes) {
 	slices.SortFunc(nodes, func(a, b common.Node) int {
-		return bytes.Compare(a.Node[:], b.Node[:])
+		return bytes.Compare(a.Id[:], b.Id[:])
 	})
 }
 

--- a/simplex/epoch_failover_test.go
+++ b/simplex/epoch_failover_test.go
@@ -1227,7 +1227,7 @@ func runCrashAndRestartExecution(t *testing.T, e *Epoch, bb *testutil.TestBlockB
 
 	// Case 2:
 	t.Run(fmt.Sprintf("%s-with-crash", t.Name()), func(t *testing.T) {
-		conf, _, _ := testutil.DefaultTestNodeEpochConfig(t, nodes[0].Node, testutil.NewNoopComm(nodes.NodeIDs()), bbAfterCrash)
+		conf, _, _ := testutil.DefaultTestNodeEpochConfig(t, nodes[0].Id, testutil.NewNoopComm(nodes.NodeIDs()), bbAfterCrash)
 		conf.Storage = cloneStorage
 		conf.WAL = cloneWAL
 

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -1677,7 +1677,7 @@ func advanceRound(t *testing.T, e *Epoch, bb *testutil.TestBlockBuilder, notariz
 		// start at one since our node has already voted
 		sigAggr := e.SignatureAggregatorCreator(nodes)
 		n, err := testutil.NewNotarization(e.Logger, sigAggr, block, nodes.NodeIDs()[0:quorum])
-		testutil.InjectTestNotarization(t, e, n, nodes[1].Node)
+		testutil.InjectTestNotarization(t, e, n, nodes[1].Id)
 
 		e.WAL.(*testutil.TestWAL).AssertNotarization(block.Metadata.Round)
 		require.NoError(t, err)
@@ -1686,10 +1686,10 @@ func advanceRound(t *testing.T, e *Epoch, bb *testutil.TestBlockBuilder, notariz
 
 	if finalize {
 		for i := 0; i <= quorum; i++ {
-			if nodes[i].Node.Equals(e.ID) {
+			if nodes[i].Id.Equals(e.ID) {
 				continue
 			}
-			testutil.InjectTestFinalizeVote(t, e, block, nodes[i].Node)
+			testutil.InjectTestFinalizeVote(t, e, block, nodes[i].Id)
 		}
 
 		if nextSeqToCommit != block.Metadata.Seq {

--- a/simplex/util.go
+++ b/simplex/util.go
@@ -19,7 +19,7 @@ import (
 )
 
 type verifiableMessage interface {
-	Verify() error
+	Verify(nodes common.Nodes) error
 }
 
 // RetrieveLastIndexFromStorage retrieves the latest block and finalization from storage.
@@ -54,7 +54,7 @@ func hasSomeNodeSignedTwice(nodeIDs []common.NodeID, logger common.Logger) (comm
 	return common.NodeID{}, false
 }
 
-func VerifyQC(qc common.QuorumCertificate, logger common.Logger, messageType string, isQuorum func(signers []common.NodeID) bool, eligibleSigners map[string]struct{}, messageToVerify verifiableMessage, from common.NodeID) error {
+func VerifyQC(qc common.QuorumCertificate, logger common.Logger, messageType string, isQuorum func(signers []common.NodeID) bool, eligibleSigners map[string]struct{}, messageToVerify verifiableMessage, from common.NodeID, nodes common.Nodes) error {
 	if qc == nil {
 		logger.Debug("Received nil QuorumCertificate")
 		return fmt.Errorf("nil QuorumCertificate")
@@ -82,7 +82,7 @@ func VerifyQC(qc common.QuorumCertificate, logger common.Logger, messageType str
 		}
 	}
 
-	if err := messageToVerify.Verify(); err != nil {
+	if err := messageToVerify.Verify(nodes); err != nil {
 		if len(from) > 0 {
 			logger.Debug(fmt.Sprintf("%s quorum certificate is invalid", messageType), zap.Stringer("NodeID", from), zap.Error(err))
 		} else {

--- a/simplex/util_test.go
+++ b/simplex/util_test.go
@@ -58,16 +58,22 @@ func TestRetrieveFromStorage(t *testing.T) {
 
 type unverifiableQC struct{}
 
-func (u *unverifiableQC) Verify() error {
+func (u *unverifiableQC) Verify(Nodes) error {
 	return fmt.Errorf("invalid QC")
 }
 
 func TestVerifyQC(t *testing.T) {
 	l := testutil.MakeLogger(t, 0)
-	nodes := []NodeID{{1}, {2}, {3}, {4}, {5}}
+	var nodeIDs []NodeID
+	var nodes Nodes
+	for _, nodeID := range []NodeID{{1}, {2}, {3}, {4}, {5}} {
+		nodes = append(nodes, Node{Id: nodeID})
+		nodeIDs = append(nodeIDs, nodeID)
+	}
+
 	eligibleSigners := make(map[string]struct{})
 	for _, n := range nodes {
-		eligibleSigners[string(n)] = struct{}{}
+		eligibleSigners[string(n.Id)] = struct{}{}
 	}
 	quorumSize := Quorum(len(nodes))
 	signatureAggregator := &testutil.TestSignatureAggregator{N: len(nodes)}
@@ -83,7 +89,7 @@ func TestVerifyQC(t *testing.T) {
 			name: "valid finalization",
 			finalization: func() Finalization {
 				block := testutil.NewTestBlock(ProtocolMetadata{}, emptyBlacklist)
-				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, nodes[:quorumSize])
+				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, nodeIDs[:quorumSize])
 				return finalization
 			}(),
 			quorumSize: quorumSize,
@@ -91,7 +97,7 @@ func TestVerifyQC(t *testing.T) {
 			name: "not enough signers",
 			finalization: func() Finalization {
 				block := testutil.NewTestBlock(ProtocolMetadata{}, emptyBlacklist)
-				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, nodes[:quorumSize-1])
+				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, nodeIDs[:quorumSize-1])
 				return finalization
 			}(),
 			quorumSize:  quorumSize,
@@ -128,7 +134,7 @@ func TestVerifyQC(t *testing.T) {
 			name: "invalid QC",
 			finalization: func() Finalization {
 				block := testutil.NewTestBlock(ProtocolMetadata{}, emptyBlacklist)
-				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, nodes[:quorumSize])
+				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, nodeIDs[:quorumSize])
 				return finalization
 			}(),
 			quorumSize:  quorumSize,
@@ -143,10 +149,10 @@ func TestVerifyQC(t *testing.T) {
 				return len(signers) >= tt.quorumSize
 			}
 			if tt.msgInvalid {
-				err := VerifyQC(tt.finalization.QC, l, "Finalization", isQuorum, eligibleSigners, &unverifiableQC{}, nil)
+				err := VerifyQC(tt.finalization.QC, l, "Finalization", isQuorum, eligibleSigners, &unverifiableQC{}, nil, nodes)
 				require.EqualError(t, err, tt.expectedErr.Error())
 			} else {
-				err := VerifyQC(tt.finalization.QC, l, "Finalization", isQuorum, eligibleSigners, &tt.finalization, nil)
+				err := VerifyQC(tt.finalization.QC, l, "Finalization", isQuorum, eligibleSigners, &tt.finalization, nil, nodes)
 				if tt.expectedErr != nil {
 					require.EqualError(t, err, tt.expectedErr.Error())
 				} else {

--- a/testutil/network.go
+++ b/testutil/network.go
@@ -147,7 +147,7 @@ func (b *BasicInMemoryNetwork) AddNode(node *BasicNode) {
 
 	allowed := false
 	for _, nodeWeight := range b.nodeWeights {
-		if bytes.Equal(nodeWeight.Node, node.E.ID) {
+		if bytes.Equal(nodeWeight.Id, node.E.ID) {
 			allowed = true
 			break
 		}

--- a/testutil/util.go
+++ b/testutil/util.go
@@ -165,7 +165,7 @@ func (t TestQC) Signers() []common.NodeID {
 	return res
 }
 
-func (t TestQC) Verify(msg []byte) error {
+func (t TestQC) Verify([]byte, common.Nodes) error {
 	return nil
 }
 


### PR DESCRIPTION
QuorumCertificates were carried around the network already parsed, which forced parsing to happen before a message reached the epoch.

Since a QC has an ability to verify its own signature, it implicitly means that a QC implementation needs knowledge of the public keys for the epoch the QC was created for.

Instead of wiring the public keys of the epoch to the QC, the QuorumCertificate.Verify() now receives the set of nodes so the verifier has access to validator membership (and their public keys) when checking a quorum certificate. The nodes argument is threaded through verifyContextQC, the Finalization/Notarization/EmptyNotarization Verify() methods, the verifiableMessage interface, and VerifyQC, with e.nodes supplied at every call site in epoch.go.

To support this, common.Node is reworked:
  - rename the Node.Node field to Node.Id to disambiguate it from the surrounding type
  - add a PK []byte field to carry each node's public key