### PR TITLE
Remove logger, messageType, and from params from VerifyQC

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -742,8 +742,8 @@ func (e *Epoch) handleFinalizationMessage(message *common.Finalization, from com
 		return nil
 	}
 
-	if err := VerifyQC(message.QC, e.Logger, "Finalization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, message, from, e.nodes); err != nil {
-		e.Logger.Debug("Received an invalid finalization",
+	if err := VerifyQC(message.QC, e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, message, e.nodes); err != nil {
+		e.Logger.Debug(fmt.Sprintf("Finalization %s", err),
 			zap.Int("round", int(message.Finalization.Round)),
 			zap.Stringer("NodeID", from))
 		return nil
@@ -1601,7 +1601,9 @@ func (e *Epoch) handleEmptyNotarizationMessage(emptyNotarization *common.EmptyNo
 	}
 
 	// Otherwise, this round is not notarized or finalized yet, so verify the empty notarization and store it.
-	if err := VerifyQC(emptyNotarization.QC, e.Logger, "Empty notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, emptyNotarization, from, e.nodes); err != nil {
+	if err := VerifyQC(emptyNotarization.QC, e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, emptyNotarization, e.nodes); err != nil {
+		e.Logger.Debug(fmt.Sprintf("Empty notarization %s", err),
+			zap.Stringer("NodeID", from))
 		return nil
 	}
 
@@ -1657,7 +1659,9 @@ func (e *Epoch) handleNotarizationMessage(message *common.Notarization, from com
 		return nil
 	}
 
-	if err := VerifyQC(message.QC, e.Logger, "Notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, message, from, e.nodes); err != nil {
+	if err := VerifyQC(message.QC, e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, message, e.nodes); err != nil {
+		e.Logger.Debug(fmt.Sprintf("Notarization %s", err),
+			zap.Stringer("NodeID", from))
 		return nil
 	}
 
@@ -3202,29 +3206,27 @@ func (e *Epoch) handleReplicationResponse(resp *common.ReplicationResponse, from
 	return e.processReplicationState()
 }
 
-func (e *Epoch) verifyQuorumRound(q common.QuorumRound, from common.NodeID) error {
+func (e *Epoch) verifyQuorumRound(q common.QuorumRound) error {
 	if err := q.VerifyQCConsistentWithBlock(); err != nil {
 		return err
 	}
 
 	if q.Finalization != nil {
 		// extra check needed if we have a finalized block
-		err := VerifyQC(q.Finalization.QC, e.Logger, "Finalization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.Finalization, from, e.nodes)
-		if err != nil {
-			return errors.New("invalid finalization")
+		if err := VerifyQC(q.Finalization.QC, e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.Finalization, e.nodes); err != nil {
+			return fmt.Errorf("invalid finalization: %w", err)
 		}
 	}
 
 	if q.Notarization != nil {
-		if err := VerifyQC(q.Notarization.QC, e.Logger, "Notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.Notarization, from, e.nodes); err != nil {
-			return fmt.Errorf("invalid notarization: %v", err)
+		if err := VerifyQC(q.Notarization.QC, e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.Notarization, e.nodes); err != nil {
+			return fmt.Errorf("invalid notarization: %w", err)
 		}
 	}
 
 	if q.EmptyNotarization != nil {
-		err := VerifyQC(q.EmptyNotarization.QC, e.Logger, "Empty notarization", e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.EmptyNotarization, from, e.nodes)
-		if err != nil {
-			return fmt.Errorf("invalid empty notarization QC: %v", err)
+		if err := VerifyQC(q.EmptyNotarization.QC, e.signatureAggregator.IsQuorum, e.eligibleNodeIDs, q.EmptyNotarization, e.nodes); err != nil {
+			return fmt.Errorf("invalid empty notarization QC: %w", err)
 		}
 	}
 
@@ -3264,7 +3266,7 @@ func (e *Epoch) processQuorumRound(round *common.QuorumRound, from common.NodeID
 		return fmt.Errorf("received a finalized round for a committed sequence. round: %d; seq: %d", round.GetRound(), round.GetSequence())
 	}
 
-	if err := e.verifyQuorumRound(*round, from); err != nil {
+	if err := e.verifyQuorumRound(*round); err != nil {
 		return fmt.Errorf("failed verifying latest round: %w", err)
 	}
 

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -975,15 +975,15 @@ func TestEpochQCSignedByNonExistentNodes(t *testing.T) {
 			wg.Done()
 			close(unknownFinalizationChan)
 		},
-		"Notarization is signed by the same node more than once": func() {
+		"Notarization quorum certificate is signed by the same node": func() {
 			wg.Done()
 			close(doubleNotarizationChan)
 		},
-		"Empty notarization is signed by the same node more than once": func() {
+		"Empty notarization quorum certificate is signed by the same node": func() {
 			wg.Done()
 			close(doubleEmptyNotarizationChan)
 		},
-		"Finalization is signed by the same node more than once": func() {
+		"Finalization quorum certificate is signed by the same node": func() {
 			wg.Done()
 			close(doubleFinalizationChan)
 		},

--- a/simplex/util.go
+++ b/simplex/util.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -40,12 +39,11 @@ func RetrieveLastIndexFromStorage(s common.Storage) (*common.VerifiedFinalizedBl
 	}, nil
 }
 
-func hasSomeNodeSignedTwice(nodeIDs []common.NodeID, logger common.Logger) (common.NodeID, bool) {
+func hasSomeNodeSignedTwice(nodeIDs []common.NodeID) (common.NodeID, bool) {
 	seen := make(map[string]struct{}, len(nodeIDs))
 
 	for _, nodeID := range nodeIDs {
 		if _, alreadySeen := seen[string(nodeID)]; alreadySeen {
-			logger.Debug("Observed a signature originating at least twice from the same node")
 			return nodeID, true
 		}
 		seen[string(nodeID)] = struct{}{}
@@ -54,43 +52,29 @@ func hasSomeNodeSignedTwice(nodeIDs []common.NodeID, logger common.Logger) (comm
 	return common.NodeID{}, false
 }
 
-func VerifyQC(qc common.QuorumCertificate, logger common.Logger, messageType string, isQuorum func(signers []common.NodeID) bool, eligibleSigners map[string]struct{}, messageToVerify verifiableMessage, from common.NodeID, nodes common.Nodes) error {
+func VerifyQC(qc common.QuorumCertificate, isQuorum func(signers []common.NodeID) bool, eligibleSigners map[string]struct{}, messageToVerify verifiableMessage, nodes common.Nodes) error {
 	if qc == nil {
-		logger.Debug("Received nil QuorumCertificate")
 		return fmt.Errorf("nil QuorumCertificate")
 	}
-	msgTypeLowerCase := strings.ToLower(messageType)
 	// Ensure no node signed the QuorumCertificate twice
-	doubleSigner, signedTwice := hasSomeNodeSignedTwice(qc.Signers(), logger)
+	doubleSigner, signedTwice := hasSomeNodeSignedTwice(qc.Signers())
 	if signedTwice {
-		logger.Debug(fmt.Sprintf("%s is signed by the same node more than once", messageType), zap.Stringer("signer", doubleSigner))
-		return fmt.Errorf("%s is signed by the same node (%s) more than once", msgTypeLowerCase, doubleSigner)
+		return fmt.Errorf("quorum certificate is signed by the same node (%s) more than once", doubleSigner)
 	}
 
 	// Check enough signers signed the QuorumCertificate
 	if !isQuorum(qc.Signers()) {
-		logger.Debug(fmt.Sprintf("%s certificate signed by insufficient nodes", messageType),
-			zap.Int("count", len(qc.Signers())))
-		return fmt.Errorf("%s certificate signed by insufficient (%d) nodes", msgTypeLowerCase, len(qc.Signers()))
+		return fmt.Errorf("quorum certificate signed by insufficient (%d) nodes", len(qc.Signers()))
 	}
 
 	// Check QuorumCertificate was signed by only eligible nodes
 	for _, signer := range qc.Signers() {
 		if _, exists := eligibleSigners[string(signer)]; !exists {
-			logger.Debug(fmt.Sprintf("%s quorum certificate contains an unknown signer", messageType), zap.Stringer("signer", signer))
-			return fmt.Errorf("%s quorum certificate contains an unknown signer (%s)", msgTypeLowerCase, signer)
+			return fmt.Errorf("quorum certificate contains an unknown signer (%s)", signer)
 		}
 	}
 
-	if err := messageToVerify.Verify(nodes); err != nil {
-		if len(from) > 0 {
-			logger.Debug(fmt.Sprintf("%s quorum certificate is invalid", messageType), zap.Stringer("NodeID", from), zap.Error(err))
-		} else {
-			logger.Debug(fmt.Sprintf("%s quorum certificate is invalid", messageType), zap.Error(err))
-		}
-		return err
-	}
-	return nil
+	return messageToVerify.Verify(nodes)
 }
 
 // GetLatestVerifiedQuorumRound returns the latest verified quorum round given

--- a/simplex/util_test.go
+++ b/simplex/util_test.go
@@ -63,7 +63,6 @@ func (u *unverifiableQC) Verify(Nodes) error {
 }
 
 func TestVerifyQC(t *testing.T) {
-	l := testutil.MakeLogger(t, 0)
 	var nodeIDs []NodeID
 	var nodes Nodes
 	for _, nodeID := range []NodeID{{1}, {2}, {3}, {4}, {5}} {
@@ -101,7 +100,7 @@ func TestVerifyQC(t *testing.T) {
 				return finalization
 			}(),
 			quorumSize:  quorumSize,
-			expectedErr: fmt.Errorf("finalization certificate signed by insufficient (3) nodes"),
+			expectedErr: fmt.Errorf("quorum certificate signed by insufficient (3) nodes"),
 		},
 		{
 			name: "signer signed twice",
@@ -112,7 +111,7 @@ func TestVerifyQC(t *testing.T) {
 				return finalization
 			}(),
 			quorumSize:  quorumSize,
-			expectedErr: fmt.Errorf("finalization is signed by the same node (0400000000000000) more than once"),
+			expectedErr: fmt.Errorf("quorum certificate is signed by the same node (0400000000000000) more than once"),
 		},
 		{
 			name:         "quorum certificate not in finalization",
@@ -128,7 +127,7 @@ func TestVerifyQC(t *testing.T) {
 				finalization, _ := testutil.NewFinalizationRecord(t, signatureAggregator, block, signers)
 				return finalization
 			}(), quorumSize: quorumSize,
-			expectedErr: fmt.Errorf("finalization quorum certificate contains an unknown signer (0600000000000000)"),
+			expectedErr: fmt.Errorf("quorum certificate contains an unknown signer (0600000000000000)"),
 		},
 		{
 			name: "invalid QC",
@@ -149,10 +148,10 @@ func TestVerifyQC(t *testing.T) {
 				return len(signers) >= tt.quorumSize
 			}
 			if tt.msgInvalid {
-				err := VerifyQC(tt.finalization.QC, l, "Finalization", isQuorum, eligibleSigners, &unverifiableQC{}, nil, nodes)
+				err := VerifyQC(tt.finalization.QC, isQuorum, eligibleSigners, &unverifiableQC{}, nodes)
 				require.EqualError(t, err, tt.expectedErr.Error())
 			} else {
-				err := VerifyQC(tt.finalization.QC, l, "Finalization", isQuorum, eligibleSigners, &tt.finalization, nil, nodes)
+				err := VerifyQC(tt.finalization.QC, isQuorum, eligibleSigners, &tt.finalization, nodes)
 				if tt.expectedErr != nil {
 					require.EqualError(t, err, tt.expectedErr.Error())
 				} else {


### PR DESCRIPTION
VerifyQC previously logged failures internally, which required threading a logger, a messageType string, and the originating node through every call. Since VerifyQC already returns a descriptive error, callers can log it themselves with whatever context they have.

VerifyQC now just validates and returns plain errors; the per-message-type debug logging moves to the call sites in epoch.go. verifyQuorumRound drops its now-unused from param accordingly.