### PR TITLE
OneTimeVerifier: Only remember if verification succeeded

### DIFF
--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -453,15 +453,18 @@ func TestEpochIndexFinalization(t *testing.T) {
 
 func TestEpochConsecutiveProposalsDoNotGetVerified(t *testing.T) {
 	for _, test := range []struct {
-		name string
-		err  error
+		name                      string
+		err                       error
+		expectedVerificationCount int
 	}{
 		{
-			name: "valid block",
+			name:                      "valid block",
+			expectedVerificationCount: 1,
 		},
 		{
-			name: "invalid block",
-			err:  fmt.Errorf("invalid block"),
+			name:                      "invalid block",
+			err:                       fmt.Errorf("invalid block"),
+			expectedVerificationCount: DefaultProcessingBlocks,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -483,11 +486,15 @@ func TestEpochConsecutiveProposalsDoNotGetVerified(t *testing.T) {
 			require.True(t, ok)
 			require.Equal(t, md.Round, md.Seq)
 
-			onlyVerifyOnce := make(chan struct{})
+			var timesVerified atomic.Uint32
+
+			var scheduledWG sync.WaitGroup
+			scheduledWG.Add(test.expectedVerificationCount)
 
 			block := vb.(*testutil.TestBlock)
 			block.OnVerify = func() {
-				close(onlyVerifyOnce)
+				defer scheduledWG.Done()
+				timesVerified.Add(1)
 			}
 			block.VerificationError = test.err
 
@@ -511,12 +518,9 @@ func TestEpochConsecutiveProposalsDoNotGetVerified(t *testing.T) {
 				}()
 			}
 			wg.Wait()
+			scheduledWG.Wait()
 
-			select {
-			case <-onlyVerifyOnce:
-			case <-time.After(time.Minute):
-				require.Fail(t, "timeout waiting for shouldOnlyBeClosedOnce")
-			}
+			require.Equal(t, uint32(test.expectedVerificationCount), timesVerified.Load())
 		})
 	}
 }

--- a/simplex/util.go
+++ b/simplex/util.go
@@ -157,6 +157,17 @@ func (block *oneTimeVerifiedBlock) Verify(ctx context.Context) (common.VerifiedB
 	digest := header.Digest
 	seq := header.Seq
 
+	if result, exists := block.otv.digests[digest]; exists {
+		block.otv.logger.Debug("Attempted to verify an already verified block", zap.Uint64("round", header.Round), zap.Error(result.err))
+		return result.vb, result.err
+	}
+
+	vb, err := block.Block.Verify(ctx)
+	if err != nil {
+		block.otv.logger.Debug("Block verification failed", zap.Uint64("round", header.Round), zap.Error(err))
+		return nil, err
+	}
+
 	// cleanup
 	defer func() {
 		for digest, vr := range block.otv.digests {
@@ -165,13 +176,6 @@ func (block *oneTimeVerifiedBlock) Verify(ctx context.Context) (common.VerifiedB
 			}
 		}
 	}()
-
-	if result, exists := block.otv.digests[digest]; exists {
-		block.otv.logger.Debug("Attempted to verify an already verified block", zap.Uint64("round", header.Round), zap.Error(result.err))
-		return result.vb, result.err
-	}
-
-	vb, err := block.Block.Verify(ctx)
 
 	block.otv.digests[digest] = verifiedResult{
 		seq: seq,


### PR DESCRIPTION
When we verify a block, we currently remember its verification result even if it failed to verify.

The motivation of the one-time verifier is to prevent a block from being verified by both replication and the regular Simplex protocol.

However, a block may deem incorrect at a specific point in time and deem correct later if it fails verifying ICM messages due to its P-chain being lagging behind. 

Similarly, an epoch transition can be concluded as an illegal one if the verifying node has a lagging P-chain.

We therefore need to adjust the one time verifier to not remember the verification result if it failed. 