### PR TITLE
Split GetPChainHeight into proposing and verifying variants

### DIFF
--- a/msm/fake_node_test.go
+++ b/msm/fake_node_test.go
@@ -31,7 +31,10 @@ func TestFakeNodeEpochChangesDespiteEmptyMempool(t *testing.T) {
 	pChainHeight.Store(100)
 	node := newFakeNode(t)
 	node.sm.GetValidatorSet = validatorSetRetriever.getValidatorSet
-	node.sm.GetPChainHeight = func() uint64 {
+	node.sm.GetPChainHeightForProposing = func() uint64 {
+		return pChainHeight.Load()
+	}
+	node.sm.GetPChainHeightForVerifying = func() uint64 {
 		return pChainHeight.Load()
 	}
 	node.mempoolEmpty = true
@@ -84,7 +87,10 @@ func TestFakeNode(t *testing.T) {
 	pChainHeight.Store(100)
 	node := newFakeNode(t)
 	node.sm.GetValidatorSet = validatorSetRetriever.getValidatorSet
-	node.sm.GetPChainHeight = func() uint64 {
+	node.sm.GetPChainHeightForProposing = func() uint64 {
+		return pChainHeight.Load()
+	}
+	node.sm.GetPChainHeightForVerifying = func() uint64 {
 		return pChainHeight.Load()
 	}
 
@@ -151,7 +157,10 @@ func TestFakeNodeEmptyMempool(t *testing.T) {
 	node := newFakeNode(t)
 	node.sm.MaxBlockBuildingWaitTime = 100 * time.Millisecond
 	node.sm.GetValidatorSet = validatorSetRetriever.getValidatorSet
-	node.sm.GetPChainHeight = func() uint64 {
+	node.sm.GetPChainHeightForProposing = func() uint64 {
+		return pChainHeight
+	}
+	node.sm.GetPChainHeightForVerifying = func() uint64 {
 		return pChainHeight
 	}
 
@@ -245,7 +254,7 @@ func (fn *fakeNode) WaitForProgress(ctx context.Context, pChainHeight uint64) er
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-time.After(10 * time.Millisecond):
-			if fn.sm.GetPChainHeight() != pChainHeight {
+			if fn.sm.GetPChainHeightForProposing() != pChainHeight {
 				return nil
 			}
 		}

--- a/msm/fuzz_test.go
+++ b/msm/fuzz_test.go
@@ -103,8 +103,9 @@ func FuzzVerifyBlock(f *testing.F) {
 
 		// Model the verifier as knowing the P-chain exactly up to the height the block
 		// references — the minimal knowledge required to verify it, mirroring production
-		// where GetPChainHeight returns the verifier's latest observed height.
-		sm.GetPChainHeight = func() uint64 { return block.Metadata.PChainHeight }
+		// where GetPChainHeightForVerifying returns the verifier's latest observed height.
+		sm.GetPChainHeightForProposing = func() uint64 { return block.Metadata.PChainHeight }
+		sm.GetPChainHeightForVerifying = func() uint64 { return block.Metadata.PChainHeight }
 
 		// The unfuzzed block built by the chain MSM must verify.
 		require.NoError(t, sm.VerifyBlock(context.Background(), block),
@@ -184,7 +185,8 @@ func buildEpochChain(tb testing.TB, logger common.Logger) ([]*StateMachineBlock,
 
 	sm, tc := newStateMachineWithLogger(tb, logger)
 	sm.GetValidatorSet = getValidatorSet
-	sm.GetPChainHeight = func() uint64 { return currentPChainHeight }
+	sm.GetPChainHeightForProposing = func() uint64 { return currentPChainHeight }
+	sm.GetPChainHeightForVerifying = func() uint64 { return currentPChainHeight }
 	sm.GetTime = func() time.Time { return currentTime }
 	sm.GenesisValidatorSet = validatorSet1
 	sm.LastNonSimplexBlockPChainHeight = pChainHeight1
@@ -287,7 +289,7 @@ func buildEpochChain(tb testing.TB, logger common.Logger) ([]*StateMachineBlock,
 	vtc.blockStore = tc.blockStore.clone()
 	verifier.GetBlock = vtc.blockStore.getBlock
 	verifier.GetValidatorSet = getValidatorSet
-	// GetPChainHeight is set by the caller per verified block (see FuzzVerifyBlock).
+	// GetPChainHeightForVerifying is set by the caller per verified block (see FuzzVerifyBlock).
 	// A time safely after every block, so the not-too-far-in-future check always passes.
 	verifyTime := startTime.Add(2 * time.Second)
 	verifier.GetTime = func() time.Time { return verifyTime }

--- a/msm/msm.go
+++ b/msm/msm.go
@@ -162,16 +162,6 @@ type BlockBuilder interface {
 	WaitForPendingBlock(ctx context.Context)
 }
 
-type verificationInput struct {
-	prevMD              StateMachineMetadata
-	proposedBlockMD     StateMachineMetadata
-	hasInnerBlock       bool
-	innerBlockTimestamp time.Time // only set when hasInnerBlock is true
-	prevBlockSeq        uint64
-	nextBlockType       BlockType
-	state               state
-}
-
 // StateMachine manages block building and verification across epoch transitions.
 type StateMachine struct {
 	*Config
@@ -188,8 +178,10 @@ type Config struct {
 	TimeSkewLimit time.Duration
 	// GetTime returns the current time.
 	GetTime func() time.Time
-	// GetPChainHeight returns the latest known P-chain height.
-	GetPChainHeight func() uint64
+	// GetPChainHeightForProposing returns the latest known P-chain height to be used when building a block.
+	GetPChainHeightForProposing func() uint64
+	// GetPChainHeightForVerifying returns the latest known P-chain height to be used when verifying a block.
+	GetPChainHeightForVerifying func() uint64
 	// BlockBuilder builds new VM blocks.
 	BlockBuilder BlockBuilder
 	// Logger is used for logging state machine operations.
@@ -345,7 +337,7 @@ func (sm *StateMachine) verifyNonZeroBlock(ctx context.Context, block, prevBlock
 		return fmt.Errorf("failed to verify timestamp: %w", err)
 	}
 
-	currentPChainHeight := sm.GetPChainHeight()
+	currentPChainHeight := sm.GetPChainHeightForVerifying()
 	prevPChainHeight := prevBlockMD.PChainHeight
 	proposedPChainHeight := block.Metadata.PChainHeight
 
@@ -572,7 +564,7 @@ func (sm *StateMachine) verifyNextPChainRefHeightNormal(prevMD StateMachineMetad
 	}
 
 	// Make sure we have reached the next P-chain reference height, otherwise we won't be able to validate it.
-	pChainHeight := sm.GetPChainHeight()
+	pChainHeight := sm.GetPChainHeightForVerifying()
 
 	if pChainHeight < next.NextPChainReferenceHeight {
 		return fmt.Errorf("%w: target %d, current %d", errPChainHeightNotReached, next.NextPChainReferenceHeight, pChainHeight)
@@ -625,7 +617,7 @@ func (sm *StateMachine) verifyNextPChainRefHeightForNewEpoch(expectedEpochInfo S
 
 	// If we haven't reached this P-chain height yet, we cannot accept the next P-chain reference height,
 	// because there is no way of querying the validator set for the next P-chain reference height.
-	pChainHeight := sm.GetPChainHeight()
+	pChainHeight := sm.GetPChainHeightForVerifying()
 	if pChainHeight < next.NextPChainReferenceHeight {
 		return fmt.Errorf("%w: target %d, current %d", errPChainHeightNotReached, next.NextPChainReferenceHeight, pChainHeight)
 	}
@@ -653,7 +645,7 @@ func (sm *StateMachine) createBlockBuildingDecider(pChainReferenceHeight uint64)
 		logger:                   sm.Logger,
 		maxBlockBuildingWaitTime: sm.MaxBlockBuildingWaitTime,
 		pChainListener:           sm.PChainProgressListener,
-		getPChainHeight:          sm.GetPChainHeight,
+		getPChainHeight:          sm.GetPChainHeightForProposing,
 		waitForPendingBlock:      sm.BlockBuilder.WaitForPendingBlock,
 		hasValidatorSetChanged: func(pChainHeight uint64) (bool, error) {
 			// The given pChainHeight was sampled by the caller of shouldTransitionEpoch().
@@ -1222,7 +1214,7 @@ func (sm *StateMachine) verifyBlockEpochSealed(ctx context.Context, parentBlock 
 	// the proposed pchain height and (optional) next pchain reference height, mirroring
 	// what buildBlockOrTransitionEpoch does on the build side.
 	proposedPChainHeight := nextBlock.Metadata.PChainHeight
-	currentPChainHeight := sm.GetPChainHeight()
+	currentPChainHeight := sm.GetPChainHeightForVerifying()
 	prevPChainHeight := parentBlock.Metadata.PChainHeight
 	if err := verifyPChainHeight(proposedPChainHeight, currentPChainHeight, prevPChainHeight); err != nil {
 		return fmt.Errorf("failed to verify P-chain height: %w", err)

--- a/msm/msm_test.go
+++ b/msm/msm_test.go
@@ -325,7 +325,8 @@ func TestMSMNormalOp(t *testing.T) {
 				tc.validatorSetRetriever.resultMap = map[uint64]NodeBLSMappings{
 					newPChainHeight: newValidatorSet,
 				}
-				sm.GetPChainHeight = func() uint64 { return newPChainHeight }
+				sm.GetPChainHeightForProposing = func() uint64 { return newPChainHeight }
+				sm.GetPChainHeightForVerifying = func() uint64 { return newPChainHeight }
 			},
 			expectedPChainHeight:        newPChainHeight,
 			expectedNextPChainRefHeight: newPChainHeight,
@@ -501,8 +502,18 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 				}
 				return validatorSet1, nil
 			}
-			getPChainHeight := func() uint64 {
+			// In production the two P-chain height functions differ: proposing uses a slightly
+			// lagging "stable" height, while verifying uses the up-to-date real-time height.
+			// getProposingPChainHeight is the lagging height the builder proposes at (it drives
+			// the block contents, e.g. the validator-set-change observation at pChainHeight2).
+			// getVerifyingPChainHeight stays ahead of it, modelling the more up-to-date height
+			// the verifier checks against.
+			const pChainHeightLag = uint64(50)
+			getProposingPChainHeight := func() uint64 {
 				return currentPChainHeight
+			}
+			getVerifyingPChainHeight := func() uint64 {
+				return currentPChainHeight + pChainHeightLag
 			}
 
 			// Since we explicitly compare the built block with an expected value,
@@ -538,10 +549,9 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 			// The zero block carries over the parent's ICM epoch.
 			testCase.firstBlockBeforeSimplex.Metadata.ICMEpochInfo = testCase.firstBlockICMEpochInfo
 
-			// Create fresh state machine instances for each iteration.
 			sm, tc := newStateMachine(t)
 			sm.GetValidatorSet = getValidatorSet
-			sm.GetPChainHeight = getPChainHeight
+
 			sm.GetTime = fixedTime
 			tc.blockStore[0] = &outerBlock{block: genesis}
 			tc.blockStore[42] = &outerBlock{block: notGenesis}
@@ -552,7 +562,22 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 
 			smVerify, tcVerify := newStateMachine(t)
 			smVerify.GetValidatorSet = getValidatorSet
-			smVerify.GetPChainHeight = getPChainHeight
+
+			// sm only ever builds blocks and smVerify only ever verifies them.
+			// Each one fails the test if it consults the P-chain height function it must not use,
+			// proving that building reads GetPChainHeightForProposing and verifying reads GetPChainHeightForVerifying.
+			sm.GetPChainHeightForProposing = getProposingPChainHeight
+			sm.GetPChainHeightForVerifying = func() uint64 {
+				require.FailNow(t, "builder must not use GetPChainHeightForVerifying when proposing")
+				return 0
+			}
+
+			smVerify.GetPChainHeightForProposing = func() uint64 {
+				require.FailNow(t, "verifier must not use GetPChainHeightForProposing when verifying")
+				return 0
+			}
+			smVerify.GetPChainHeightForVerifying = getVerifyingPChainHeight
+
 			smVerify.GetTime = fixedTime
 
 			smVerify.LastNonSimplexInnerBlock = testCase.firstBlockBeforeSimplex.InnerBlock

--- a/msm/util_test.go
+++ b/msm/util_test.go
@@ -307,7 +307,10 @@ func newStateMachineWithLogger(tb testing.TB, logger common.Logger) (*StateMachi
 		SignatureAggregatorCreator:      newSignatureAggregatorCreator(),
 		BlockBuilder:                    &testConfig.blockBuilder,
 		KeyAggregator:                   &testConfig.keyAggregator,
-		GetPChainHeight: func() uint64 {
+		GetPChainHeightForProposing: func() uint64 {
+			return 100
+		},
+		GetPChainHeightForVerifying: func() uint64 {
 			return 100
 		},
 		GetValidatorSet:          testConfig.validatorSetRetriever.getValidatorSet,


### PR DESCRIPTION
When Simplex is integrated into AvalancheGo, block proposing must use a "stable" P-chain height (GetMinimumHeight), while block verification must use the actual real-time P-chain height.

A single GetPChainHeight callback cannot serve both.

Replace Config.GetPChainHeight with two callbacks:
  - GetPChainHeightForProposing, used on the build path (createBlockBuildingDecider).
  - GetPChainHeightForVerifying, used on every verify path (verifyNonZeroBlock, verifyNextPChainRefHeightNormal, verifyNextPChainRefHeightForNewEpoch, verifyBlockEpochSealed).

Update every test that initialized GetPChainHeightForProposing to also set GetPChainHeightForVerifying to the same value.

Extend TestMSMFullEpochLifecycle to prove the split: its builder and verifier state machines now use distinct heights (proposing lags, verifying leads), and each fails the test if it ever consults the height function it must not use. This exercises all four build/verify states (first-simplex, normal-op, collecting-approvals, epoch-sealed).