### PR TITLE
Implement Close() for GarbageCollectedWAL

### DIFF
--- a/wal/gc.go
+++ b/wal/gc.go
@@ -10,6 +10,10 @@ import (
 	"github.com/ava-labs/simplex/common"
 )
 
+const (
+	defaultMaxWALSize = 100 * 1024 * 1024 // 100 MB
+)
+
 // Creator creates a DeletableWAL. Returns an error upon failure.
 type Creator func() (DeletableWAL, error)
 
@@ -60,6 +64,11 @@ func NewGarbageCollectedWAL(WALs []DeletableWAL, creator Creator, reader Reader,
 		}
 		wals = append(wals, wal)
 	}
+
+	if maxWALSize == 0 {
+		maxWALSize = defaultMaxWALSize
+	}
+
 	return &GarbageCollectedWAL{
 		maxWalSize: maxWALSize,
 		reader:     reader,
@@ -158,7 +167,7 @@ func (gcw *GarbageCollectedWAL) ReadAll() ([][]byte, error) {
 	return allEntries, nil
 }
 
-func (gcw *GarbageCollectedWAL) Truncate(retentionTerm uint64) error {
+func (gcw *GarbageCollectedWAL) GarbageCollect(retentionTerm uint64) error {
 	newWALs := make([]garbageCollectedWAL, 0, len(gcw.wals))
 
 	for i, wal := range gcw.wals {
@@ -175,5 +184,15 @@ func (gcw *GarbageCollectedWAL) Truncate(retentionTerm uint64) error {
 
 	gcw.wals = newWALs
 
+	return nil
+}
+
+func (gcw *GarbageCollectedWAL) Close() error {
+	for i, wal := range gcw.wals {
+		if err := wal.Close(); err != nil {
+			return fmt.Errorf("error closing WAL %d: %v", i, err)
+		}
+	}
+	gcw.wals = nil
 	return nil
 }

--- a/wal/gc_test.go
+++ b/wal/gc_test.go
@@ -47,12 +47,12 @@ func TestGarbageCollectedWAL(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, records, walRecords)
 
-	require.NoError(t, gcw.Truncate(6))
+	require.NoError(t, gcw.GarbageCollect(6))
 	walRecords, err = gcw.ReadAll()
 	require.NoError(t, err)
 	require.Equal(t, records[6:], walRecords)
 
-	require.NoError(t, gcw.Truncate(10))
+	require.NoError(t, gcw.GarbageCollect(10))
 	walRecords, err = gcw.ReadAll()
 	require.NoError(t, err)
 	require.Empty(t, walRecords)


### PR DESCRIPTION
GarbageCollectedWAL is the top most WAL that the Epoch holds, but it needs to have Close() in order to fully implement WriteAheadLog.