### PR TITLE
fix off by one replication request error and add unit test

### DIFF
--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1760,3 +1760,51 @@ messages:
 	notarization := wal.AssertNotarization(uint64(len(blocks)))
 	require.Equal(t, common.EmptyNotarizationRecordType, notarization)
 }
+
+
+// TestReplicationRequestsWithinMaxRoundWindow ensures that a node that observes a finalization more than MaxRoundWindow
+// sequences ahead of its next sequence to commit only requests sequences up to MaxRoundWindow-1 ahead of it
+func TestReplicationRequestsWithinMaxRoundWindow(t *testing.T) {
+	bb := testutil.NewTestBlockBuilder()
+	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
+	sentMessages := make(chan *common.Message, 100)
+	conf, _, _ := testutil.DefaultTestNodeEpochConfig(t, nodes[1], &recordingComm{
+		Communication: testutil.NewNoopComm(nodes),
+		SentMessages:  sentMessages,
+	}, bb)
+	conf.ReplicationEnabled = true
+
+	e, err := simplex.NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	// observe a finalization more than MaxRoundWindow sequences ahead of us
+	seqCount := 2 * conf.MaxRoundWindow
+	finalization := createBlocks(t, nodes, seqCount)[seqCount-1].Finalization
+	err = e.HandleMessage(&common.Message{Finalization: &finalization}, nodes[0])
+	require.NoError(t, err)
+
+	// collect the replication requests sent out in response to the finalization
+	requested := make(map[uint64]struct{})
+	timeout := time.After(30 * time.Second)
+	for uint64(len(requested)) < conf.MaxRoundWindow {
+		select {
+		case msg := <-sentMessages:
+			if msg.ReplicationRequest == nil {
+				continue
+			}
+			for _, seq := range msg.ReplicationRequest.Seqs {
+				requested[seq] = struct{}{}
+			}
+		case <-timeout:
+			require.FailNow(t, "timed out waiting for replication requests")
+		}
+	}
+
+	// our next sequence to commit is 0, so we may request at most sequences [0, MaxRoundWindow-1]
+	for seq := range requested {
+		require.Less(t, seq, conf.MaxRoundWindow,
+			"requested a sequence more than MaxRoundWindow ahead of the next sequence to commit")
+	}
+}

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1786,8 +1786,7 @@ func TestReplicationRequestsWithinMaxRoundWindow(t *testing.T) {
 
 	// collect the replication requests sent out in response to the finalization
 	requested := make(map[uint64]struct{})
-	timeout := time.After(30 * time.Second)
-	for uint64(len(requested)) < conf.MaxRoundWindow {
+	for done := false; !done; {
 		select {
 		case msg := <-sentMessages:
 			if msg.ReplicationRequest == nil {
@@ -1796,12 +1795,13 @@ func TestReplicationRequestsWithinMaxRoundWindow(t *testing.T) {
 			for _, seq := range msg.ReplicationRequest.Seqs {
 				requested[seq] = struct{}{}
 			}
-		case <-timeout:
-			require.FailNow(t, "timed out waiting for replication requests")
+		default:
+			done = true
 		}
 	}
 
 	// our next sequence to commit is 0, so we may request at most sequences [0, MaxRoundWindow-1]
+	require.Len(t, requested, int(conf.MaxRoundWindow))
 	for seq := range requested {
 		require.Less(t, seq, conf.MaxRoundWindow,
 			"requested a sequence more than MaxRoundWindow ahead of the next sequence to commit")

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1787,7 +1787,7 @@ func TestReplicationRequestsWithinMaxRoundWindow(t *testing.T) {
 	// collect the replication requests sent out in response to the finalization
 	requested := make(map[uint64]struct{})
 	for len(sentMessages) > 0 {
-	 	msg := <-sentMessages
+		msg := <-sentMessages
 		if msg.ReplicationRequest == nil {
 			continue
 		}

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1786,17 +1786,13 @@ func TestReplicationRequestsWithinMaxRoundWindow(t *testing.T) {
 
 	// collect the replication requests sent out in response to the finalization
 	requested := make(map[uint64]struct{})
-	for done := false; !done; {
-		select {
-		case msg := <-sentMessages:
-			if msg.ReplicationRequest == nil {
-				continue
-			}
-			for _, seq := range msg.ReplicationRequest.Seqs {
-				requested[seq] = struct{}{}
-			}
-		default:
-			done = true
+	for len(sentMessages) > 0 {
+	 	msg := <-sentMessages
+		if msg.ReplicationRequest == nil {
+			continue
+		}
+		for _, seq := range msg.ReplicationRequest.Seqs {
+			requested[seq] = struct{}{}
 		}
 	}
 

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1761,7 +1761,6 @@ messages:
 	require.Equal(t, common.EmptyNotarizationRecordType, notarization)
 }
 
-
 // TestReplicationRequestsWithinMaxRoundWindow ensures that a node that observes a finalization more than MaxRoundWindow
 // sequences ahead of its next sequence to commit only requests sequences up to MaxRoundWindow-1 ahead of it
 func TestReplicationRequestsWithinMaxRoundWindow(t *testing.T) {

--- a/simplex/requestor.go
+++ b/simplex/requestor.go
@@ -159,7 +159,7 @@ func (r *requestor) observedSignedQuorum(observed *signedQuorum, currentSeqOrRou
 func (r *requestor) sendMoreReplicationRequests(observedSeqOrRound, currentSeqOrRound uint64) {
 	start := math.Max(float64(currentSeqOrRound), float64(r.highestRequested))
 	// we limit the number of outstanding requests to be at most maxRoundWindow ahead of nextSeqToCommit
-	end := math.Min(float64(observedSeqOrRound), float64(r.maxRoundWindow+currentSeqOrRound))
+	end := math.Min(float64(observedSeqOrRound), float64(r.maxRoundWindow+currentSeqOrRound -1))
 
 	r.logger.Debug("Node is behind, attempting to request missing values", zap.Uint64("value", observedSeqOrRound), zap.Uint64("start", uint64(start)), zap.Uint64("end", uint64(end)), zap.Bool("seq requestor", r.replicateSeqs))
 	r.sendReplicationRequests(uint64(start), uint64(end))

--- a/simplex/requestor.go
+++ b/simplex/requestor.go
@@ -159,7 +159,7 @@ func (r *requestor) observedSignedQuorum(observed *signedQuorum, currentSeqOrRou
 func (r *requestor) sendMoreReplicationRequests(observedSeqOrRound, currentSeqOrRound uint64) {
 	start := math.Max(float64(currentSeqOrRound), float64(r.highestRequested))
 	// we limit the number of outstanding requests to be at most maxRoundWindow ahead of nextSeqToCommit
-	end := math.Min(float64(observedSeqOrRound), float64(r.maxRoundWindow+currentSeqOrRound -1))
+	end := math.Min(float64(observedSeqOrRound), float64(r.maxRoundWindow+currentSeqOrRound-1))
 
 	r.logger.Debug("Node is behind, attempting to request missing values", zap.Uint64("value", observedSeqOrRound), zap.Uint64("start", uint64(start)), zap.Uint64("end", uint64(end)), zap.Bool("seq requestor", r.replicateSeqs))
 	r.sendReplicationRequests(uint64(start), uint64(end))


### PR DESCRIPTION
This PR fixes the following bug:

- When a node sends a replication requests, it sends more than maxRoundWindow (off-by-one)

Also one unit test for this functionality was added. 