### PR TITLE
Discard equivocated round when processing notarizations

### DIFF
--- a/common/msg.go
+++ b/common/msg.go
@@ -285,6 +285,14 @@ func (q *QuorumRound) IsWellFormed() error {
 		return fmt.Errorf("malformed QuorumRound, block but no notarization or finalization")
 	}
 
+	if q.Finalization != nil && q.Block == nil {
+		return fmt.Errorf("malformed QuorumRound, finalization but no block")
+	}
+
+	if q.Notarization != nil && q.Block == nil {
+		return fmt.Errorf("malformed QuorumRound, notarization but no block")
+	}
+
 	return nil
 }
 

--- a/common/msg_test.go
+++ b/common/msg_test.go
@@ -193,6 +193,31 @@ func TestQuorumRoundMalformed(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		{
+			name: "empty notarization and finalization, no block",
+			qr: common.QuorumRound{
+				EmptyNotarization: &common.EmptyNotarization{},
+				Finalization:      &common.Finalization{},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "empty notarization and notarization, no block",
+			qr: common.QuorumRound{
+				EmptyNotarization: &common.EmptyNotarization{},
+				Notarization:      &common.Notarization{},
+			},
+			expectedErr: true,
+		},
+		{
+			name: "empty notarization and notarization and finalization, no block",
+			qr: common.QuorumRound{
+				EmptyNotarization: &common.EmptyNotarization{},
+				Notarization:      &common.Notarization{},
+				Finalization:      &common.Finalization{},
+			},
+			expectedErr: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -483,13 +483,11 @@ func (e *Epoch) loadFinalizationRecord(r []byte) error {
 		e.Logger.Debug("Finalization already indexed, skipping restoration", zap.Uint64("Sequence", finalization.Finalization.Seq))
 		return nil
 	}
-
-	round, ok := e.rounds[finalization.Finalization.Round]
-	if !ok {
-		return fmt.Errorf("round not found for finalization")
+	err = e.storeFinalization(&finalization)
+	if err != nil {
+		return err
 	}
 	e.Logger.Info("Finalization Recovered From WAL", zap.Uint64("Round", finalization.Finalization.Round))
-	round.finalization = &finalization
 	return nil
 }
 
@@ -762,18 +760,15 @@ func (e *Epoch) handleFinalizationMessage(message *common.Finalization, from com
 		return nil
 	}
 
-	round, exists := e.rounds[message.Finalization.Round]
+	_, exists := e.rounds[message.Finalization.Round]
 	if !exists {
 		e.handleFinalizationForPendingOrFutureRound(message, message.Finalization.Round, nextSeqToCommit)
 		return nil
 	}
 
-	if round.finalization != nil {
-		e.Logger.Debug("Received finalization for an already finalized round", zap.Uint64("round", message.Finalization.Round))
+	if err := e.storeFinalization(message); err != nil {
 		return nil
 	}
-
-	round.finalization = message
 
 	return e.persistFinalization(*message)
 }
@@ -1204,10 +1199,10 @@ func (e *Epoch) maybeCollectFinalization(round *Round) error {
 		return nil
 	}
 
-	return e.assembleFinalization(round, finalizations)
+	return e.assembleFinalization(finalizations)
 }
 
-func (e *Epoch) assembleFinalization(round *Round, finalizationVotes []*common.FinalizeVote) error {
+func (e *Epoch) assembleFinalization(finalizationVotes []*common.FinalizeVote) error {
 	for _, vote := range finalizationVotes {
 		e.Logger.Debug("Collected a finalize vote from node", zap.Stringer("NodeID", vote.Signature.Signer), zap.Uint64("round", vote.Finalization.Round), zap.Uint64("seq", vote.Finalization.Seq))
 	}
@@ -1217,7 +1212,10 @@ func (e *Epoch) assembleFinalization(round *Round, finalizationVotes []*common.F
 		return err
 	}
 
-	round.finalization = &finalization
+	if err := e.storeFinalization(&finalization); err != nil {
+		return nil
+	}
+
 	return e.persistFinalization(finalization)
 }
 
@@ -1954,7 +1952,10 @@ func (e *Epoch) processFinalizedBlock(block common.Block, finalization *common.F
 			delete(e.rounds, round.num)
 			return e.processFinalizedBlock(block, finalization)
 		}
-		round.finalization = finalization
+		if err := e.storeFinalization(finalization); err != nil {
+			e.Logger.Error("Failed storing finalization", zap.Error(err))
+			return err
+		}
 		prevEpochRound := e.round
 		if err := e.indexFinalizations(round.num); err != nil {
 			e.Logger.Error("Failed to index finalization", zap.Error(err))
@@ -2182,8 +2183,10 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block common.Block, finaliz
 
 		// Store the verified block in rounds map so subsequent blocks can find it as a dependency
 		roundEntry := NewRound(verifiedBlock)
-		roundEntry.finalization = finalization
 		e.rounds[md.Round] = roundEntry
+		if err := e.storeFinalization(finalization); err != nil {
+			return md.Digest
+		}
 		e.Logger.Debug("Stored finalized replicated block in rounds map",
 			zap.Uint64("round", md.Round),
 			zap.Uint64("seq", md.Seq),
@@ -2831,6 +2834,38 @@ func (e *Epoch) retrieveLastPersistedBlacklist() (common.Blacklist, bool) {
 		blacklist = e.lastBlock.VerifiedBlock.Blacklist()
 	}
 	return blacklist, true
+}
+
+func (e *Epoch) storeFinalization(finalization *common.Finalization) error {
+	if finalization == nil {
+		return errors.New("finalization is nil")
+	}
+	roundNum := finalization.Finalization.BlockHeader.Round
+	round, exists := e.rounds[roundNum]
+	if !exists {
+		return fmt.Errorf("round %d not found", roundNum)
+	}
+	if round.finalization != nil {
+		e.Logger.Debug("Received finalization for an already finalized round", zap.Uint64("round", finalization.Finalization.Round))
+		return fmt.Errorf("round %d already has a finalization", roundNum)
+	}
+	if round.block == nil {
+		return fmt.Errorf("round %d has no block to associate finalization with", roundNum)
+	}
+
+	expectedBlockHeader := round.block.BlockHeader()
+	if !expectedBlockHeader.Equals(&finalization.Finalization.BlockHeader) {
+		e.Logger.Debug("Equivocation detected: finalization block header does not match round block header",
+			zap.Uint64("round", roundNum),
+			zap.Stringer("block header", &expectedBlockHeader),
+			zap.Stringer("finalized block header", &finalization.Finalization.BlockHeader))
+		delete(e.rounds, roundNum)
+		return fmt.Errorf("finalization block header does not match round %d block header", roundNum)
+	}
+
+	round.finalization = finalization
+
+	return nil
 }
 
 func (e *Epoch) startRound() error {

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -369,12 +369,45 @@ func (e *Epoch) loadNotarizationRecord(r []byte) error {
 		return nil
 	}
 
-	round, exists := e.rounds[notarization.Vote.Round]
-	if !exists {
-		return fmt.Errorf("could not find round %d, its proposal was probably not persisted earlier", notarization.Vote.Round)
+	if err := e.storeNotarization(&notarization); err != nil {
+		return err
 	}
-	round.notarization = &notarization
+
 	e.Logger.Info("Notarization Recovered From WAL", zap.Uint64("Round", notarization.Vote.Round))
+	return nil
+}
+
+func (e *Epoch) storeNotarization(notarization *common.Notarization) error {
+	if notarization == nil {
+		return errors.New("notarization is nil")
+	}
+
+	roundNum := notarization.Vote.Round
+	round, exists := e.rounds[roundNum]
+	if !exists {
+		return fmt.Errorf("could not find round %d", roundNum)
+	}
+
+	if round.notarization != nil {
+		return fmt.Errorf("notarization for round %d already exists", roundNum)
+	}
+
+	if round.block == nil {
+		return fmt.Errorf("round %d has no block to associate notarization with", roundNum)
+	}
+
+	expectedBlockHeader := round.block.BlockHeader()
+	if !expectedBlockHeader.Equals(&notarization.Vote.BlockHeader) {
+		e.Logger.Debug("Equivocation detected: notarization block header does not match round block header",
+			zap.Uint64("round", roundNum),
+			zap.Stringer("block header", &expectedBlockHeader),
+			zap.Stringer("notarized block header", &notarization.Vote.BlockHeader))
+		delete(e.rounds, roundNum)
+		return fmt.Errorf("notarization block header does not match round %d block header", roundNum)
+	}
+
+	round.notarization = notarization
+
 	return nil
 }
 
@@ -1583,6 +1616,11 @@ func (e *Epoch) maybeCollectNotarization() error {
 		return err
 	}
 
+	if err := e.storeNotarization(&notarization); err != nil {
+		e.Logger.Debug("Not persisting notarization", zap.Error(err))
+		return nil
+	}
+
 	return e.persistAndBroadcastNotarization(notarization)
 }
 
@@ -1603,13 +1641,6 @@ func (e *Epoch) writeNotarizationToWal(notarization common.Notarization) error {
 }
 
 func (e *Epoch) persistNotarization(notarization common.Notarization) error {
-	r, exists := e.rounds[notarization.Vote.Round]
-	if !exists {
-		return fmt.Errorf("attempted to store notarization of a non existent round %d", notarization.Vote.Round)
-	}
-
-	r.notarization = &notarization
-
 	if err := e.writeNotarizationToWal(notarization); err != nil {
 		return err
 	}
@@ -1770,6 +1801,11 @@ func (e *Epoch) handleNotarizationMessage(message *common.Notarization, from com
 	// Else, this is a notarization for the current round, and we have stored the proposal for this round.
 	// Note that we don't need to check if we have timed out on this round,
 	// because if we had collected an empty notarization for this round, we would have progressed to the next round.
+	if err := e.storeNotarization(message); err != nil {
+		e.Logger.Debug("Not persisting notarization", zap.Error(err))
+		return nil
+	}
+
 	return e.persistAndBroadcastNotarization(*message)
 }
 
@@ -2031,6 +2067,10 @@ func (e *Epoch) processNotarizedBlock(block common.Block, notarization *common.N
 			return e.processNotarizedBlock(block, notarization)
 		}
 
+		if err := e.storeNotarization(notarization); err != nil {
+			return nil
+		}
+
 		if err := e.persistNotarization(*notarization); err != nil {
 			e.Logger.Warn("Failed to persist notarization", zap.Error(err))
 			e.haltedError = err
@@ -2256,6 +2296,10 @@ func (e *Epoch) createNotarizedBlockVerificationTask(block common.Block, notariz
 		// store the block in rounds
 		if !e.storeProposal(verifiedBlock) {
 			e.Logger.Debug("Unable to store proposed block for the round", zap.Uint64("round", md.Round))
+			return md.Digest
+		}
+
+		if err := e.storeNotarization(&notarization); err != nil {
 			return md.Digest
 		}
 

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -382,6 +382,10 @@ func (e *Epoch) storeNotarization(notarization *common.Notarization) error {
 		return errors.New("notarization is nil")
 	}
 
+	if notarization.QC == nil {
+		return errors.New("notarization has no QC")
+	}
+
 	roundNum := notarization.Vote.Round
 	round, exists := e.rounds[roundNum]
 	if !exists {
@@ -403,6 +407,8 @@ func (e *Epoch) storeNotarization(notarization *common.Notarization) error {
 			zap.Stringer("block header", &expectedBlockHeader),
 			zap.Stringer("notarized block header", &notarization.Vote.BlockHeader))
 		delete(e.rounds, roundNum)
+		// We need to request the correct block from the network, as we have received the wrong block for this round.
+		e.replicationState.ReceivedFutureRound(expectedBlockHeader.Round, expectedBlockHeader.Seq, e.round, notarization.QC.Signers())
 		return fmt.Errorf("notarization block header does not match round %d block header", roundNum)
 	}
 
@@ -2904,6 +2910,9 @@ func (e *Epoch) storeFinalization(finalization *common.Finalization) error {
 			zap.Stringer("block header", &expectedBlockHeader),
 			zap.Stringer("finalized block header", &finalization.Finalization.BlockHeader))
 		delete(e.rounds, roundNum)
+		// We have received a block that has been equivocated and doesn't match the finalization that was assembled.
+		// We therefore need to request a different block that corresponds to this finalization.
+		e.replicationState.ReceivedFutureFinalization(finalization, e.nextSeqToCommit())
 		return fmt.Errorf("finalization block header does not match round %d block header", roundNum)
 	}
 

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -21,7 +21,7 @@ import (
 )
 
 var (
-	ErrAlreadyStarted = errors.New("epoch already started")
+	ErrAlreadyStarted         = errors.New("epoch already started")
 	notarizationBlockMismatch = errors.New("notarization block header mismatches stored round block header")
 )
 
@@ -372,7 +372,7 @@ func (e *Epoch) loadNotarizationRecord(r []byte) error {
 		return nil
 	}
 
-	if err := e.storeNotarization(&notarization); err != nil && ! errors.Is(err, notarizationBlockMismatch){
+	if err := e.storeNotarization(&notarization); err != nil && !errors.Is(err, notarizationBlockMismatch) {
 		e.Logger.Debug("Failed to store notarization from WAL", zap.Uint64("Round", notarization.Vote.Round), zap.Error(err))
 		return err
 	}
@@ -2310,16 +2310,16 @@ func (e *Epoch) createNotarizedBlockVerificationTask(block common.Block, notariz
 			return md.Digest
 		}
 
+		// store the block in rounds
+		if !e.storeProposal(verifiedBlock) {
+			e.Logger.Debug("Unable to store proposed block for the round", zap.Uint64("round", md.Round))
+			return md.Digest
+		}
+
 		blockRecord := common.BlockRecord(md, blockBytes)
 		if err := e.WAL.Append(blockRecord); err != nil {
 			e.haltedError = err
 			e.Logger.Error("Failed to append block record to WAL", zap.Error(err))
-			return md.Digest
-		}
-
-		// store the block in rounds
-		if !e.storeProposal(verifiedBlock) {
-			e.Logger.Debug("Unable to store proposed block for the round", zap.Uint64("round", md.Round))
 			return md.Digest
 		}
 

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -20,7 +20,10 @@ import (
 	"go.uber.org/zap"
 )
 
-var ErrAlreadyStarted = errors.New("epoch already started")
+var (
+	ErrAlreadyStarted = errors.New("epoch already started")
+	notarizationBlockMismatch = errors.New("notarization block header mismatches stored round block header")
+)
 
 const (
 	DefaultMaxRoundWindow                 = 10
@@ -369,7 +372,8 @@ func (e *Epoch) loadNotarizationRecord(r []byte) error {
 		return nil
 	}
 
-	if err := e.storeNotarization(&notarization); err != nil {
+	if err := e.storeNotarization(&notarization); err != nil && ! errors.Is(err, notarizationBlockMismatch){
+		e.Logger.Debug("Failed to store notarization from WAL", zap.Uint64("Round", notarization.Vote.Round), zap.Error(err))
 		return err
 	}
 
@@ -409,7 +413,7 @@ func (e *Epoch) storeNotarization(notarization *common.Notarization) error {
 		delete(e.rounds, roundNum)
 		// We need to request the correct block from the network, as we have received the wrong block for this round.
 		e.replicationState.ReceivedFutureRound(expectedBlockHeader.Round, expectedBlockHeader.Seq, e.round, notarization.QC.Signers())
-		return fmt.Errorf("notarization block header does not match round %d block header", roundNum)
+		return notarizationBlockMismatch
 	}
 
 	round.notarization = notarization
@@ -2296,6 +2300,20 @@ func (e *Epoch) createNotarizedBlockVerificationTask(block common.Block, notariz
 		if ok && round.notarization != nil {
 			e.Logger.Debug("Verifying notarized block that already has a notarization for the round",
 				zap.Uint64("round", md.Round))
+			return md.Digest
+		}
+
+		blockBytes, err := verifiedBlock.Bytes()
+		if err != nil {
+			e.haltedError = err
+			e.Logger.Error("Failed to serialize block", zap.Error(err))
+			return md.Digest
+		}
+
+		blockRecord := common.BlockRecord(md, blockBytes)
+		if err := e.WAL.Append(blockRecord); err != nil {
+			e.haltedError = err
+			e.Logger.Error("Failed to append block record to WAL", zap.Error(err))
 			return md.Digest
 		}
 

--- a/simplex/epoch_failover_test.go
+++ b/simplex/epoch_failover_test.go
@@ -1078,6 +1078,7 @@ func TestEpochBlacklist(t *testing.T) {
 	wal.AssertNotarization(11)
 
 	// Now it's our turn to propose a new block.
+	// We make sure it is built how we expect it to be built below.
 	bb.BlockShouldBeBuilt <- struct{}{}
 
 	block = bb.GetBuiltBlock()
@@ -1096,21 +1097,8 @@ func TestEpochBlacklist(t *testing.T) {
 		Updates: []BlacklistUpdate{{Type: BlacklistOpType_NodeRedeemed, NodeIndex: 3}},
 	}, block.Blacklist(), "Node should vote to redeem the previously failed node")
 
-	blacklist = Blacklist{
-		NodeCount: 4,
-		SuspectedNodes: SuspectedNodes{
-			{
-				NodeIndex:       3,
-				SuspectingCount: 2,
-				OrbitSuspected:  1,
-				RedeemingCount:  2,
-				OrbitToRedeem:   Orbit(12, 3, 4),
-			},
-		},
-		Updates: []BlacklistUpdate{{Type: BlacklistOpType_NodeRedeemed, NodeIndex: 3}},
-	}
-
-	block, _ = bb.BuildBlock(context.Background(), e.Metadata(), blacklist)
+	require.Equal(t, conf.ID, LeaderForRound(nodes, block.BlockHeader().Round))
+	bb.SetBuiltBlock(block.(*testutil.TestBlock)) // Insert the block built by the block builder back into block builder so it will re-propose it
 	block, _ = notarizeAndFinalizeRound(t, e, bb)
 
 	// The next blacklist garbage collects node 3 from the blacklist.

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -1727,6 +1727,58 @@ func TestEpochRequestsEmptyRoundDependency(t *testing.T) {
 	require.Equal(t, uint64(3), e.Metadata().Round)
 }
 
+func TestReplicatedNotarizationRestart(t *testing.T) {
+	// A test that makes a notarization be replicated to a node that doesn't have the block,
+	// and then restarts the node. The node must recover from the WAL and start successfully.
+
+	bb := testutil.NewTestBlockBuilder()
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+
+	conf, wal, _ := testutil.DefaultTestNodeEpochConfig(t, nodes[1], testutil.NewNoopComm(nodes), bb)
+	conf.ReplicationEnabled = true
+
+	leader := LeaderForRound(nodes, 0)
+	require.NotEqual(t, conf.ID, leader) // The node is not the leader for round 0.
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+	require.NoError(t, e.Start())
+
+	// Build the block the leader proposed for round 0. The node itself never receives it.
+	md := e.Metadata()
+	_, ok := bb.BuildBlock(context.Background(), md, emptyBlacklist)
+	require.True(t, ok)
+	block := bb.GetBuiltBlock()
+
+	validators := e.Comm.Validators()
+	sigAggr := e.SignatureAggregatorCreator(validators)
+	signers := validators.NodeIDs()[:Quorum(len(validators))]
+
+	notarization, err := testutil.NewNotarization(conf.Logger, sigAggr, block, signers)
+	require.NoError(t, err)
+
+	// (1) Feed the node the notarization. It has no block for this round, so it must
+	// request the block from the network (replication).
+	testutil.InjectTestNotarization(t, e, notarization, nodes[2])
+
+	// (2) Feed the node the replication response carrying the authentic notarized block.
+	require.NoError(t, e.HandleMessage(&Message{
+		ReplicationResponse: &ReplicationResponse{
+			Data: []QuorumRound{{Block: block, Notarization: &notarization}},
+		},
+	}, nodes[2]))
+
+	// (3) The node persisted the notarization to the WAL.
+	require.Equal(t, NotarizationRecordType, wal.AssertNotarization(0))
+
+	// (4) Restart: the node must recover from the WAL and start successfully.
+	e.Stop()
+	e, err = NewEpoch(conf)
+	require.NoError(t, err)
+	require.NoError(t, e.Start())
+	t.Cleanup(e.Stop)
+}
+
 // Ensures we don't double increment the round on persisting a notarization
 func TestDoubleIncrementOnPersistNotarization(t *testing.T) {
 	// add an empty notarization, then a notarization for a previous round

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -451,6 +451,115 @@ func TestEpochIndexFinalization(t *testing.T) {
 	storage.WaitForBlockCommit(2)
 }
 
+func TestEquivocatedBlockNotarized(t *testing.T) {
+	bb := testutil.NewTestBlockBuilder()
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+
+	recordingComm := &recordingComm{
+		Communication:     testutil.NewNoopComm(nodes),
+		BroadcastMessages: make(chan *Message, 100),
+		SentMessages:      make(chan *Message, 100),
+	}
+	conf, wal, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[1], recordingComm, bb)
+	conf.ReplicationEnabled = true
+
+	leader := LeaderForRound(nodes, 0)
+	require.NotEqual(t, conf.ID, leader) // Ensure that the node is not the leader for the first round.
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	// (1) Byzantine leader equivocates and sends a block to the node.
+	md := e.Metadata()
+	_, ok := bb.BuildBlock(context.Background(), md, emptyBlacklist)
+	require.True(t, ok)
+	blockA := bb.GetBuiltBlock()
+
+	voteA, err := testutil.NewTestVote(blockA, leader)
+	require.NoError(t, err)
+	require.NoError(t, e.HandleMessage(&Message{
+		BlockMessage: &BlockMessage{
+			Vote:  *voteA,
+			Block: blockA,
+		},
+	}, leader))
+
+	// (2) Ensure the node has written the block to the WAL.
+	wal.AssertWALSize(1)
+
+	// (3) The honest majority notarizes a *different* block B for the same round.
+	blockB := testutil.NewTestBlock(blockA.BlockHeader().ProtocolMetadata, emptyBlacklist)
+	blockB.Data = []byte("equivocated-block-B")
+	blockB.ComputeDigest()
+	// Ensure that the two blocks are different.
+	require.NotEqual(t, blockA.BlockHeader().Digest, blockB.BlockHeader().Digest)
+
+	validators := e.Comm.Validators()
+	quorum := Quorum(len(validators))
+	sigAggr := e.SignatureAggregatorCreator(validators)
+	notarizationB, err := testutil.NewNotarization(e.Logger, sigAggr, blockB, validators.NodeIDs()[:quorum])
+	require.NoError(t, err)
+	require.Equal(t, blockB.BlockHeader().Digest, notarizationB.Vote.BlockHeader.Digest)
+
+	// (4) Send the notarization for block B to the node.
+	testutil.InjectTestNotarization(t, e, notarizationB, nodes[2])
+
+	// The node must NOT advance the round: it never received block B, so it cannot
+	// notarize the round it has (which holds block A). The equivocated round is thrown away.
+	require.Never(t, func() bool {
+		return e.Metadata().Round > 0
+	}, time.Second, 100*time.Millisecond)
+	// The equivocated notarization is not persisted to the WAL (still just the block record).
+	wal.AssertWALSize(1)
+
+	// (5) The honest majority continues past the equivocated round: round 1 is empty
+	// notarized (a timeout), and block C is finalized at round 2 building directly on
+	// top of block B (seq 1). Receiving the finalization for round 2 makes the node
+	// realize it is behind and triggers replication.
+	blockC := testutil.NewTestBlock(ProtocolMetadata{
+		Round: 2,
+		Seq:   1,
+		Prev:  blockB.BlockHeader().Digest,
+	}, emptyBlacklist)
+	finalizationC, _ := testutil.NewFinalizationRecord(t, sigAggr, blockC, validators.NodeIDs()[:quorum])
+
+	// (6) The future finalization for round 2 triggers a replication request.
+	testutil.InjectTestFinalization(t, e, &finalizationC, nodes[2])
+
+	for msg := range recordingComm.SentMessages {
+		if msg.ReplicationRequest != nil {
+			break
+		}
+	}
+
+	// (7) Feed the node the replication response containing block B (notarized and
+	// finalized by the network) and block C built on block B.
+	finalizationB, _ := testutil.NewFinalizationRecord(t, sigAggr, blockB, validators.NodeIDs()[:quorum])
+	replicationResponse := &ReplicationResponse{
+		Data: []QuorumRound{
+			{
+				Block:        blockB,
+				Finalization: &finalizationB,
+			},
+			{
+				Block:        blockC,
+				Finalization: &finalizationC,
+			},
+		},
+	}
+	require.NoError(t, e.HandleMessage(&Message{
+		ReplicationResponse: replicationResponse,
+	}, nodes[2]))
+
+	// (8) The node recovers by committing the block the network actually agreed on
+	// (block B) at seq 0, not the equivocated block A, followed by block C at seq 1.
+	require.Equal(t, blockB, storage.WaitForBlockCommit(0))
+	require.Equal(t, blockC, storage.WaitForBlockCommit(1))
+	require.Equal(t, uint64(2), storage.NumBlocks())
+}
+
 func TestEquivocatedBlockFinalized(t *testing.T) {
 	bb := testutil.NewTestBlockBuilder()
 	nodes := []NodeID{{1}, {2}, {3}, {4}}

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -451,7 +451,6 @@ func TestEpochIndexFinalization(t *testing.T) {
 	storage.WaitForBlockCommit(2)
 }
 
-
 func TestEquivocatedBlock(t *testing.T) {
 	// Tests a case where a Byzantine leader equivocates:
 	// it sends block A to the node while the honest majority certifies a different
@@ -1771,7 +1770,7 @@ func TestDoubleIncrementOnPersistNotarization(t *testing.T) {
 	}, nodes[0])
 	require.NoError(t, err)
 
-	wal.AssertWALSize(2)
+	wal.AssertWALSize(3)
 	// ensure the round is still 1
 	require.Equal(t, uint64(1), e.Metadata().Round)
 }

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -468,7 +468,6 @@ func TestEquivocatedBlockNotarized(t *testing.T) {
 
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)
-	t.Cleanup(e.Stop)
 	require.NoError(t, e.Start())
 
 	// (1) Byzantine leader equivocates and sends a block to the node.
@@ -523,12 +522,15 @@ func TestEquivocatedBlockNotarized(t *testing.T) {
 
 	// (6) Feed the node the replication response containing block B (notarized and
 	// finalized by the network)
-	finalizationB, _ := testutil.NewFinalizationRecord(t, sigAggr, blockB, validators.NodeIDs()[:quorum])
+	l := testutil.MakeLogger(t)
+	notarization, err := testutil.NewNotarization(l, sigAggr, blockB, validators.NodeIDs()[:quorum])
+	require.NoError(t, err)
+
 	replicationResponse := &ReplicationResponse{
 		Data: []QuorumRound{
 			{
 				Block:        blockB,
-				Finalization: &finalizationB,
+				Notarization: &notarization,
 			},
 		},
 	}
@@ -536,10 +538,51 @@ func TestEquivocatedBlockNotarized(t *testing.T) {
 		ReplicationResponse: replicationResponse,
 	}, nodes[2]))
 
-	// (7) The node commits the block the network actually agreed on
-	// (block B) at seq 0, not the equivocated block A.
-	require.Equal(t, blockB, storage.WaitForBlockCommit(0))
-	require.Equal(t, uint64(1), storage.NumBlocks())
+	// (7) The node writes the notarization of (block B) to the WAL
+	require.Equal(t, NotarizationRecordType, wal.AssertNotarization(0))
+	require.Equal(t, uint64(0), storage.NumBlocks())
+
+	// The rest of the test ensures that when the node restarts,
+	// the node will have in its memory only the correct block and not the equivocated block.
+	e.Stop()
+	e, err = NewEpoch(conf)
+	require.NoError(t, err)
+	require.NoError(t, e.Start())
+	t.Cleanup(e.Stop)
+
+	// Drain the output channel
+	for len(recordingComm.SentMessages) > 0 {
+		<-recordingComm.SentMessages
+	}
+
+	// Next we send a replication request to the node and we expect to get the correct block B and not the equivocated block A.
+	require.NoError(t, e.HandleMessage(&Message{
+		ReplicationRequest: &ReplicationRequest{
+			Rounds: []uint64{0},
+		},
+	}, nodes[2]))
+
+	// The node should reply with the block the network finalized (block B), never the
+	// equivocated block A that only it ever saw.
+	var resp *VerifiedReplicationResponse
+	require.Eventually(t, func() bool {
+		for {
+			select {
+			case msg := <-recordingComm.SentMessages:
+				if msg.VerifiedReplicationResponse != nil {
+					resp = msg.VerifiedReplicationResponse
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, 5*time.Second, 50*time.Millisecond, "node did not reply to the replication request")
+
+	require.Len(t, resp.Data, 1)
+	gotBlock := resp.Data[0].VerifiedBlock
+	require.Equal(t, blockB.BlockHeader().Digest, gotBlock.BlockHeader().Digest)
+	require.NotEqual(t, blockA.BlockHeader().Digest, gotBlock.BlockHeader().Digest)
 }
 
 func TestEquivocatedBlockFinalized(t *testing.T) {
@@ -559,7 +602,6 @@ func TestEquivocatedBlockFinalized(t *testing.T) {
 
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)
-	t.Cleanup(e.Stop)
 	require.NoError(t, e.Start())
 
 	// (1) Byzantine leader equivocates and sends a block to the node.
@@ -624,6 +666,44 @@ func TestEquivocatedBlockFinalized(t *testing.T) {
 	// (block B) at seq 0, not the equivocated block A, followed by block C at seq 1.
 	require.Equal(t, blockB, storage.WaitForBlockCommit(0))
 	require.Equal(t, uint64(1), storage.NumBlocks())
+
+	// The rest of the test ensures that when the node restarts,
+	// the node will have in its memory only the correct block and not the equivocated block.
+	e.Stop()
+	e, err = NewEpoch(conf)
+	require.NoError(t, err)
+	require.NoError(t, e.Start())
+	t.Cleanup(e.Stop)
+
+	// Send a replication request to the restarted node and expect to get the correct
+	// block B and not the equivocated block A.
+	require.NoError(t, e.HandleMessage(&Message{
+		ReplicationRequest: &ReplicationRequest{
+			Seqs: []uint64{0},
+		},
+	}, nodes[2]))
+
+	// The node should reply with the block the network finalized (block B), never the
+	// equivocated block A that only it ever saw.
+	var resp *VerifiedReplicationResponse
+	require.Eventually(t, func() bool {
+		for {
+			select {
+			case msg := <-recordingComm.SentMessages:
+				if msg.VerifiedReplicationResponse != nil {
+					resp = msg.VerifiedReplicationResponse
+					return true
+				}
+			default:
+				return false
+			}
+		}
+	}, 5*time.Second, 50*time.Millisecond, "node did not reply to the replication request")
+
+	require.Len(t, resp.Data, 1)
+	gotBlock := resp.Data[0].VerifiedBlock
+	require.Equal(t, blockB.BlockHeader().Digest, gotBlock.BlockHeader().Digest)
+	require.NotEqual(t, blockA.BlockHeader().Digest, gotBlock.BlockHeader().Digest)
 }
 
 func TestEpochConsecutiveProposalsDoNotGetVerified(t *testing.T) {

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -451,6 +451,109 @@ func TestEpochIndexFinalization(t *testing.T) {
 	storage.WaitForBlockCommit(2)
 }
 
+func TestEquivocatedBlockFinalized(t *testing.T) {
+	bb := testutil.NewTestBlockBuilder()
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+
+	recordingComm := &recordingComm{
+		Communication:     testutil.NewNoopComm(nodes),
+		BroadcastMessages: make(chan *Message, 100),
+		SentMessages:      make(chan *Message, 100),
+	}
+	conf, wal, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[1], recordingComm, bb)
+	conf.ReplicationEnabled = true
+
+	leader := LeaderForRound(nodes, 0)
+	require.NotEqual(t, conf.ID, leader) // Ensure that the node is not the leader for the first round.
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	// (1) Byzantine leader equivocates and sends a block to the node.
+	md := e.Metadata()
+	_, ok := bb.BuildBlock(context.Background(), md, emptyBlacklist)
+	require.True(t, ok)
+	blockA := bb.GetBuiltBlock()
+
+	voteA, err := testutil.NewTestVote(blockA, leader)
+	require.NoError(t, err)
+	require.NoError(t, e.HandleMessage(&Message{
+		BlockMessage: &BlockMessage{
+			Vote:  *voteA,
+			Block: blockA,
+		},
+	}, leader))
+
+	// (2) Ensure the node has written the block to the WAL.
+	wal.AssertWALSize(1)
+
+	// (3) The honest majority finalizes a *different* block B
+	blockB := testutil.NewTestBlock(blockA.BlockHeader().ProtocolMetadata, emptyBlacklist)
+	blockB.Data = []byte("equivocated-block-B")
+	blockB.ComputeDigest()
+	// Ensure that the two blocks are different.
+	require.NotEqual(t, blockA.BlockHeader().Digest, blockB.BlockHeader().Digest)
+
+	validators := e.Comm.Validators()
+	quorum := Quorum(len(validators))
+	sigAggr := e.SignatureAggregatorCreator(validators)
+	finalizationB, _ := testutil.NewFinalizationRecord(t, sigAggr, blockB, validators.NodeIDs()[:quorum])
+	require.Equal(t, blockB.BlockHeader().Digest, finalizationB.Finalization.BlockHeader.Digest)
+
+	// (4) Send the finalization for block B to the node.
+	testutil.InjectTestFinalization(t, e, &finalizationB, nodes[2])
+
+	// Block 0 should not commit the block because it has never received block B.
+	storage.EnsureNoBlockCommit(t, 0)
+
+	// (5) The honest majority continues past the equivocated round: round 1 is empty
+	// notarized (a timeout), and block C is finalized at round 2 building directly on
+	// top of block B (seq 1). Receiving the finalization for round 2 makes the node
+	// realize it is behind and triggers replication.
+
+	blockC := testutil.NewTestBlock(ProtocolMetadata{
+		Round: 2,
+		Seq:   1,
+		Prev:  blockB.BlockHeader().Digest,
+	}, emptyBlacklist)
+	finalizationC, _ := testutil.NewFinalizationRecord(t, sigAggr, blockC, validators.NodeIDs()[:quorum])
+
+	// (6) The future finalization for round 2 triggers a replication request.
+	testutil.InjectTestFinalization(t, e, &finalizationC, nodes[2])
+
+	for msg := range recordingComm.SentMessages {
+		if msg.ReplicationRequest != nil {
+			break
+		}
+	}
+
+	// (7) Feed the node the replication response containing the correctly finalized
+	// block B and block C built on block B.
+	replicationResponse := &ReplicationResponse{
+		Data: []QuorumRound{
+			{
+				Block:        blockB,
+				Finalization: &finalizationB,
+			},
+			{
+				Block:        blockC,
+				Finalization: &finalizationC,
+			},
+		},
+	}
+	require.NoError(t, e.HandleMessage(&Message{
+		ReplicationResponse: replicationResponse,
+	}, nodes[2]))
+
+	// (8) The node recovers by committing the block the network actually finalized
+	// (block B) at seq 0, not the equivocated block A, followed by block C at seq 1.
+	require.Equal(t, blockB, storage.WaitForBlockCommit(0))
+	require.Equal(t, blockC, storage.WaitForBlockCommit(1))
+	require.Equal(t, uint64(2), storage.NumBlocks())
+}
+
 func TestEpochConsecutiveProposalsDoNotGetVerified(t *testing.T) {
 	for _, test := range []struct {
 		name                      string

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -514,28 +514,15 @@ func TestEquivocatedBlockNotarized(t *testing.T) {
 	// The equivocated notarization is not persisted to the WAL (still just the block record).
 	wal.AssertWALSize(1)
 
-	// (5) The honest majority continues past the equivocated round: round 1 is empty
-	// notarized (a timeout), and block C is finalized at round 2 building directly on
-	// top of block B (seq 1). Receiving the finalization for round 2 makes the node
-	// realize it is behind and triggers replication.
-	blockC := testutil.NewTestBlock(ProtocolMetadata{
-		Round: 2,
-		Seq:   1,
-		Prev:  blockB.BlockHeader().Digest,
-	}, emptyBlacklist)
-	finalizationC, _ := testutil.NewFinalizationRecord(t, sigAggr, blockC, validators.NodeIDs()[:quorum])
-
-	// (6) The future finalization for round 2 triggers a replication request.
-	testutil.InjectTestFinalization(t, e, &finalizationC, nodes[2])
-
+	// (5) Wait until we receive a request to replicate the authentic block, block B.
 	for msg := range recordingComm.SentMessages {
 		if msg.ReplicationRequest != nil {
 			break
 		}
 	}
 
-	// (7) Feed the node the replication response containing block B (notarized and
-	// finalized by the network) and block C built on block B.
+	// (6) Feed the node the replication response containing block B (notarized and
+	// finalized by the network)
 	finalizationB, _ := testutil.NewFinalizationRecord(t, sigAggr, blockB, validators.NodeIDs()[:quorum])
 	replicationResponse := &ReplicationResponse{
 		Data: []QuorumRound{
@@ -543,21 +530,16 @@ func TestEquivocatedBlockNotarized(t *testing.T) {
 				Block:        blockB,
 				Finalization: &finalizationB,
 			},
-			{
-				Block:        blockC,
-				Finalization: &finalizationC,
-			},
 		},
 	}
 	require.NoError(t, e.HandleMessage(&Message{
 		ReplicationResponse: replicationResponse,
 	}, nodes[2]))
 
-	// (8) The node recovers by committing the block the network actually agreed on
-	// (block B) at seq 0, not the equivocated block A, followed by block C at seq 1.
+	// (7) The node commits the block the network actually agreed on
+	// (block B) at seq 0, not the equivocated block A.
 	require.Equal(t, blockB, storage.WaitForBlockCommit(0))
-	require.Equal(t, blockC, storage.WaitForBlockCommit(1))
-	require.Equal(t, uint64(2), storage.NumBlocks())
+	require.Equal(t, uint64(1), storage.NumBlocks())
 }
 
 func TestEquivocatedBlockFinalized(t *testing.T) {
@@ -617,38 +599,20 @@ func TestEquivocatedBlockFinalized(t *testing.T) {
 	// Block 0 should not commit the block because it has never received block B.
 	storage.EnsureNoBlockCommit(t, 0)
 
-	// (5) The honest majority continues past the equivocated round: round 1 is empty
-	// notarized (a timeout), and block C is finalized at round 2 building directly on
-	// top of block B (seq 1). Receiving the finalization for round 2 makes the node
-	// realize it is behind and triggers replication.
-
-	blockC := testutil.NewTestBlock(ProtocolMetadata{
-		Round: 2,
-		Seq:   1,
-		Prev:  blockB.BlockHeader().Digest,
-	}, emptyBlacklist)
-	finalizationC, _ := testutil.NewFinalizationRecord(t, sigAggr, blockC, validators.NodeIDs()[:quorum])
-
-	// (6) The future finalization for round 2 triggers a replication request.
-	testutil.InjectTestFinalization(t, e, &finalizationC, nodes[2])
-
+	// (5) Wait until we receive a request to replicate the authentic block, block B.
 	for msg := range recordingComm.SentMessages {
 		if msg.ReplicationRequest != nil {
 			break
 		}
 	}
 
-	// (7) Feed the node the replication response containing the correctly finalized
-	// block B and block C built on block B.
+	// (6) Feed the node the replication response containing the correctly finalized
+	// block B.
 	replicationResponse := &ReplicationResponse{
 		Data: []QuorumRound{
 			{
 				Block:        blockB,
 				Finalization: &finalizationB,
-			},
-			{
-				Block:        blockC,
-				Finalization: &finalizationC,
 			},
 		},
 	}
@@ -659,8 +623,7 @@ func TestEquivocatedBlockFinalized(t *testing.T) {
 	// (8) The node recovers by committing the block the network actually finalized
 	// (block B) at seq 0, not the equivocated block A, followed by block C at seq 1.
 	require.Equal(t, blockB, storage.WaitForBlockCommit(0))
-	require.Equal(t, blockC, storage.WaitForBlockCommit(1))
-	require.Equal(t, uint64(2), storage.NumBlocks())
+	require.Equal(t, uint64(1), storage.NumBlocks())
 }
 
 func TestEpochConsecutiveProposalsDoNotGetVerified(t *testing.T) {

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -451,259 +451,200 @@ func TestEpochIndexFinalization(t *testing.T) {
 	storage.WaitForBlockCommit(2)
 }
 
-func TestEquivocatedBlockNotarized(t *testing.T) {
-	bb := testutil.NewTestBlockBuilder()
-	nodes := []NodeID{{1}, {2}, {3}, {4}}
 
-	recordingComm := &recordingComm{
-		Communication:     testutil.NewNoopComm(nodes),
-		BroadcastMessages: make(chan *Message, 100),
-		SentMessages:      make(chan *Message, 100),
-	}
-	conf, wal, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[1], recordingComm, bb)
-	conf.ReplicationEnabled = true
+func TestEquivocatedBlock(t *testing.T) {
+	// Tests a case where a Byzantine leader equivocates:
+	// it sends block A to the node while the honest majority certifies a different
+	// block B for the same round. The node must discard the equivocated round, replicate
+	// the authentic block B, and — after a restart — serve block B (never block A).
+	// The two sub-cases differ only in whether the honest majority notarized or
+	// finalized block B.
 
-	leader := LeaderForRound(nodes, 0)
-	require.NotEqual(t, conf.ID, leader) // Ensure that the node is not the leader for the first round.
-
-	e, err := NewEpoch(conf)
-	require.NoError(t, err)
-	require.NoError(t, e.Start())
-
-	// (1) Byzantine leader equivocates and sends a block to the node.
-	md := e.Metadata()
-	_, ok := bb.BuildBlock(context.Background(), md, emptyBlacklist)
-	require.True(t, ok)
-	blockA := bb.GetBuiltBlock()
-
-	voteA, err := testutil.NewTestVote(blockA, leader)
-	require.NoError(t, err)
-	require.NoError(t, e.HandleMessage(&Message{
-		BlockMessage: &BlockMessage{
-			Vote:  *voteA,
-			Block: blockA,
-		},
-	}, leader))
-
-	// (2) Ensure the node has written the block to the WAL.
-	wal.AssertWALSize(1)
-
-	// (3) The honest majority notarizes a *different* block B for the same round.
-	blockB := testutil.NewTestBlock(blockA.BlockHeader().ProtocolMetadata, emptyBlacklist)
-	blockB.Data = []byte("equivocated-block-B")
-	blockB.ComputeDigest()
-	// Ensure that the two blocks are different.
-	require.NotEqual(t, blockA.BlockHeader().Digest, blockB.BlockHeader().Digest)
-
-	validators := e.Comm.Validators()
-	quorum := Quorum(len(validators))
-	sigAggr := e.SignatureAggregatorCreator(validators)
-	notarizationB, err := testutil.NewNotarization(e.Logger, sigAggr, blockB, validators.NodeIDs()[:quorum])
-	require.NoError(t, err)
-	require.Equal(t, blockB.BlockHeader().Digest, notarizationB.Vote.BlockHeader.Digest)
-
-	// (4) Send the notarization for block B to the node.
-	testutil.InjectTestNotarization(t, e, notarizationB, nodes[2])
-
-	// The node must NOT advance the round: it never received block B, so it cannot
-	// notarize the round it has (which holds block A). The equivocated round is thrown away.
-	require.Never(t, func() bool {
-		return e.Metadata().Round > 0
-	}, time.Second, 100*time.Millisecond)
-	// The equivocated notarization is not persisted to the WAL (still just the block record).
-	wal.AssertWALSize(1)
-
-	// (5) Wait until we receive a request to replicate the authentic block, block B.
-	for msg := range recordingComm.SentMessages {
-		if msg.ReplicationRequest != nil {
-			break
-		}
-	}
-
-	// (6) Feed the node the replication response containing block B (notarized and
-	// finalized by the network)
-	l := testutil.MakeLogger(t)
-	notarization, err := testutil.NewNotarization(l, sigAggr, blockB, validators.NodeIDs()[:quorum])
-	require.NoError(t, err)
-
-	replicationResponse := &ReplicationResponse{
-		Data: []QuorumRound{
-			{
-				Block:        blockB,
-				Notarization: &notarization,
+	for _, tt := range []struct {
+		name string
+		// injectEquivocation delivers the honest majority's certificate for block B
+		// (which the node itself never received) to the running node.
+		injectEquivocation func(t *testing.T, e *Epoch, sigAggr SignatureAggregator, blockB *testutil.TestBlock, signers []NodeID, from NodeID)
+		// assertEquivocationDiscarded verifies the node discarded the equivocated round
+		// rather than acting on a certificate for a block it never saw.
+		assertEquivocationDiscarded func(t *testing.T, e *Epoch, wal *testutil.TestWAL, storage *testutil.InMemStorage)
+		// buildQR builds the QuorumRound carrying the authentic block B.
+		buildQR func(t *testing.T, sigAggr SignatureAggregator, blockB *testutil.TestBlock, signers []NodeID) QuorumRound
+		// assertReplicated verifies the node persisted block B after replication.
+		assertReplicated func(t *testing.T, wal *testutil.TestWAL, storage *testutil.InMemStorage, blockB *testutil.TestBlock)
+		// replicationRequest is the request sent to the restarted node to fetch block B.
+		replicationRequest ReplicationRequest
+	}{
+		{
+			name: "Notarized",
+			injectEquivocation: func(t *testing.T, e *Epoch, sigAggr SignatureAggregator, blockB *testutil.TestBlock, signers []NodeID, from NodeID) {
+				notarizationB, err := testutil.NewNotarization(e.Logger, sigAggr, blockB, signers)
+				require.NoError(t, err)
+				require.Equal(t, blockB.BlockHeader().Digest, notarizationB.Vote.BlockHeader.Digest)
+				testutil.InjectTestNotarization(t, e, notarizationB, from)
 			},
-		},
-	}
-	require.NoError(t, e.HandleMessage(&Message{
-		ReplicationResponse: replicationResponse,
-	}, nodes[2]))
-
-	// (7) The node writes the notarization of (block B) to the WAL
-	require.Equal(t, NotarizationRecordType, wal.AssertNotarization(0))
-	require.Equal(t, uint64(0), storage.NumBlocks())
-
-	// The rest of the test ensures that when the node restarts,
-	// the node will have in its memory only the correct block and not the equivocated block.
-	e.Stop()
-	e, err = NewEpoch(conf)
-	require.NoError(t, err)
-	require.NoError(t, e.Start())
-	t.Cleanup(e.Stop)
-
-	// Drain the output channel
-	for len(recordingComm.SentMessages) > 0 {
-		<-recordingComm.SentMessages
-	}
-
-	// Next we send a replication request to the node and we expect to get the correct block B and not the equivocated block A.
-	require.NoError(t, e.HandleMessage(&Message{
-		ReplicationRequest: &ReplicationRequest{
-			Rounds: []uint64{0},
-		},
-	}, nodes[2]))
-
-	// The node should reply with the block the network finalized (block B), never the
-	// equivocated block A that only it ever saw.
-	var resp *VerifiedReplicationResponse
-	require.Eventually(t, func() bool {
-		for {
-			select {
-			case msg := <-recordingComm.SentMessages:
-				if msg.VerifiedReplicationResponse != nil {
-					resp = msg.VerifiedReplicationResponse
-					return true
-				}
-			default:
-				return false
-			}
-		}
-	}, 5*time.Second, 50*time.Millisecond, "node did not reply to the replication request")
-
-	require.Len(t, resp.Data, 1)
-	gotBlock := resp.Data[0].VerifiedBlock
-	require.Equal(t, blockB.BlockHeader().Digest, gotBlock.BlockHeader().Digest)
-	require.NotEqual(t, blockA.BlockHeader().Digest, gotBlock.BlockHeader().Digest)
-}
-
-func TestEquivocatedBlockFinalized(t *testing.T) {
-	bb := testutil.NewTestBlockBuilder()
-	nodes := []NodeID{{1}, {2}, {3}, {4}}
-
-	recordingComm := &recordingComm{
-		Communication:     testutil.NewNoopComm(nodes),
-		BroadcastMessages: make(chan *Message, 100),
-		SentMessages:      make(chan *Message, 100),
-	}
-	conf, wal, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[1], recordingComm, bb)
-	conf.ReplicationEnabled = true
-
-	leader := LeaderForRound(nodes, 0)
-	require.NotEqual(t, conf.ID, leader) // Ensure that the node is not the leader for the first round.
-
-	e, err := NewEpoch(conf)
-	require.NoError(t, err)
-	require.NoError(t, e.Start())
-
-	// (1) Byzantine leader equivocates and sends a block to the node.
-	md := e.Metadata()
-	_, ok := bb.BuildBlock(context.Background(), md, emptyBlacklist)
-	require.True(t, ok)
-	blockA := bb.GetBuiltBlock()
-
-	voteA, err := testutil.NewTestVote(blockA, leader)
-	require.NoError(t, err)
-	require.NoError(t, e.HandleMessage(&Message{
-		BlockMessage: &BlockMessage{
-			Vote:  *voteA,
-			Block: blockA,
-		},
-	}, leader))
-
-	// (2) Ensure the node has written the block to the WAL.
-	wal.AssertWALSize(1)
-
-	// (3) The honest majority finalizes a *different* block B
-	blockB := testutil.NewTestBlock(blockA.BlockHeader().ProtocolMetadata, emptyBlacklist)
-	blockB.Data = []byte("equivocated-block-B")
-	blockB.ComputeDigest()
-	// Ensure that the two blocks are different.
-	require.NotEqual(t, blockA.BlockHeader().Digest, blockB.BlockHeader().Digest)
-
-	validators := e.Comm.Validators()
-	quorum := Quorum(len(validators))
-	sigAggr := e.SignatureAggregatorCreator(validators)
-	finalizationB, _ := testutil.NewFinalizationRecord(t, sigAggr, blockB, validators.NodeIDs()[:quorum])
-	require.Equal(t, blockB.BlockHeader().Digest, finalizationB.Finalization.BlockHeader.Digest)
-
-	// (4) Send the finalization for block B to the node.
-	testutil.InjectTestFinalization(t, e, &finalizationB, nodes[2])
-
-	// Block 0 should not commit the block because it has never received block B.
-	storage.EnsureNoBlockCommit(t, 0)
-
-	// (5) Wait until we receive a request to replicate the authentic block, block B.
-	for msg := range recordingComm.SentMessages {
-		if msg.ReplicationRequest != nil {
-			break
-		}
-	}
-
-	// (6) Feed the node the replication response containing the correctly finalized
-	// block B.
-	replicationResponse := &ReplicationResponse{
-		Data: []QuorumRound{
-			{
-				Block:        blockB,
-				Finalization: &finalizationB,
+			assertEquivocationDiscarded: func(t *testing.T, e *Epoch, wal *testutil.TestWAL, storage *testutil.InMemStorage) {
+				// The node must NOT advance the round: it never received block B, so it
+				// cannot notarize the round it has (which holds block A). The equivocated
+				// round is thrown away.
+				require.Never(t, func() bool {
+					return e.Metadata().Round > 0
+				}, time.Second, 100*time.Millisecond)
+				// The equivocated notarization is not persisted to the WAL (still just the block record).
+				wal.AssertWALSize(1)
 			},
+			buildQR: func(t *testing.T, sigAggr SignatureAggregator, blockB *testutil.TestBlock, signers []NodeID) QuorumRound {
+				notarization, err := testutil.NewNotarization(testutil.MakeLogger(t), sigAggr, blockB, signers)
+				require.NoError(t, err)
+				return QuorumRound{Block: blockB, Notarization: &notarization}
+			},
+			assertReplicated: func(t *testing.T, wal *testutil.TestWAL, storage *testutil.InMemStorage, blockB *testutil.TestBlock) {
+				// The node writes the notarization of block B to the WAL but does not commit it.
+				require.Equal(t, NotarizationRecordType, wal.AssertNotarization(0))
+				require.Equal(t, uint64(0), storage.NumBlocks())
+			},
+			replicationRequest: ReplicationRequest{Rounds: []uint64{0}},
 		},
-	}
-	require.NoError(t, e.HandleMessage(&Message{
-		ReplicationResponse: replicationResponse,
-	}, nodes[2]))
-
-	// (8) The node recovers by committing the block the network actually finalized
-	// (block B) at seq 0, not the equivocated block A, followed by block C at seq 1.
-	require.Equal(t, blockB, storage.WaitForBlockCommit(0))
-	require.Equal(t, uint64(1), storage.NumBlocks())
-
-	// The rest of the test ensures that when the node restarts,
-	// the node will have in its memory only the correct block and not the equivocated block.
-	e.Stop()
-	e, err = NewEpoch(conf)
-	require.NoError(t, err)
-	require.NoError(t, e.Start())
-	t.Cleanup(e.Stop)
-
-	// Send a replication request to the restarted node and expect to get the correct
-	// block B and not the equivocated block A.
-	require.NoError(t, e.HandleMessage(&Message{
-		ReplicationRequest: &ReplicationRequest{
-			Seqs: []uint64{0},
+		{
+			name: "Finalized",
+			injectEquivocation: func(t *testing.T, e *Epoch, sigAggr SignatureAggregator, blockB *testutil.TestBlock, signers []NodeID, from NodeID) {
+				finalizationB, _ := testutil.NewFinalizationRecord(t, sigAggr, blockB, signers)
+				require.Equal(t, blockB.BlockHeader().Digest, finalizationB.Finalization.BlockHeader.Digest)
+				testutil.InjectTestFinalization(t, e, &finalizationB, from)
+			},
+			assertEquivocationDiscarded: func(t *testing.T, e *Epoch, wal *testutil.TestWAL, storage *testutil.InMemStorage) {
+				// Block 0 should not commit because the node never received block B.
+				storage.EnsureNoBlockCommit(t, 0)
+			},
+			buildQR: func(t *testing.T, sigAggr SignatureAggregator, blockB *testutil.TestBlock, signers []NodeID) QuorumRound {
+				finalizationB, _ := testutil.NewFinalizationRecord(t, sigAggr, blockB, signers)
+				return QuorumRound{Block: blockB, Finalization: &finalizationB}
+			},
+			assertReplicated: func(t *testing.T, wal *testutil.TestWAL, storage *testutil.InMemStorage, blockB *testutil.TestBlock) {
+				// The node recovers by committing the block the network actually finalized
+				// (block B) at seq 0, not the equivocated block A.
+				require.Equal(t, blockB, storage.WaitForBlockCommit(0))
+				require.Equal(t, uint64(1), storage.NumBlocks())
+			},
+			replicationRequest: ReplicationRequest{Seqs: []uint64{0}},
 		},
-	}, nodes[2]))
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bb := testutil.NewTestBlockBuilder()
+			nodes := []NodeID{{1}, {2}, {3}, {4}}
 
-	// The node should reply with the block the network finalized (block B), never the
-	// equivocated block A that only it ever saw.
-	var resp *VerifiedReplicationResponse
-	require.Eventually(t, func() bool {
-		for {
-			select {
-			case msg := <-recordingComm.SentMessages:
-				if msg.VerifiedReplicationResponse != nil {
-					resp = msg.VerifiedReplicationResponse
-					return true
-				}
-			default:
-				return false
+			recordingComm := &recordingComm{
+				Communication:     testutil.NewNoopComm(nodes),
+				BroadcastMessages: make(chan *Message, 100),
+				SentMessages:      make(chan *Message, 100),
 			}
-		}
-	}, 5*time.Second, 50*time.Millisecond, "node did not reply to the replication request")
+			conf, wal, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[1], recordingComm, bb)
+			conf.ReplicationEnabled = true
 
-	require.Len(t, resp.Data, 1)
-	gotBlock := resp.Data[0].VerifiedBlock
-	require.Equal(t, blockB.BlockHeader().Digest, gotBlock.BlockHeader().Digest)
-	require.NotEqual(t, blockA.BlockHeader().Digest, gotBlock.BlockHeader().Digest)
+			leader := LeaderForRound(nodes, 0)
+			require.NotEqual(t, conf.ID, leader) // Ensure that the node is not the leader for the first round.
+
+			e, err := NewEpoch(conf)
+			require.NoError(t, err)
+			require.NoError(t, e.Start())
+
+			// (1) Byzantine leader equivocates and sends block A to the node.
+			md := e.Metadata()
+			_, ok := bb.BuildBlock(context.Background(), md, emptyBlacklist)
+			require.True(t, ok)
+			blockA := bb.GetBuiltBlock()
+
+			voteA, err := testutil.NewTestVote(blockA, leader)
+			require.NoError(t, err)
+			require.NoError(t, e.HandleMessage(&Message{
+				BlockMessage: &BlockMessage{
+					Vote:  *voteA,
+					Block: blockA,
+				},
+			}, leader))
+
+			// (2) Ensure the node has written the block to the WAL.
+			wal.AssertWALSize(1)
+
+			// (3) The honest majority certifies a *different* block B for the same round.
+			blockB := testutil.NewTestBlock(blockA.BlockHeader().ProtocolMetadata, emptyBlacklist)
+			blockB.Data = []byte("equivocated-block-B")
+			blockB.ComputeDigest()
+			// Ensure that the two blocks are different.
+			require.NotEqual(t, blockA.BlockHeader().Digest, blockB.BlockHeader().Digest)
+
+			validators := e.Comm.Validators()
+			quorum := Quorum(len(validators))
+			sigAggr := e.SignatureAggregatorCreator(validators)
+			signers := validators.NodeIDs()[:quorum]
+
+			// (4) Send the honest majority's certificate for block B to the node.
+			tt.injectEquivocation(t, e, sigAggr, blockB, signers, nodes[2])
+
+			// The node must discard the equivocated round: it never received block B.
+			tt.assertEquivocationDiscarded(t, e, wal, storage)
+
+			// (5) Wait until we receive a request to replicate the authentic block, block B.
+			for msg := range recordingComm.SentMessages {
+				if msg.ReplicationRequest != nil {
+					break
+				}
+			}
+
+			// (6) Feed the node the replication response containing the authentic block B.
+			replicationResponse := &ReplicationResponse{
+				Data: []QuorumRound{tt.buildQR(t, sigAggr, blockB, signers)},
+			}
+			require.NoError(t, e.HandleMessage(&Message{
+				ReplicationResponse: replicationResponse,
+			}, nodes[2]))
+
+			// (7) The node persists block B.
+			tt.assertReplicated(t, wal, storage, blockB)
+
+			// The rest of the test ensures that when the node restarts, it has in its
+			// storage/memory only the correct block B and not the equivocated block A.
+			e.Stop()
+			e, err = NewEpoch(conf)
+			require.NoError(t, err)
+			require.NoError(t, e.Start())
+			t.Cleanup(e.Stop)
+
+			// Drain the output channel.
+			for len(recordingComm.SentMessages) > 0 {
+				<-recordingComm.SentMessages
+			}
+
+			// (8) Send a replication request to the restarted node and expect to get the
+			// correct block B and not the equivocated block A.
+			replicationRequest := tt.replicationRequest
+			require.NoError(t, e.HandleMessage(&Message{
+				ReplicationRequest: &replicationRequest,
+			}, nodes[2]))
+
+			// The node should reply with the block the network certified (block B), never
+			// the equivocated block A that only it ever saw.
+			var resp *VerifiedReplicationResponse
+			require.Eventually(t, func() bool {
+				for {
+					select {
+					case msg := <-recordingComm.SentMessages:
+						if msg.VerifiedReplicationResponse != nil {
+							resp = msg.VerifiedReplicationResponse
+							return true
+						}
+					default:
+						return false
+					}
+				}
+			}, 5*time.Second, 50*time.Millisecond, "node did not reply to the replication request")
+
+			require.Len(t, resp.Data, 1)
+			gotBlock := resp.Data[0].VerifiedBlock
+			require.Equal(t, blockB.BlockHeader().Digest, gotBlock.BlockHeader().Digest)
+			require.NotEqual(t, blockA.BlockHeader().Digest, gotBlock.BlockHeader().Digest)
+		})
+	}
 }
 
 func TestEpochConsecutiveProposalsDoNotGetVerified(t *testing.T) {


### PR DESCRIPTION
When receiving a notarization, check if the block received beforehand corresponds to the received notarization, and if not, delete the round.