### PR TITLE
Delay AdvanceTime() until Start() finished

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -121,6 +121,10 @@ func NewEpoch(conf EpochConfig) (*Epoch, error) {
 
 // AdvanceTime hints the engine that the given amount of time has passed.
 func (e *Epoch) AdvanceTime(t time.Time) {
+	// Don't advance time until the epoch has finished starting.
+	if !e.canReceiveMessages.Load() {
+		return
+	}
 	e.monitor.AdvanceTime(t)
 	e.replicationState.AdvanceTime(t)
 	e.timeoutHandler.Tick(t)


### PR DESCRIPTION
Start() performs operations without the lock because it is expected to be executed without anything else operating on the Epoch object.

Just like HandleMessage() checks that Start() finished executing, we should do the same for AdvanceTime().

Otherwise, we have a data race.