### PR TITLE
Fix TestMonitorPrematureCancelTask flake

### DIFF
--- a/simplex/monitor_test.go
+++ b/simplex/monitor_test.go
@@ -68,6 +68,17 @@ func TestMonitorPrematureCancelTask(t *testing.T) {
 	})
 
 	t.Run("Cancelled task does not fire", func(t *testing.T) {
+		// Occupy the monitor goroutine, otherwise it can dequeue and start the task below
+		// before we cancel it, and cancelling cannot stop a task that already started.
+		busy := make(chan struct{})
+		released := make(chan struct{})
+
+		mon.RunTask(func() {
+			close(busy)
+			<-released
+		})
+		<-busy
+
 		finish := make(chan struct{})
 
 		mon.RunTask(func() {
@@ -76,6 +87,7 @@ func TestMonitorPrematureCancelTask(t *testing.T) {
 		})
 
 		mon.CancelTask()
+		close(released)
 
 		close(finish)
 	})


### PR DESCRIPTION
`TestMonitorPrematureCancelTask/Cancelled_task_does_not_fire` enqueued a task with `RunTask` and cancelled it on the next line, with nothing ordering the two against the monitor goroutine. When that goroutine dequeued and started the task first, `CancelTask` could no longer stop it: it sets the flag after the task has already read it. The task then closed an already closed channel and panicked from the monitor goroutine, after the test had reported PASS.

The fix occupies the monitor goroutine first, so the task under test is provably still queued when `CancelTask` runs. The assertion is unchanged. Seen on an unrelated PR's CI: https://github.com/ava-labs/Simplex/actions/runs/30946903157/job/92121915997