### PR TITLE
Sweep the rounds map when replication commits a block

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -766,6 +766,15 @@ func (e *Epoch) restoreFromWal() error {
 		return err
 	}
 
+	// A restored finalization is stored but never indexed, so one may already be for the next
+	// sequence to commit. Blocks below that sequence are not restored, so the lowest round in
+	// the map holds the lowest restored sequence and is where the sweep has to start.
+	if len(e.rounds) > 0 {
+		if err := e.indexFinalizations(e.minRoundInRoundsMap()); err != nil {
+			return err
+		}
+	}
+
 	return e.resumeFromWal(highestRoundRecord)
 }
 
@@ -2010,9 +2019,13 @@ func (e *Epoch) processFinalizedBlock(block common.Block, finalization *common.F
 			delete(e.rounds, round.num)
 			return e.processFinalizedBlock(block, finalization)
 		}
-		if err := e.storeFinalization(finalization); err != nil {
-			e.Logger.Error("Failed storing finalization", zap.Error(err))
-			return err
+		// The round can already hold this finalization, stored while its sequence was ahead
+		// of the storage or restored from the WAL. Indexing it is all that remains.
+		if round.finalization == nil {
+			if err := e.storeFinalization(finalization); err != nil {
+				e.Logger.Error("Failed storing finalization", zap.Error(err))
+				return err
+			}
 		}
 		prevEpochRound := e.round
 		if err := e.indexFinalizations(round.num); err != nil {

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -766,15 +766,6 @@ func (e *Epoch) restoreFromWal() error {
 		return err
 	}
 
-	// A restored finalization is stored but never indexed, so one may already be for the next
-	// sequence to commit. Blocks below that sequence are not restored, so the lowest round in
-	// the map holds the lowest restored sequence and is where the sweep has to start.
-	if len(e.rounds) > 0 {
-		if err := e.indexFinalizations(e.minRoundInRoundsMap()); err != nil {
-			return err
-		}
-	}
-
 	return e.resumeFromWal(highestRoundRecord)
 }
 
@@ -2019,13 +2010,9 @@ func (e *Epoch) processFinalizedBlock(block common.Block, finalization *common.F
 			delete(e.rounds, round.num)
 			return e.processFinalizedBlock(block, finalization)
 		}
-		// The round can already hold this finalization, stored while its sequence was ahead
-		// of the storage or restored from the WAL. Indexing it is all that remains.
-		if round.finalization == nil {
-			if err := e.storeFinalization(finalization); err != nil {
-				e.Logger.Error("Failed storing finalization", zap.Error(err))
-				return err
-			}
+		if err := e.storeFinalization(finalization); err != nil {
+			e.Logger.Error("Failed storing finalization", zap.Error(err))
+			return err
 		}
 		prevEpochRound := e.round
 		if err := e.indexFinalizations(round.num); err != nil {

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2236,7 +2236,9 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block common.Block, finaliz
 			zap.Uint64("seq", md.Seq),
 			zap.Stringer("digest", md.Digest))
 
-		if err := e.indexFinalization(verifiedBlock, *finalization); err != nil {
+		// Sweep from this round, not just this block. Later rounds may already hold a
+		// finalization stored while their sequence was ahead of the storage.
+		if err := e.indexFinalizations(md.Round); err != nil {
 			e.haltedError = err
 			e.Logger.Error("Failed to index finalization", zap.Error(err))
 			return md.Digest

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2010,9 +2010,13 @@ func (e *Epoch) processFinalizedBlock(block common.Block, finalization *common.F
 			delete(e.rounds, round.num)
 			return e.processFinalizedBlock(block, finalization)
 		}
-		if err := e.storeFinalization(finalization); err != nil {
-			e.Logger.Error("Failed storing finalization", zap.Error(err))
-			return err
+		// The round can already hold this finalization, stored while its sequence was ahead
+		// of the storage. Indexing it is all that remains.
+		if round.finalization == nil {
+			if err := e.storeFinalization(finalization); err != nil {
+				e.Logger.Error("Failed storing finalization", zap.Error(err))
+				return err
+			}
 		}
 		prevEpochRound := e.round
 		if err := e.indexFinalizations(round.num); err != nil {

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1938,10 +1938,10 @@ func TestLeaderStartsRoundAfterReplicatedQuorumRound(t *testing.T) {
 	}
 }
 
-// setupStrandedFinalization returns a node whose storage holds seq 0 and whose WAL holds the
+// setupFutureFinalization returns a node whose storage holds seq 0 and whose WAL holds the
 // block and finalization for round 2 (seq 2), which recovery restores into the rounds map
-// without indexing. Only seq 1 is genuinely missing.
-func setupStrandedFinalization(t *testing.T, nodes []common.NodeID) (*simplex.Epoch, *InMemStorage, []common.VerifiedFinalizedBlock) {
+// without indexing, since seq 2 is a future finalization. Only seq 1 is genuinely missing.
+func setupFutureFinalization(t *testing.T, nodes []common.NodeID) (*simplex.Epoch, *InMemStorage, []common.VerifiedFinalizedBlock) {
 	ctx := context.Background()
 	blocks := createBlocks(t, nodes, 3)
 
@@ -1974,13 +1974,11 @@ func replicateSeq(block common.VerifiedFinalizedBlock) *common.Message {
 	}}
 }
 
-// TestReplicationIndexesStrandedFinalization asserts a node commits a finalization it already
-// holds once storage reaches its sequence. createFinalizedBlockVerificationTask indexed only
-// the block it verified, so a finalization stored while it was ahead of storage was never
-// revisited and the node stalled holding everything it needed.
-func TestReplicationIndexesStrandedFinalization(t *testing.T) {
+// TestReplicationIndexesFutureFinalization asserts a node indexes a future finalization once nextSeqToCommit
+// is processed via replication.
+func TestReplicationIndexesFutureFinalization(t *testing.T) {
 	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
-	e, storage, blocks := setupStrandedFinalization(t, nodes)
+	e, storage, blocks := setupFutureFinalization(t, nodes)
 
 	// filling the one real gap should commit seq 1 and then seq 2 from the rounds map
 	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
@@ -1990,13 +1988,11 @@ func TestReplicationIndexesStrandedFinalization(t *testing.T) {
 		"seq 2 never indexed, though the node holds its block and finalization")
 }
 
-// TestReplicationRedeliversStoredFinalization asserts a replication response carrying a
-// finalization the round already holds is not an error. processFinalizedBlock propagated
-// storeFinalization's "already has a finalization" error, which reached HandleMessage
-// whenever a peer answered with a sequence the node had stranded.
+// TestReplicationRedeliversStoredFinalization asserts a replication response with a
+// finalization the rounds map already holds is not an error.
 func TestReplicationRedeliversStoredFinalization(t *testing.T) {
 	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
-	e, storage, blocks := setupStrandedFinalization(t, nodes)
+	e, storage, blocks := setupFutureFinalization(t, nodes)
 
 	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
 	storage.WaitForBlockCommit(1)
@@ -2005,10 +2001,9 @@ func TestReplicationRedeliversStoredFinalization(t *testing.T) {
 	require.NoError(t, e.HandleMessage(replicateSeq(blocks[2]), nodes[1]))
 }
 
-// TestReplicationRedeliversRestoredFinalization asserts a replication response for a round that
-// already holds a finalization is committed rather than failing. indexFinalizations stops at the
-// first round holding a block with no finalization, so a round can stay stranded at the next
-// sequence to commit and processFinalizedBlock then reached storeFinalization on it.
+// TestReplicationRedeliversRestoredFinalization asserts that we can index a finalized block that already has
+// a finalization in the rounds map. This is possible if the WAL recovered the finalization or if it was sent via
+// a finalization message.
 func TestReplicationRedeliversRestoredFinalization(t *testing.T) {
 	ctx := context.Background()
 	nodes := []common.NodeID{{1}, {2}, {3}, {4}}

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1937,3 +1937,70 @@ func TestLeaderStartsRoundAfterReplicatedQuorumRound(t *testing.T) {
 		})
 	}
 }
+
+// setupStrandedFinalization returns a node whose storage holds seq 0 and whose WAL holds the
+// block and finalization for round 2 (seq 2), which recovery restores into the rounds map
+// without indexing. Only seq 1 is genuinely missing.
+func setupStrandedFinalization(t *testing.T, nodes []common.NodeID) (*simplex.Epoch, *InMemStorage, []common.VerifiedFinalizedBlock) {
+	ctx := context.Background()
+	blocks := createBlocks(t, nodes, 3)
+
+	conf, wal, storage := DefaultTestNodeEpochConfig(t, nodes[3], NewNoopComm(nodes), testutil.NewTestBlockBuilder())
+	conf.ReplicationEnabled = true
+	require.NoError(t, storage.Index(ctx, blocks[0].VerifiedBlock, blocks[0].Finalization))
+
+	third := blocks[2].VerifiedBlock
+	blockRecord, err := common.BlockRecord(third.BlockHeader(), third.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, wal.Append(blockRecord))
+	_, finalizationRecord := NewFinalizationRecord(t, &TestSignatureAggregator{N: len(nodes)}, third, nodes)
+	require.NoError(t, wal.Append(finalizationRecord))
+
+	e, err := simplex.NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+	require.Equal(t, uint64(1), storage.NumBlocks())
+
+	return e, storage, blocks
+}
+
+func replicateSeq(block common.VerifiedFinalizedBlock) *common.Message {
+	return &common.Message{ReplicationResponse: &common.ReplicationResponse{
+		Data: []common.QuorumRound{{
+			Block:        block.VerifiedBlock.(common.Block),
+			Finalization: &block.Finalization,
+		}},
+	}}
+}
+
+// TestReplicationIndexesStrandedFinalization asserts a node commits a finalization it already
+// holds once storage reaches its sequence. The replicated commit path indexed only its own
+// block (epoch.go:2235), so a finalization stored while it was ahead of storage was never
+// revisited and the node stalled holding everything it needed.
+func TestReplicationIndexesStrandedFinalization(t *testing.T) {
+	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
+	e, storage, blocks := setupStrandedFinalization(t, nodes)
+
+	// filling the one real gap should commit seq 1 and then seq 2 from the rounds map
+	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
+	storage.WaitForBlockCommit(1)
+	require.Eventually(t, func() bool { return storage.NumBlocks() == 3 },
+		5*time.Second, 10*time.Millisecond,
+		"seq 2 never indexed, though the node holds its block and finalization")
+}
+
+// TestReplicationRedeliversStoredFinalization asserts a replication response carrying a
+// finalization the round already holds is not an error. processFinalizedBlock propagates
+// storeFinalization's "already has a finalization" error (epoch.go:2009), which reached
+// HandleMessage whenever a peer answered with a sequence the node had stranded.
+func TestReplicationRedeliversStoredFinalization(t *testing.T) {
+	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
+	e, storage, blocks := setupStrandedFinalization(t, nodes)
+
+	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
+	storage.WaitForBlockCommit(1)
+
+	// a peer answering with seq 2, whose finalization round 2 already holds, must not fail
+	require.NoError(t, e.HandleMessage(replicateSeq(blocks[2]), nodes[1]))
+}

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -2004,35 +2004,3 @@ func TestReplicationRedeliversStoredFinalization(t *testing.T) {
 	// a peer answering with seq 2, whose finalization round 2 already holds, must not fail
 	require.NoError(t, e.HandleMessage(replicateSeq(blocks[2]), nodes[1]))
 }
-
-// TestRecoveryIndexesRestoredFinalization asserts a node commits a finalization restored from
-// the WAL when its sequence is already the next to commit. loadFinalizationRecord stores it
-// without indexing, and sequenceAlreadyIndexed only skips sequences strictly below the
-// storage height, so recovery left the round stranded and the node never committed.
-func TestRecoveryIndexesRestoredFinalization(t *testing.T) {
-	ctx := context.Background()
-	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
-	blocks := createBlocks(t, nodes, 2)
-
-	conf, wal, storage := DefaultTestNodeEpochConfig(t, nodes[3], NewNoopComm(nodes), testutil.NewTestBlockBuilder())
-	conf.ReplicationEnabled = true
-	require.NoError(t, storage.Index(ctx, blocks[0].VerifiedBlock, blocks[0].Finalization))
-
-	// the WAL holds the block and finalization for round 1, whose seq 1 is next to commit
-	second := blocks[1].VerifiedBlock
-	blockRecord, err := common.BlockRecord(second.BlockHeader(), second.Bytes())
-	require.NoError(t, err)
-	require.NoError(t, wal.Append(blockRecord))
-	_, finalizationRecord := NewFinalizationRecord(t, &TestSignatureAggregator{N: len(nodes)}, second, nodes)
-	require.NoError(t, wal.Append(finalizationRecord))
-
-	e, err := simplex.NewEpoch(conf)
-	require.NoError(t, err)
-	t.Cleanup(e.Stop)
-	require.NoError(t, e.Start())
-
-	require.Equal(t, uint64(2), storage.NumBlocks(), "seq 1 was restored but never indexed")
-
-	// and redelivery of the same sequence is still not an error
-	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
-}

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -2004,3 +2004,33 @@ func TestReplicationRedeliversStoredFinalization(t *testing.T) {
 	// a peer answering with seq 2, whose finalization round 2 already holds, must not fail
 	require.NoError(t, e.HandleMessage(replicateSeq(blocks[2]), nodes[1]))
 }
+
+// TestReplicationRedeliversRestoredFinalization asserts a replication response for a round that
+// already holds a finalization is committed rather than failing. indexFinalizations stops at the
+// first round holding a block with no finalization, so a round can stay stranded at the next
+// sequence to commit and processFinalizedBlock then reached storeFinalization on it.
+func TestReplicationRedeliversRestoredFinalization(t *testing.T) {
+	ctx := context.Background()
+	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
+	blocks := createBlocks(t, nodes, 2)
+
+	conf, wal, storage := DefaultTestNodeEpochConfig(t, nodes[3], NewNoopComm(nodes), testutil.NewTestBlockBuilder())
+	conf.ReplicationEnabled = true
+	require.NoError(t, storage.Index(ctx, blocks[0].VerifiedBlock, blocks[0].Finalization))
+
+	// the round is restored holding a finalization whose seq is the next one to commit
+	second := blocks[1].VerifiedBlock
+	blockRecord, err := common.BlockRecord(second.BlockHeader(), second.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, wal.Append(blockRecord))
+	_, finalizationRecord := NewFinalizationRecord(t, &TestSignatureAggregator{N: len(nodes)}, second, nodes)
+	require.NoError(t, wal.Append(finalizationRecord))
+
+	e, err := simplex.NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
+	storage.WaitForBlockCommit(1)
+}

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1975,8 +1975,8 @@ func replicateSeq(block common.VerifiedFinalizedBlock) *common.Message {
 }
 
 // TestReplicationIndexesStrandedFinalization asserts a node commits a finalization it already
-// holds once storage reaches its sequence. The replicated commit path indexed only its own
-// block (epoch.go:2235), so a finalization stored while it was ahead of storage was never
+// holds once storage reaches its sequence. createFinalizedBlockVerificationTask indexed only
+// the block it verified, so a finalization stored while it was ahead of storage was never
 // revisited and the node stalled holding everything it needed.
 func TestReplicationIndexesStrandedFinalization(t *testing.T) {
 	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
@@ -1991,9 +1991,9 @@ func TestReplicationIndexesStrandedFinalization(t *testing.T) {
 }
 
 // TestReplicationRedeliversStoredFinalization asserts a replication response carrying a
-// finalization the round already holds is not an error. processFinalizedBlock propagates
-// storeFinalization's "already has a finalization" error (epoch.go:2009), which reached
-// HandleMessage whenever a peer answered with a sequence the node had stranded.
+// finalization the round already holds is not an error. processFinalizedBlock propagated
+// storeFinalization's "already has a finalization" error, which reached HandleMessage
+// whenever a peer answered with a sequence the node had stranded.
 func TestReplicationRedeliversStoredFinalization(t *testing.T) {
 	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
 	e, storage, blocks := setupStrandedFinalization(t, nodes)
@@ -2003,4 +2003,36 @@ func TestReplicationRedeliversStoredFinalization(t *testing.T) {
 
 	// a peer answering with seq 2, whose finalization round 2 already holds, must not fail
 	require.NoError(t, e.HandleMessage(replicateSeq(blocks[2]), nodes[1]))
+}
+
+// TestRecoveryIndexesRestoredFinalization asserts a node commits a finalization restored from
+// the WAL when its sequence is already the next to commit. loadFinalizationRecord stores it
+// without indexing, and sequenceAlreadyIndexed only skips sequences strictly below the
+// storage height, so recovery left the round stranded and the node never committed.
+func TestRecoveryIndexesRestoredFinalization(t *testing.T) {
+	ctx := context.Background()
+	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
+	blocks := createBlocks(t, nodes, 2)
+
+	conf, wal, storage := DefaultTestNodeEpochConfig(t, nodes[3], NewNoopComm(nodes), testutil.NewTestBlockBuilder())
+	conf.ReplicationEnabled = true
+	require.NoError(t, storage.Index(ctx, blocks[0].VerifiedBlock, blocks[0].Finalization))
+
+	// the WAL holds the block and finalization for round 1, whose seq 1 is next to commit
+	second := blocks[1].VerifiedBlock
+	blockRecord, err := common.BlockRecord(second.BlockHeader(), second.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, wal.Append(blockRecord))
+	_, finalizationRecord := NewFinalizationRecord(t, &TestSignatureAggregator{N: len(nodes)}, second, nodes)
+	require.NoError(t, wal.Append(finalizationRecord))
+
+	e, err := simplex.NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	require.Equal(t, uint64(2), storage.NumBlocks(), "seq 1 was restored but never indexed")
+
+	// and redelivery of the same sequence is still not an error
+	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
 }


### PR DESCRIPTION
Fixes the `TestNetworkSimpleFuzz` panic in [run 30950633369](https://github.com/ava-labs/Simplex/actions/runs/30950633369/job/92131525911) (subtest `#01`, seed `1785877451019`):

```
panic: error handling message from 0100000000000000 to 0600000000000000: ...
  Err message: round 54 already has a finalization
```

This reproduces on `main`, so it is not specific to any feature branch.

## Root cause

`createFinalizedBlockVerificationTask` committed only the block it had just verified, using the singular `indexFinalization`, while the consensus path in `persistFinalization` uses `indexFinalizations`, which walks the rounds map forward.

A finalization can be stored while its sequence is still ahead of the storage, by `handleFinalizationMessage` or by `assembleFinalization`. `persistFinalization` writes it to the WAL rather than indexing it, and it sits in the rounds map. When replication then filled in the missing sequence, the commit did not sweep, so nothing re-examined that round. The node was left holding a finalized block it would not commit, while reporting itself as behind:

```
Nothing to process in replication state {"NextSeqToCommit": 2}
Node is behind, attempting to request missing values {"value": 2}
```

`processReplicationState` decides what it can commit purely from the replication state's sequences, so a finalization sitting in the rounds map is invisible to it. The node then requests over the network a sequence it already has, and the answer drives `processFinalizedBlock` into `storeFinalization` on a round that already has a finalization. That is the one caller of `storeFinalization` that propagates the error rather than guarding or swallowing it, so it reaches `HandleMessage`, where the test harness panics.

The stall is the bug, the panic is a symptom of it.

## Change

One line: `createFinalizedBlockVerificationTask` indexes from the round rather than the single block. Afterwards the only caller of the singular `indexFinalization` is `indexFinalizations` itself.

This is sufficient because sequences have no gaps. Rounds holding blocks have increasing sequences, so if a round between the committed one and a stranded one has a block but no finalization, that round owns the next sequence to commit and the stranded round cannot. A sweep from the round just committed therefore always stops somewhere legitimate, and a fixed node cannot end a run with a round stranded at the next sequence to commit.

## Tests

Two regression tests, both failing on `main`:

| test | asserts | failure without the fix |
|---|---|---|
| `TestReplicationIndexesStrandedFinalization` | the node commits a finalization it already holds once the storage reaches its sequence | `seq 2 never indexed, though the node holds its block and finalization` |
| `TestReplicationRedeliversStoredFinalization` | redelivery of a held finalization is not an error | `round 2 already has a finalization` |

The fuzz test reproduces this roughly once per 500 iterations, so these drive the state deterministically through `HandleMessage` instead. Also verified `TestNetworkSimpleFuzz` over 3 runs of 10 iterations.

## Note for CI

`TestReplicationEmptyNotarizations` hangs in `net.AdvanceWithoutLeader`. It predates this change and reproduces on `main`: the fuzz panic was aborting the `simplex` test binary before any replication test ran, so CI never reported it. With the panic fixed, CI will reach it. Tracked separately, not addressed here.
