### PR TITLE
Don't re-store a finalization the round already holds

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2010,9 +2010,13 @@ func (e *Epoch) processFinalizedBlock(block common.Block, finalization *common.F
 			delete(e.rounds, round.num)
 			return e.processFinalizedBlock(block, finalization)
 		}
-		if err := e.storeFinalization(finalization); err != nil {
-			e.Logger.Error("Failed storing finalization", zap.Error(err))
-			return err
+		// The round can already hold this finalization, restored from the WAL or received in a
+		// finalization message. Indexing it is all that remains.
+		if round.finalization == nil {
+			if err := e.storeFinalization(finalization); err != nil {
+				e.Logger.Error("Failed storing finalization", zap.Error(err))
+				return err
+			}
 		}
 		prevEpochRound := e.round
 		if err := e.indexFinalizations(round.num); err != nil {

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1947,9 +1947,9 @@ func replicateSeq(block common.VerifiedFinalizedBlock) *common.Message {
 	}}
 }
 
-// TestReplicationRedeliversRestoredFinalization asserts that we can index a finalized block that already has
-// a finalization in the rounds map. This is possible if the WAL recovered the finalization or if it was sent via
-// a finalization message.
+// TestReplicationRedeliversRestoredFinalization asserts that a node commits a block when a replication
+// response redelivers a finalization the node already knows of. This is possible if the finalization was
+// recovered from the WAL or previously received in a finalization message.
 func TestReplicationRedeliversRestoredFinalization(t *testing.T) {
 	ctx := context.Background()
 	nodes := []common.NodeID{{1}, {2}, {3}, {4}}

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1937,3 +1937,41 @@ func TestLeaderStartsRoundAfterReplicatedQuorumRound(t *testing.T) {
 		})
 	}
 }
+
+func replicateSeq(block common.VerifiedFinalizedBlock) *common.Message {
+	return &common.Message{ReplicationResponse: &common.ReplicationResponse{
+		Data: []common.QuorumRound{{
+			Block:        block.VerifiedBlock.(common.Block),
+			Finalization: &block.Finalization,
+		}},
+	}}
+}
+
+// TestReplicationRedeliversRestoredFinalization asserts that we can index a finalized block that already has
+// a finalization in the rounds map. This is possible if the WAL recovered the finalization or if it was sent via
+// a finalization message.
+func TestReplicationRedeliversRestoredFinalization(t *testing.T) {
+	ctx := context.Background()
+	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
+	blocks := createBlocks(t, nodes, 2)
+
+	conf, wal, storage := DefaultTestNodeEpochConfig(t, nodes[3], NewNoopComm(nodes), testutil.NewTestBlockBuilder())
+	conf.ReplicationEnabled = true
+	require.NoError(t, storage.Index(ctx, blocks[0].VerifiedBlock, blocks[0].Finalization))
+
+	// the round is restored holding a finalization whose seq is the next one to commit
+	second := blocks[1].VerifiedBlock
+	blockRecord, err := common.BlockRecord(second.BlockHeader(), second.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, wal.Append(blockRecord))
+	_, finalizationRecord := NewFinalizationRecord(t, &TestSignatureAggregator{N: len(nodes)}, second, nodes)
+	require.NoError(t, wal.Append(finalizationRecord))
+
+	e, err := simplex.NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
+	storage.WaitForBlockCommit(1)
+}

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1951,7 +1951,7 @@ func TestReplicationRedeliversRestoredFinalization(t *testing.T) {
 	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
 	blocks := createBlocks(t, nodes, 2)
 
-	conf, wal, storage := DefaultTestNodeEpochConfig(t, nodes[3], NewNoopComm(nodes), testutil.NewTestBlockBuilder())
+	conf, wal, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[3], testutil.NewNoopComm(nodes), testutil.NewTestBlockBuilder())
 	conf.ReplicationEnabled = true
 	require.NoError(t, storage.Index(ctx, blocks[0].VerifiedBlock, blocks[0].Finalization))
 
@@ -1960,7 +1960,7 @@ func TestReplicationRedeliversRestoredFinalization(t *testing.T) {
 	blockRecord, err := common.BlockRecord(second.BlockHeader(), second.Bytes())
 	require.NoError(t, err)
 	require.NoError(t, wal.Append(blockRecord))
-	_, finalizationRecord := NewFinalizationRecord(t, &TestSignatureAggregator{N: len(nodes)}, second, nodes)
+	_, finalizationRecord := testutil.NewFinalizationRecord(t, &testutil.TestSignatureAggregator{N: len(nodes)}, second, nodes)
 	require.NoError(t, wal.Append(finalizationRecord))
 
 	e, err := simplex.NewEpoch(conf)


### PR DESCRIPTION
`processFinalizedBlock` stored the finalization unconditionally. When the round already held one, restored from the WAL or received in a finalization message, `storeFinalization` returned `round N already has a finalization`, that error reached `HandleMessage`, and the block was never indexed.

Store only when `round.finalization == nil`, then index as before.

`TestReplicationRedeliversRestoredFinalization` fails without the guard with `round 1 already has a finalization`.

This random long running test failed CI that caught the issue. [run 30950633369](https://github.com/ava-labs/Simplex/actions/runs/30950633369/job/92131525911) (subtest `#01`, seed `1785877451019`):