### PR TITLE
Index potential future finalizations when replication commits a block

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2236,8 +2236,6 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block common.Block, finaliz
 			zap.Uint64("seq", md.Seq),
 			zap.Stringer("digest", md.Digest))
 
-		// Sweep from this round, not just this block. Later rounds may already hold a future
-		// finalization, stored while its sequence was ahead of the next one to commit.
 		if err := e.indexFinalizations(md.Round); err != nil {
 			e.haltedError = err
 			e.Logger.Error("Failed to index finalization", zap.Error(err))

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2236,7 +2236,9 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block common.Block, finaliz
 			zap.Uint64("seq", md.Seq),
 			zap.Stringer("digest", md.Digest))
 
-		if err := e.indexFinalization(verifiedBlock, *finalization); err != nil {
+		// Sweep from this round, not just this block. Later rounds may already hold a future
+		// finalization, stored while its sequence was ahead of the next one to commit.
+		if err := e.indexFinalizations(md.Round); err != nil {
 			e.haltedError = err
 			e.Logger.Error("Failed to index finalization", zap.Error(err))
 			return md.Digest

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1965,7 +1965,7 @@ func setupFutureFinalization(t *testing.T, nodes []common.NodeID) (*simplex.Epoc
 	return e, storage, blocks
 }
 
-func replicateSeq(block common.VerifiedFinalizedBlock) *common.Message {
+func replicatedBlock(block common.VerifiedFinalizedBlock) *common.Message {
 	return &common.Message{ReplicationResponse: &common.ReplicationResponse{
 		Data: []common.QuorumRound{{
 			Block:        block.VerifiedBlock.(common.Block),
@@ -1981,7 +1981,7 @@ func TestReplicationIndexesFutureFinalization(t *testing.T) {
 	e, storage, blocks := setupFutureFinalization(t, nodes)
 
 	// filling the one real gap should commit seq 1 and then seq 2 from the rounds map
-	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
+	require.NoError(t, e.HandleMessage(replicatedBlock(blocks[1]), nodes[1]))
 	storage.WaitForBlockCommit(1)
 	require.Eventually(t, func() bool { return storage.NumBlocks() == 3 },
 		5*time.Second, 10*time.Millisecond,
@@ -1994,9 +1994,9 @@ func TestReplicationRedeliversStoredFinalization(t *testing.T) {
 	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
 	e, storage, blocks := setupFutureFinalization(t, nodes)
 
-	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
+	require.NoError(t, e.HandleMessage(replicatedBlock(blocks[1]), nodes[1]))
 	storage.WaitForBlockCommit(1)
 
 	// a peer answering with seq 2, whose finalization round 2 already holds, must not fail
-	require.NoError(t, e.HandleMessage(replicateSeq(blocks[2]), nodes[1]))
+	require.NoError(t, e.HandleMessage(replicatedBlock(blocks[2]), nodes[1]))
 }

--- a/simplex/replication_test.go
+++ b/simplex/replication_test.go
@@ -1937,3 +1937,66 @@ func TestLeaderStartsRoundAfterReplicatedQuorumRound(t *testing.T) {
 		})
 	}
 }
+
+// setupFutureFinalization returns a node whose storage holds seq 0 and whose WAL holds the
+// block and finalization for round 2 (seq 2), which recovery restores into the rounds map
+// without indexing, since seq 2 is a future finalization. Only seq 1 is genuinely missing.
+func setupFutureFinalization(t *testing.T, nodes []common.NodeID) (*simplex.Epoch, *InMemStorage, []common.VerifiedFinalizedBlock) {
+	ctx := context.Background()
+	blocks := createBlocks(t, nodes, 3)
+
+	conf, wal, storage := DefaultTestNodeEpochConfig(t, nodes[3], NewNoopComm(nodes), testutil.NewTestBlockBuilder())
+	conf.ReplicationEnabled = true
+	require.NoError(t, storage.Index(ctx, blocks[0].VerifiedBlock, blocks[0].Finalization))
+
+	third := blocks[2].VerifiedBlock
+	blockRecord, err := common.BlockRecord(third.BlockHeader(), third.Bytes())
+	require.NoError(t, err)
+	require.NoError(t, wal.Append(blockRecord))
+	_, finalizationRecord := NewFinalizationRecord(t, &TestSignatureAggregator{N: len(nodes)}, third, nodes)
+	require.NoError(t, wal.Append(finalizationRecord))
+
+	e, err := simplex.NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+	require.Equal(t, uint64(1), storage.NumBlocks())
+
+	return e, storage, blocks
+}
+
+func replicateSeq(block common.VerifiedFinalizedBlock) *common.Message {
+	return &common.Message{ReplicationResponse: &common.ReplicationResponse{
+		Data: []common.QuorumRound{{
+			Block:        block.VerifiedBlock.(common.Block),
+			Finalization: &block.Finalization,
+		}},
+	}}
+}
+
+// TestReplicationIndexesFutureFinalization asserts a node indexes a future finalization once nextSeqToCommit
+// is processed via replication.
+func TestReplicationIndexesFutureFinalization(t *testing.T) {
+	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
+	e, storage, blocks := setupFutureFinalization(t, nodes)
+
+	// filling the one real gap should commit seq 1 and then seq 2 from the rounds map
+	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
+	storage.WaitForBlockCommit(1)
+	require.Eventually(t, func() bool { return storage.NumBlocks() == 3 },
+		5*time.Second, 10*time.Millisecond,
+		"seq 2 never indexed, though the node holds its block and finalization")
+}
+
+// TestReplicationRedeliversStoredFinalization asserts a replication response with a
+// finalization the rounds map already holds is not an error.
+func TestReplicationRedeliversStoredFinalization(t *testing.T) {
+	nodes := []common.NodeID{{1}, {2}, {3}, {4}}
+	e, storage, blocks := setupFutureFinalization(t, nodes)
+
+	require.NoError(t, e.HandleMessage(replicateSeq(blocks[1]), nodes[1]))
+	storage.WaitForBlockCommit(1)
+
+	// a peer answering with seq 2, whose finalization round 2 already holds, must not fail
+	require.NoError(t, e.HandleMessage(replicateSeq(blocks[2]), nodes[1]))
+}


### PR DESCRIPTION
`createFinalizedBlockVerificationTask` indexed only the block it had just verified. A later round holding a future finalization, stored while its sequence was ahead of the next one to commit, was never revisited, so the node stalled while holding the block and finalization it was waiting for.

Index from the verified block's round forward with `indexFinalizations`, which stops as soon as a round is missing a finalization or is not next to commit.

`TestReplicationIndexesFutureFinalization` fails without this: seq 2 is never indexed.

Note: this and #490 both add the `replicateSeq` helper, so whichever merges second needs a small conflict fixup.