### PR TITLE
Log error dropped by BlockBuilderWaiter.BuildBlock

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ava-labs/simplex/common"
 	metadata "github.com/ava-labs/simplex/msm"
+	"go.uber.org/zap"
 )
 
 type Communication struct {
@@ -191,6 +192,7 @@ type BlockBuilderWaiter struct {
 	cancel context.CancelFunc
 	msm    *metadata.StateMachine
 	vm     VM
+	log    common.Logger
 }
 
 func (bw *BlockBuilderWaiter) stop() {
@@ -217,6 +219,9 @@ func (bw *BlockBuilderWaiter) WaitForPendingBlock(ctx context.Context) {
 func (bw *BlockBuilderWaiter) BuildBlock(ctx context.Context, metadata common.ProtocolMetadata, blacklist common.Blacklist) (common.VerifiedBlock, bool) {
 	block, err := bw.msm.BuildBlock(ctx, metadata, blacklist)
 	if err != nil {
+		if ctx.Err() == nil {
+			bw.log.Warn("Failed building block", zap.Error(err))
+		}
 		return nil, false
 	}
 

--- a/instance.go
+++ b/instance.go
@@ -476,7 +476,7 @@ func (i *Instance) createEpochConfig() (simplex.EpochConfig, error) {
 		return simplex.EpochConfig{}, err
 	}
 
-	blockBuilder := &BlockBuilderWaiter{vm: i.Config.VM, msm: msm}
+	blockBuilder := &BlockBuilderWaiter{vm: i.Config.VM, msm: msm, log: i.Config.Logger}
 
 	comm := &Communication{Sender: i.Config.Sender, Broadcaster: i.Config.Broadcaster}
 	comm.SetValidators(nodes)

--- a/instance_test.go
+++ b/instance_test.go
@@ -1148,3 +1148,24 @@ func verifiedQuorumRoundToQuorumRound(t *testing.T, vqr common.VerifiedQuorumRou
 	}
 	return qr
 }
+
+// TestBlockBuilderWaiterLogsBuildError asserts that BlockBuilderWaiter.BuildBlock
+// logs the error returned by the state machine. It used to discard it
+// (adapters.go), leaving only a generic warning at the epoch level.
+func TestBlockBuilderWaiterLogsBuildError(t *testing.T) {
+	logger := testutil.MakeLogger(t)
+	var logged bool
+	logger.Intercept(func(entry zapcore.Entry) error {
+		if entry.Level == zapcore.WarnLevel && strings.Contains(entry.Message, "Failed building block") {
+			logged = true
+		}
+		return nil
+	})
+
+	bw := &BlockBuilderWaiter{msm: &metadata.StateMachine{}, log: logger}
+
+	// Seq 0 is reserved for genesis, so the state machine fails to build.
+	_, ok := bw.BuildBlock(context.Background(), common.ProtocolMetadata{}, common.Blacklist{})
+	require.False(t, ok)
+	require.True(t, logged)
+}


### PR DESCRIPTION
What was wrong
BlockBuilderWaiter.BuildBlock (adapters.go:219) discarded the error returned by msm.BuildBlock and returned (nil, false). The common.BlockBuilder interface (common/api.go:44) only exposes a bool, so the epoch caller (simplex/epoch.go:2591) could only emit a generic "Failed building block" warning with no cause.

Consequence
Any block building failure, for example "failed to retrieve sealing block for previous epoch" (msm/msm.go:454) or a parent block lookup failure (msm/msm.go:288), was undiagnosable from logs. This sent the investigation of TestValidator_ValidatorSetDecreased down a wrong path.

Fix
Added a logger to BlockBuilderWaiter, wired from Config.Logger at construction (instance.go:479), and log the error at Warn. Context cancellation is the documented normal false path, so it is not logged.

Verification
TestBlockBuilderWaiterLogsBuildError, failed before the log call was added, passes after.

Found while debugging TestValidator_ValidatorSetDecreased.