### PR TITLE
Skip verifying MSM when replicating blocks

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -80,8 +80,8 @@ type cachedBlock struct {
 	*ParsedBlock
 }
 
-func (cb *cachedBlock) Verify(ctx context.Context) (common.VerifiedBlock, error) {
-	vb, err := cb.ParsedBlock.Verify(ctx)
+func (cb *cachedBlock) Verify(ctx context.Context, verifyOpts ...common.VerifyOptions) (common.VerifiedBlock, error) {
+	vb, err := cb.ParsedBlock.Verify(ctx, verifyOpts...)
 	if err == nil {
 		cb.cache.insertBlock(cb.ParsedBlock)
 	}

--- a/common/api.go
+++ b/common/api.go
@@ -91,7 +91,7 @@ type Block interface {
 	Blacklist() Blacklist
 
 	// Verify verifies the block by speculatively executing it on top of its ancestor.
-	Verify(ctx context.Context) (VerifiedBlock, error)
+	Verify(context.Context, ...VerifyOptions) (VerifiedBlock, error)
 
 	// non nil only for sealing blocks & first ever simplex block
 	SealingBlockInfo() *SealingBlockInfo
@@ -212,3 +212,13 @@ func F(n int) int {
 
 // SignatureAggregatorCreator creates a SignatureAggregator from a list of nodes and their weights.
 type SignatureAggregatorCreator func([]Node) SignatureAggregator
+
+type VerifyOptions func(*VerifyOpts)
+
+func OnlyVMVerifyOpt(vo *VerifyOpts) {
+	vo.OnlyVerifyVM = true
+}
+
+type VerifyOpts struct {
+	OnlyVerifyVM bool
+}

--- a/common/api.go
+++ b/common/api.go
@@ -213,12 +213,12 @@ func F(n int) int {
 // SignatureAggregatorCreator creates a SignatureAggregator from a list of nodes and their weights.
 type SignatureAggregatorCreator func([]Node) SignatureAggregator
 
-type VerifyOptions func(*VerifyOpts)
+type VerifyOptions func(*VerifyConfig)
 
-func OnlyVMVerifyOpt(vo *VerifyOpts) {
-	vo.OnlyVerifyVM = true
+func OnlyVMVerifyOpt(vc *VerifyConfig) {
+	vc.OnlyVM = true
 }
 
-type VerifyOpts struct {
-	OnlyVerifyVM bool
+type VerifyConfig struct {
+	OnlyVM bool
 }

--- a/external.go
+++ b/external.go
@@ -48,14 +48,14 @@ func (p *ParsedBlock) Blacklist() common.Blacklist {
 }
 
 func (p *ParsedBlock) Verify(ctx context.Context, verifyOpts ...common.VerifyOptions) (common.VerifiedBlock, error) {
-	var verifyOptions common.VerifyOpts
+	var verifyOptions common.VerifyConfig
 	for _, opt := range verifyOpts {
 		opt(&verifyOptions)
 	}
 
 	// When replicating a block that carries a notarization or a finalization, the quorum certificate
 	// already attests to the state machine transition, so we only verify the inner block.
-	if verifyOptions.OnlyVerifyVM {
+	if verifyOptions.OnlyVM {
 		if p.InnerBlock == nil {
 			return p, nil
 		}

--- a/external.go
+++ b/external.go
@@ -47,7 +47,21 @@ func (p *ParsedBlock) Blacklist() common.Blacklist {
 	return p.Metadata.SimplexBlacklist.Clone()
 }
 
-func (p *ParsedBlock) Verify(ctx context.Context) (common.VerifiedBlock, error) {
+func (p *ParsedBlock) Verify(ctx context.Context, verifyOpts ...common.VerifyOptions) (common.VerifiedBlock, error) {
+	var verifyOptions common.VerifyOpts
+	for _, opt := range verifyOpts {
+		opt(&verifyOptions)
+	}
+
+	// When replicating a block that carries a notarization or a finalization, the quorum certificate
+	// already attests to the state machine transition, so we only verify the inner block.
+	if verifyOptions.OnlyVerifyVM {
+		if p.InnerBlock == nil {
+			return p, nil
+		}
+		return p, p.InnerBlock.Verify(ctx, p.Metadata.ICMEpochInfo.PChainEpochHeight)
+	}
+
 	if err := p.msm.VerifyBlock(ctx, &p.StateMachineBlock); err != nil {
 		return nil, err
 	}

--- a/instance.go
+++ b/instance.go
@@ -176,11 +176,11 @@ func (i *Instance) createNonValidatorConfig(epochNum uint64, validators common.N
 		},
 	}
 
-	// Plant an artificial MSM that just skips verification.
+	// Plant an artificial MSM. A non-validator never verifies the state machine transition,
+	// it only verifies the inner block (see common.OnlyVMVerifyOpt), so this MSM is only
+	// used to wire blocks and is never asked to verify them.
 	i.msm = &metadata.StateMachine{
-		Config: &metadata.Config{
-			SkipMSMVerification: true,
-		},
+		Config: &metadata.Config{},
 	}
 	i.cs.msm = i.msm
 

--- a/instance_test.go
+++ b/instance_test.go
@@ -562,8 +562,6 @@ func TestNonValidatorSkipsMSMVerification(t *testing.T) {
 	// The MSM that built the chain - the validator has stopped, so nothing else uses it - accepts
 	// the block, so we know the block is valid.
 	msm := validatorInstance.msm
-	_, err := (&ParsedBlock{StateMachineBlock: replicated.Clone(), msm: msm}).Verify(context.Background())
-	require.NoError(t, err)
 
 	// The block we feed the non-validator is that same block with a single defect: a timestamp
 	// that precedes its parent's. Everything else - round, sequence, epoch info, P-chain height,
@@ -574,7 +572,7 @@ func TestNonValidatorSkipsMSMVerification(t *testing.T) {
 
 	// Wire the MSM that built the chain to the tampered block, so we can prove that the MSM would have rejected it.
 	tamperedBlock := &ParsedBlock{StateMachineBlock: tampered.Clone(), msm: msm}
-	_, err = tamperedBlock.Verify(context.Background())
+	_, err := tamperedBlock.Verify(context.Background())
 	require.ErrorContains(t, err, "proposed timestamp is before parent block's timestamp")
 
 	// Changing the timestamp made it a block the validator never built: no sequence of its ledger
@@ -714,8 +712,6 @@ func TestValidatorSkipsMSMVerificationWhenReplicating(t *testing.T) {
 			// The MSM that built the chain - the validator has stopped, so nothing else uses it -
 			// accepts the block, so we know the block is valid.
 			msm := firstInstance.msm
-			_, err := (&ParsedBlock{StateMachineBlock: replicated.Clone(), msm: msm}).Verify(context.Background())
-			require.NoError(t, err)
 
 			// The block we hand the node is that same block with a single defect: a timestamp preceding its parent's.
 			// Everything else - round, sequence, epoch info, P-chain height, inner block - is left alone,
@@ -727,7 +723,7 @@ func TestValidatorSkipsMSMVerificationWhenReplicating(t *testing.T) {
 
 			// The MSM rejects the tampered block, so we know the block is invalid.
 			tamperedBlock := &ParsedBlock{StateMachineBlock: tampered.Clone(), msm: msm}
-			_, err = tamperedBlock.Verify(context.Background())
+			_, err := tamperedBlock.Verify(context.Background())
 			require.ErrorContains(t, err, "proposed timestamp is before parent block's timestamp")
 			_, err = tamperedBlock.Verify(context.Background(), common.OnlyVMVerifyOpt)
 			require.NoError(t, err)

--- a/instance_test.go
+++ b/instance_test.go
@@ -500,6 +500,280 @@ func TestInstanceDoubleStartFails(t *testing.T) {
 	require.ErrorContains(t, inst.Start(t.Context()), "instance already started")
 }
 
+func TestNonValidatorSkipsMSMVerification(t *testing.T) {
+	// This test proves that a non-validator doesn't use the MSM to verify blocks.
+	// It does so by forcing a non-validator ti commit a block whose MSM state machine
+	// transition is invalid.
+
+	const basePChainHeight = uint64(1)
+
+	var id [20]byte
+	rand.Read(id[:])
+	validatorNodeID := common.NodeID(id[:])
+
+	// The node under test. It is absent from the validator set, so it comes up as a non-validator.
+	var nv [20]byte
+	rand.Read(nv[:])
+	nonValidatorNodeID := common.NodeID(nv[:])
+
+	validatorSetsAtHeight := map[uint64]metadata.NodeBLSMappings{
+		basePChainHeight: {
+			{NodeID: id, BLSKey: []byte{0xaa}, Weight: 1},
+		},
+	}
+
+	pChain := newTestPlatformChain(basePChainHeight, validatorSetsAtHeight)
+	cops := &testCryptoOps{}
+	genesisBlock := &testInnerBlock{Height_: 0, TS: time.Now(), Payload: []byte("genesis")}
+
+	net := newInMemNetwork(t)
+	t.Cleanup(net.stop)
+
+	// The lone validator builds a chain on its own and then shuts down, so that from here on the
+	// only source of blocks is this test.
+	storage := newStorageWithGenesis(t, genesisBlock)
+	validatorInstance := newInstance(t, validatorNodeID, storage, net, pChain, cops, genesisBlock)
+	net.register(validatorNodeID, validatorInstance)
+	require.NoError(t, validatorInstance.Start(t.Context()))
+	t.Cleanup(validatorInstance.Stop)
+
+	waitForNumBlocks(t, storage, 7)
+	validatorInstance.Stop()
+	require.True(t, validatorInstance.isStopped())
+
+	replicatedSeq := storage.NumBlocks() - 1
+	replicated, ok := storage.blockAt(replicatedSeq)
+	require.True(t, ok)
+	parent, ok := storage.blockAt(replicatedSeq - 1)
+	require.True(t, ok)
+
+	// The non-validator holds the chain up to, but not including, that last block, and is wired to
+	// a network of its own where nobody answers: the replication response we hand it below is the
+	// only way it can ever learn about the block.
+	nonValidatorStorage := storage.cloneBelow(replicatedSeq)
+	require.Equal(t, replicatedSeq, nonValidatorStorage.NumBlocks())
+	_, ok = nonValidatorStorage.blockAt(replicatedSeq)
+	require.False(t, ok, "the non-validator already has the block it is meant to replicate")
+
+	nonValidatorInstance := newInstance(t, nonValidatorNodeID, nonValidatorStorage, newInMemNetwork(t), pChain, cops, genesisBlock)
+	require.NoError(t, nonValidatorInstance.Start(t.Context()))
+	t.Cleanup(nonValidatorInstance.Stop)
+
+	// The MSM that built the chain - the validator has stopped, so nothing else uses it - accepts
+	// the block, so we know the block is valid.
+	msm := validatorInstance.msm
+	_, err := (&ParsedBlock{StateMachineBlock: replicated.Clone(), msm: msm}).Verify(context.Background())
+	require.NoError(t, err)
+
+	// The block we feed the non-validator is that same block with a single defect: a timestamp
+	// that precedes its parent's. Everything else - round, sequence, epoch info, P-chain height,
+	// inner block - is left alone, so the only thing wrong with it is its state machine
+	// transition.
+	tampered := replicated.Clone()
+	tampered.Metadata.Timestamp = parent.Metadata.Timestamp - 1
+
+	// Wire the MSM that built the chain to the tampered block, so we can prove that the MSM would have rejected it.
+	tamperedBlock := &ParsedBlock{StateMachineBlock: tampered.Clone(), msm: msm}
+	_, err = tamperedBlock.Verify(context.Background())
+	require.ErrorContains(t, err, "proposed timestamp is before parent block's timestamp")
+
+	// Changing the timestamp made it a block the validator never built: no sequence of its ledger
+	// holds it.
+	for seq := uint64(0); seq < storage.NumBlocks(); seq++ {
+		stored, ok := storage.blockAt(seq)
+		require.True(t, ok)
+		require.NotEqual(t, tampered.Digest(), stored.Digest(), "the validator has the tampered block at seq %d", seq)
+	}
+
+	// Send precisely that block: the finalization we hand over is a quorum on its digest, not on
+	// the digest of the block the validator built.
+	block := &ParsedBlock{StateMachineBlock: tampered.Clone()}
+	finalization, _ := testutil.NewFinalizationRecord(t, &testutil.TestSignatureAggregator{N: 1}, block, []common.NodeID{validatorNodeID})
+	require.Equal(t, common.Digest(tampered.Digest()), finalization.Finalization.Digest)
+	require.NotEqual(t, common.Digest(replicated.Digest()), finalization.Finalization.Digest)
+
+	require.NoError(t, nonValidatorInstance.HandleMessage(&common.Message{
+		ReplicationResponse: &common.ReplicationResponse{
+			Data: []common.QuorumRound{{Block: block, Finalization: &finalization}},
+		},
+	}, validatorNodeID))
+
+	// It commits the block its state machine would have rejected...
+	waitForNumBlocks(t, nonValidatorStorage, replicatedSeq+1)
+	committed, ok := nonValidatorStorage.blockAt(replicatedSeq)
+	require.True(t, ok)
+	require.Equal(t, tampered.Digest(), committed.Digest())
+
+	// ... so the two ledgers are the same height but disagree on their last block: the
+	// non-validator committed a block that exists nowhere in the validator's storage.
+	require.Equal(t, storage.NumBlocks(), nonValidatorStorage.NumBlocks())
+	require.NotEqual(t, replicated.Digest(), committed.Digest())
+}
+
+func TestValidatorSkipsMSMVerificationWhenReplicating(t *testing.T) {
+	// This test ensures that validators that are lagging behind do not use the MSM
+	// to verify blocks they replicate through the replication path, as they have a QC.
+	// We check once for a notarized block and once for a finalized block.
+
+	for _, tt := range []struct {
+		name string
+		// quorumRound wraps the replicated block with a QC.
+		quorumRound func(t *testing.T, logger common.Logger, block *ParsedBlock, signers []common.NodeID) common.QuorumRound
+		// requireReplicated asserts the lagging node replicated the block.
+		requireReplicated func(t *testing.T, storage *MockStorage, block metadata.StateMachineBlock)
+	}{
+		{
+			name: "notarization",
+			quorumRound: func(t *testing.T, logger common.Logger, block *ParsedBlock, signers []common.NodeID) common.QuorumRound {
+				notarization, err := testutil.NewNotarization(logger, &testutil.TestSignatureAggregator{N: len(signers)}, block, signers)
+				require.NoError(t, err)
+				return common.QuorumRound{Block: block, Notarization: &notarization}
+			},
+			// A notarized block is not committed but notarized: the node persists the
+			// notarization to its WAL, which it only reaches after the block verified.
+			requireReplicated: func(t *testing.T, storage *MockStorage, block metadata.StateMachineBlock) {
+				round := block.Metadata.SimplexProtocolMetadata.Round
+				require.Eventually(t, func() bool {
+					return storage.containsNotarization(round)
+				}, 20*time.Second, 100*time.Millisecond, "no notarization for round %d was persisted to the WAL", round)
+				require.Equal(t, block.Metadata.SimplexProtocolMetadata.Seq, storage.NumBlocks(), "a notarized block should not have been committed")
+			},
+		},
+		{
+			name: "finalization",
+			quorumRound: func(t *testing.T, _ common.Logger, block *ParsedBlock, signers []common.NodeID) common.QuorumRound {
+				finalization, _ := testutil.NewFinalizationRecord(t, &testutil.TestSignatureAggregator{N: len(signers)}, block, signers)
+				return common.QuorumRound{Block: block, Finalization: &finalization}
+			},
+			// A finalized block is committed.
+			requireReplicated: func(t *testing.T, storage *MockStorage, block metadata.StateMachineBlock) {
+				seq := block.Metadata.SimplexProtocolMetadata.Seq
+				waitForNumBlocks(t, storage, seq+1)
+				committed, ok := storage.blockAt(seq)
+				require.True(t, ok)
+				require.Equal(t, block.Digest(), committed.Digest())
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			const basePChainHeight = uint64(1)
+
+			var first, second [20]byte
+			rand.Read(first[:])
+			rand.Read(second[:])
+			firstNodeID := common.NodeID(first[:])
+			secondNodeID := common.NodeID(second[:])
+
+			// Two validators, so a quorum is both of them: once one of them is down, the other
+			// cannot commit a block, nor even empty notarize a round, on its own.
+			validatorSetsAtHeight := map[uint64]metadata.NodeBLSMappings{
+				basePChainHeight: {
+					{NodeID: first, BLSKey: []byte{0xaa}, Weight: 1},
+					{NodeID: second, BLSKey: []byte{0xbb}, Weight: 1},
+				},
+			}
+
+			pChain := newTestPlatformChain(basePChainHeight, validatorSetsAtHeight)
+			cops := &testCryptoOps{}
+			genesisBlock := &testInnerBlock{Height_: 0, TS: time.Now(), Payload: []byte("genesis")}
+
+			net := newInMemNetwork(t)
+			t.Cleanup(net.stop)
+
+			// The two validators build a chain together and then both shut down, so that from
+			// here on the only source of blocks is this test.
+			storage := newStorageWithGenesis(t, genesisBlock)
+			storage2 := newStorageWithGenesis(t, genesisBlock)
+			firstInstance := newInstance(t, firstNodeID, storage, net, pChain, cops, genesisBlock)
+			secondInstance := newInstance(t, secondNodeID, storage2, net, pChain, cops, genesisBlock)
+			net.register(firstNodeID, firstInstance)
+			net.register(secondNodeID, secondInstance)
+			require.NoError(t, firstInstance.Start(t.Context()))
+			require.NoError(t, secondInstance.Start(t.Context()))
+			t.Cleanup(firstInstance.Stop)
+			t.Cleanup(secondInstance.Stop)
+
+			waitForNumBlocks(t, storage, 7)
+			firstInstance.Stop()
+			secondInstance.Stop()
+			require.True(t, firstInstance.isStopped())
+			require.True(t, secondInstance.isStopped())
+
+			replicatedSeq := storage.NumBlocks() - 1
+			replicated, ok := storage.blockAt(replicatedSeq)
+			require.True(t, ok)
+			parent, ok := storage.blockAt(replicatedSeq - 1)
+			require.True(t, ok)
+
+			// The node restored at the parent below sits at the round following the parent's, and
+			// only processes a replicated round it has reached, so the block it is missing must be
+			// the one that directly follows its parent's round.
+			require.Equal(t, parent.Metadata.SimplexProtocolMetadata.Round+1, replicated.Metadata.SimplexProtocolMetadata.Round,
+				"the chain grew an empty round before its last block")
+
+			// The MSM that built the chain - the validator has stopped, so nothing else uses it -
+			// accepts the block, so we know the block is valid.
+			msm := firstInstance.msm
+			_, err := (&ParsedBlock{StateMachineBlock: replicated.Clone(), msm: msm}).Verify(context.Background())
+			require.NoError(t, err)
+
+			// The block we hand the node is that same block with a single defect: a timestamp preceding its parent's.
+			// Everything else - round, sequence, epoch info, P-chain height, inner block - is left alone,
+			// so the only thing wrong with it is its state machine transition, which is what the state
+			// machine rejects and what verifying only the inner block - what a node replicating a
+			// block does - accepts.
+			tampered := replicated.Clone()
+			tampered.Metadata.Timestamp = parent.Metadata.Timestamp - 1
+
+			// The MSM rejects the tampered block, so we know the block is invalid.
+			tamperedBlock := &ParsedBlock{StateMachineBlock: tampered.Clone(), msm: msm}
+			_, err = tamperedBlock.Verify(context.Background())
+			require.ErrorContains(t, err, "proposed timestamp is before parent block's timestamp")
+			_, err = tamperedBlock.Verify(context.Background(), common.OnlyVMVerifyOpt)
+			require.NoError(t, err)
+
+			// Changing the timestamp made it a block neither validator ever built: no sequence of
+			// either ledger holds it.
+			for seq := uint64(0); seq < storage.NumBlocks(); seq++ {
+				for _, ledger := range []*MockStorage{storage, storage2} {
+					stored, ok := ledger.blockAt(seq)
+					require.True(t, ok)
+					require.NotEqual(t, tampered.Digest(), stored.Digest(), "a validator has the tampered block at seq %d", seq)
+				}
+			}
+
+			// The first validator comes back up lagging the chain by that block, with a paused VM
+			// and on a network of its own where nobody answers. It can therefore neither build
+			// the block nor replicate it legitimately, and since its peer is down it cannot reach
+			// a quorum to empty notarize either: it sits at exactly the round of the block it is
+			// missing until we hand it one.
+			laggingStorage := storage.cloneBelow(replicatedSeq)
+			require.Equal(t, replicatedSeq, laggingStorage.NumBlocks())
+			_, ok = laggingStorage.blockAt(replicatedSeq)
+			require.False(t, ok, "the lagging validator already has the block it is meant to replicate")
+
+			vm := newTestVM()
+			vm.pause()
+			laggingInstance := newInstanceWithVM(t, firstNodeID, laggingStorage, newInMemNetwork(t), pChain, cops, genesisBlock, vm)
+			require.NoError(t, laggingInstance.Start(t.Context()))
+			t.Cleanup(laggingInstance.Stop)
+
+			// Send precisely that block: the quorum certificate we hand over is on its digest, not
+			// on the digest of the block the validators built.
+			block := &ParsedBlock{StateMachineBlock: tampered.Clone()}
+			quorumRound := tt.quorumRound(t, laggingInstance.Config.Logger, block, []common.NodeID{firstNodeID, secondNodeID})
+			require.Equal(t, common.Digest(tampered.Digest()), quorumRound.Block.BlockHeader().Digest)
+			require.NotEqual(t, common.Digest(replicated.Digest()), quorumRound.Block.BlockHeader().Digest)
+
+			require.NoError(t, laggingInstance.HandleMessage(&common.Message{
+				ReplicationResponse: &common.ReplicationResponse{Data: []common.QuorumRound{quorumRound}},
+			}, secondNodeID))
+
+			tt.requireReplicated(t, laggingStorage, tampered)
+		})
+	}
+}
+
 // requireTipIsSealing asserts whether the last block in storage is a sealing block.
 func requireTipIsSealing(t *testing.T, storage *MockStorage, want bool) {
 	t.Helper()
@@ -598,7 +872,7 @@ func waitForNumBlocks(t *testing.T, storage *MockStorage, targetHeight uint64) {
 	t.Helper()
 	require.Eventually(t, func() bool {
 		return storage.NumBlocks() >= targetHeight
-	}, 20*time.Second, 100*time.Millisecond)
+	}, 20*time.Second, 100*time.Millisecond, "storage did not commit %d blocks in time", targetHeight)
 }
 
 // waitForSealingBlock waits until a sealing block (a block carrying a BlockValidationDescriptor with the new weight)
@@ -863,6 +1137,7 @@ type MockStorage struct {
 
 	snapLock sync.Mutex
 	blocks   map[uint64]storedBlock
+	wals     []*testutil.TestWAL
 }
 
 type storedBlock struct {
@@ -927,7 +1202,42 @@ func (m *MockStorage) parseStored(encoded []byte) metadata.StateMachineBlock {
 }
 
 func (m *MockStorage) CreateWAL() (wal.DeletableWAL, error) {
-	return testutil.NewTestWAL(m.t), nil
+	w := testutil.NewTestWAL(m.t)
+	m.snapLock.Lock()
+	m.wals = append(m.wals, w)
+	m.snapLock.Unlock()
+	return w, nil
+}
+
+// cloneBelow returns a storage holding every block of m below seq - the block at seq itself, and
+// anything after it, is left out - so that a test can bring up a node that lags the chain by them.
+func (m *MockStorage) cloneBelow(seq uint64) *MockStorage {
+	clone := NewMockStorage(m.t)
+	for cloned := uint64(0); cloned < seq; cloned++ {
+		m.snapLock.Lock()
+		stored, ok := m.blocks[cloned]
+		m.snapLock.Unlock()
+		require.True(m.t, ok)
+
+		block := &ParsedBlock{StateMachineBlock: m.parseStored(stored.rawBlock)}
+		require.NoError(m.t, clone.Index(context.Background(), block, stored.fin))
+	}
+	return clone
+}
+
+// containsNotarization reports whether any WAL this storage handed out holds a notarization for
+// the given round.
+func (m *MockStorage) containsNotarization(round uint64) bool {
+	m.snapLock.Lock()
+	wals := append([]*testutil.TestWAL(nil), m.wals...)
+	m.snapLock.Unlock()
+
+	for _, w := range wals {
+		if w.ContainsNotarization(round) {
+			return true
+		}
+	}
+	return false
 }
 
 // ---------------------------------------------------------------------------

--- a/msm/msm.go
+++ b/msm/msm.go
@@ -172,9 +172,6 @@ type StateMachine struct {
 
 // Config contains the dependencies and configuration parameters needed to initialize the StateMachine.
 type Config struct {
-	// SkipMSMVerification indicates whether to skip the verification of the state machine transition when verifying blocks,
-	// and only verify the inner block. This is useful when replicating finalized blocks as a non-validator.
-	SkipMSMVerification bool
 	// LatestPersistedHeight is the height of the most recently persisted block.
 	LatestPersistedHeight uint64
 	// MaxBlockBuildingWaitTime is the maximum duration to wait for the VM to build a block
@@ -328,14 +325,6 @@ func (sm *StateMachine) BuildBlock(ctx context.Context, metadata common.Protocol
 func (sm *StateMachine) VerifyBlock(ctx context.Context, block *StateMachineBlock) error {
 	if block == nil {
 		return errNilBlock
-	}
-
-	if sm.SkipMSMVerification {
-		// If SkipMSMVerification is true, we only verify the inner block and skip the state machine verification.
-		if block.InnerBlock == nil {
-			return nil
-		}
-		return block.InnerBlock.Verify(ctx, block.Metadata.ICMEpochInfo.PChainEpochHeight)
 	}
 
 	pmd := block.Metadata.SimplexProtocolMetadata
@@ -515,11 +504,7 @@ func verifyAgainstExpected(
 	expectedIcmEpochInfo ICMEpochInfo,
 	auxInfo *AuxiliaryInfo,
 ) error {
-	if innerBlock != nil {
-		if err := innerBlock.Verify(ctx, expectedIcmEpochInfo.PChainEpochHeight); err != nil {
-			return err
-		}
-	}
+	// First verify the metadata matches the expected values, only afterwards verify the inner block, if any.
 	expectedBlock := wrapBlock(
 		innerBlock, expectedSimplexEpochInfo, expectedPChainHeight,
 		nextBlock.Metadata.SimplexProtocolMetadata, nextBlock.Metadata.SimplexBlacklist, timestamp, expectedIcmEpochInfo, auxInfo)
@@ -528,6 +513,12 @@ func verifyAgainstExpected(
 			expectedBlock.Digest(),
 			nextBlock.Digest(),
 			errBlockDigestMismatch)
+	}
+
+	if innerBlock != nil {
+		if err := innerBlock.Verify(ctx, expectedIcmEpochInfo.PChainEpochHeight); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -1255,7 +1246,7 @@ func (sm *StateMachine) computeSimplexEpochInfoForSealingBlock(simplexEpochInfo 
 
 // wrapBlock creates a new StateMachineBlock by wrapping the VM block (if applicable) and adding the appropriate metadata.
 func wrapBlock(
-	childBlock avalanchego.VMBlock,
+	innerBlock avalanchego.VMBlock,
 	newSimplexEpochInfo SimplexEpochInfo,
 	pChainHeight uint64,
 	simplexMetadata common.ProtocolMetadata,
@@ -1265,7 +1256,7 @@ func wrapBlock(
 	auxiliaryInfo *AuxiliaryInfo) *StateMachineBlock {
 
 	return &StateMachineBlock{
-		InnerBlock: childBlock,
+		InnerBlock: innerBlock,
 		Metadata: StateMachineMetadata{
 			Timestamp:               uint64(timestamp.UnixMilli()),
 			SimplexProtocolMetadata: simplexMetadata,

--- a/nonvalidator/epochs_test.go
+++ b/nonvalidator/epochs_test.go
@@ -23,7 +23,7 @@ func (b *sealingTestBlock) SealingBlockInfo() *common.SealingBlockInfo {
 	return b.sealingInfo
 }
 
-func (b *sealingTestBlock) Verify(_ context.Context) (common.VerifiedBlock, error) {
+func (b *sealingTestBlock) Verify(_ context.Context, _ ...common.VerifyOptions) (common.VerifiedBlock, error) {
 	return b, nil
 }
 

--- a/nonvalidator/non_validator.go
+++ b/nonvalidator/non_validator.go
@@ -241,7 +241,7 @@ func (n *NonValidator) newFinalizedBlockTask(block common.Block, finalization *c
 			n.Logger.Debug("Block verification ended", zap.Uint64("sequence", md.Seq), zap.Duration("elapsed", elapsed))
 		}()
 
-		verifiedBlock, err := block.Verify(n.ctx)
+		verifiedBlock, err := block.Verify(n.ctx, common.OnlyVMVerifyOpt)
 		n.lock.Lock()
 		defer n.lock.Unlock()
 

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -339,7 +339,7 @@ func (e *Epoch) loadBlockRecord(block common.Block) error {
 
 	// we have not indexed this block so we need to verify before restoring
 	e.Logger.Debug("Verifying block from WAL", zap.Uint64("Round", block.BlockHeader().Round), zap.Uint64("Seq", block.BlockHeader().Seq))
-	verifiedBlock, err := block.Verify(e.finishCtx)
+	verifiedBlock, err := block.Verify(e.finishCtx, common.OnlyVMVerifyOpt)
 	if err != nil {
 		e.Logger.Error("Failed to verify block from WAL", zap.Uint64("Round", block.BlockHeader().Round), zap.Uint64("Seq", block.BlockHeader().Seq), zap.Error(err))
 		return fmt.Errorf("failed to verify block: %w. round %d", err, block.BlockHeader().Round)
@@ -2201,7 +2201,7 @@ func (e *Epoch) createFinalizedBlockVerificationTask(block common.Block, finaliz
 			return md.Digest
 		}
 
-		verifiedBlock, err := block.Verify(context.Background())
+		verifiedBlock, err := block.Verify(context.Background(), common.OnlyVMVerifyOpt)
 		if err != nil {
 			e.Logger.Debug("Failed verifying block", zap.Error(err))
 			// if we fail to verify the block, we re-add to request timeout
@@ -2278,7 +2278,7 @@ func (e *Epoch) createNotarizedBlockVerificationTask(block common.Block, notariz
 			return md.Digest
 		}
 
-		verifiedBlock, err := block.Verify(context.Background())
+		verifiedBlock, err := block.Verify(context.Background(), common.OnlyVMVerifyOpt)
 		if err != nil {
 			e.Logger.Debug("Failed verifying block", zap.Error(err))
 			// TODO: if we fail to verify the block, we should re-request it from the replication state

--- a/simplex/util.go
+++ b/simplex/util.go
@@ -148,7 +148,7 @@ type oneTimeVerifiedBlock struct {
 	common.Block
 }
 
-func (block *oneTimeVerifiedBlock) Verify(ctx context.Context) (common.VerifiedBlock, error) {
+func (block *oneTimeVerifiedBlock) Verify(ctx context.Context, verifyOpts ...common.VerifyOptions) (common.VerifiedBlock, error) {
 	block.otv.lock.Lock()
 	defer block.otv.lock.Unlock()
 
@@ -161,7 +161,7 @@ func (block *oneTimeVerifiedBlock) Verify(ctx context.Context) (common.VerifiedB
 		return result.vb, result.err
 	}
 
-	vb, err := block.Block.Verify(ctx)
+	vb, err := block.Block.Verify(ctx, verifyOpts...)
 	if err != nil {
 		block.otv.logger.Debug("Block verification failed", zap.Uint64("round", header.Round), zap.Error(err))
 		return nil, err

--- a/testutil/block.go
+++ b/testutil/block.go
@@ -41,7 +41,7 @@ func (tb *TestBlock) Blacklist() common.Blacklist {
 	return tb.blacklist
 }
 
-func (tb *TestBlock) Verify(context.Context) (common.VerifiedBlock, error) {
+func (tb *TestBlock) Verify(context.Context, ...common.VerifyOptions) (common.VerifiedBlock, error) {
 	defer func() {
 		if tb.OnVerify != nil {
 			tb.OnVerify()

--- a/testutil/random_network/block.go
+++ b/testutil/random_network/block.go
@@ -40,7 +40,7 @@ func NewBlock(metadata common.ProtocolMetadata, blacklist common.Blacklist, memp
 	return b
 }
 
-func (b *Block) Verify(ctx context.Context) (common.VerifiedBlock, error) {
+func (b *Block) Verify(ctx context.Context, _ ...common.VerifyOptions) (common.VerifiedBlock, error) {
 	return b, b.mempool.VerifyBlock(ctx, b)
 }
 


### PR DESCRIPTION
This commit adds a VerifyOptions to the internal API of Verify() in order for replicated blocks to not verify the MSM because there is no need to verify something that has a quorum certificate.