### PR TITLE
Send the latest finalization if latest finalized sequence is the same as lastBlock

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -3203,7 +3203,7 @@ func (e *Epoch) handleReplicationRequest(req *common.ReplicationRequest, from co
 	remainingBytes := e.MaxReplicationResponseSize
 
 	if req.LatestFinalizedSeq > 0 {
-		if e.lastBlock != nil && e.lastBlock.Finalization.Finalization.Seq > req.LatestFinalizedSeq {
+		if e.lastBlock != nil && e.lastBlock.Finalization.Finalization.Seq >= req.LatestFinalizedSeq {
 			latestFinalizedSeq := &common.VerifiedQuorumRound{
 				VerifiedBlock: e.lastBlock.VerifiedBlock,
 				Finalization:  &e.lastBlock.Finalization,


### PR DESCRIPTION
A weird edge case that was caught by one of my tests

scenario: 
1. a chain that only has the first ever simplex block built.
2. a non-validator joins and tries to sync the chain
3. they cannot sync because non-validators will send a request with `latestfinalizedSeq = 1`, which will get dropped by the validator since 1 = lastBlock.Seq
https://github.com/ava-labs/Simplex/blob/f48921470c75bd851a00fbf91f4e07ec81ed83cd/nonvalidator/non_validator.go#L545-L551
