### PR TITLE
Log failed block builds when the context was not canceled

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2589,11 +2589,10 @@ func (e *Epoch) createBlockBuildingTask(metadata common.ProtocolMetadata, blackl
 		e.lock.Lock()
 		defer e.lock.Unlock()
 
+		canceled := context.Err() != nil
 		cancel()
 		if !ok {
-			select {
-			case <-context.Done():
-			default:
+			if !canceled {
 				e.Logger.Debug("Failed building block")
 			}
 			return common.Digest{}

--- a/simplex/monitor_test.go
+++ b/simplex/monitor_test.go
@@ -125,9 +125,11 @@ func TestMonitorAsyncWaitForWithNestedWaitUntil(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(1)
+	// FutureTask must be scheduled before AdvanceTime, otherwise the deadline
+	// is computed from the advanced clock and the tick never satisfies it.
 	mon.RunTask(func() {
-		go mon.AdvanceTime(start.Add(10 * time.Millisecond))
 		mon.FutureTask(10*time.Millisecond, wg.Done)
+		mon.AdvanceTime(start.Add(10 * time.Millisecond))
 	})
 	wg.Wait()
 }


### PR DESCRIPTION
`createBlockBuildingTask` checked `<-context.Done()` after already calling `cancel()`, so the "Failed building block" debug log could never fire. Capture `context.Err()` before canceling instead.