### PR TITLE
Stop indexing and gate messages once the epoch is sealed

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -166,7 +166,7 @@ func (e *Epoch) HandleMessage(msg *common.Message, from common.NodeID) error {
 	}
 
 	_, known := e.validatorsToPKs[string(from)]
-	if !known {
+	if !known || e.isEpochSealed() {
 		e.Logger.Debug("Received message from a non-validator node", zap.Stringer("nodeID", from))
 		switch {
 		case msg.ReplicationRequest != nil && e.ReplicationEnabled:
@@ -1466,13 +1466,17 @@ func (e *Epoch) indexFinalizations(startRound uint64) error {
 }
 
 func (e *Epoch) indexFinalization(block common.VerifiedBlock, finalization common.Finalization) error {
-	if err := e.Storage.Index(e.finishCtx, block, finalization); err != nil {
-		return err
+	// index only if the epoch is not sealed
+	if !e.isEpochSealed() {
+		if err := e.Storage.Index(e.finishCtx, block, finalization); err != nil {
+			return err
+		}
+		e.Logger.Info("Committed block",
+			zap.Uint64("round", finalization.Finalization.Round),
+			zap.Uint64("sequence", finalization.Finalization.Seq),
+			zap.Stringer("digest", finalization.Finalization.Digest))
 	}
-	e.Logger.Info("Committed block",
-		zap.Uint64("round", finalization.Finalization.Round),
-		zap.Uint64("sequence", finalization.Finalization.Seq),
-		zap.Stringer("digest", finalization.Finalization.Digest))
+
 	e.lastBlock = &common.VerifiedFinalizedBlock{
 		VerifiedBlock: block,
 		Finalization:  finalization,

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -1467,15 +1467,13 @@ func (e *Epoch) indexFinalizations(startRound uint64) error {
 
 func (e *Epoch) indexFinalization(block common.VerifiedBlock, finalization common.Finalization) error {
 	// index only if the epoch is not sealed
-	if !e.isEpochSealed() {
-		if err := e.Storage.Index(e.finishCtx, block, finalization); err != nil {
-			return err
-		}
-		e.Logger.Info("Committed block",
-			zap.Uint64("round", finalization.Finalization.Round),
-			zap.Uint64("sequence", finalization.Finalization.Seq),
-			zap.Stringer("digest", finalization.Finalization.Digest))
+	if err := e.Storage.Index(e.finishCtx, block, finalization); err != nil {
+		return err
 	}
+	e.Logger.Info("Committed block",
+		zap.Uint64("round", finalization.Finalization.Round),
+		zap.Uint64("sequence", finalization.Finalization.Seq),
+		zap.Stringer("digest", finalization.Finalization.Digest))
 
 	e.lastBlock = &common.VerifiedFinalizedBlock{
 		VerifiedBlock: block,


### PR DESCRIPTION
Split out of the cleanup-instance branch.

Two related fixes for behavior after an epoch seals:
- `HandleMessage` now treats every sender like a non-validator once the epoch is sealed, so only replication requests are served.
- `indexFinalization` no longer indexes blocks after the epoch is sealed, though it still tracks the last block and progresses rounds.