### PR TITLE
Find verified unfinalized blocks on seq-only cache lookups

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -114,6 +114,16 @@ func (cs *CachedStorage) RetrieveBlock(seq uint64, digest common.Digest) (metada
 func (cs *CachedStorage) Retrieve(seq uint64, digest common.Digest) (common.VerifiedBlock, *common.Finalization, error) {
 	cs.lock.RLock()
 	item, exists := cs.cache[digest]
+	if !exists && digest == (common.Digest{}) {
+		// Seq-only lookups pass a zero digest, so scan the cache by seq.
+		// Otherwise a verified but not yet finalized block is invisible to them.
+		for _, cb := range cs.cache {
+			if cb.Metadata.SimplexProtocolMetadata.Seq == seq {
+				item, exists = cb, true
+				break
+			}
+		}
+	}
 	if exists {
 		cs.lock.RUnlock()
 		// If the block is cached, it means it's not finalized yet, because upon finalizing the block (indexing)


### PR DESCRIPTION
Split out of the cleanup-instance branch.

`CachedStorage.Retrieve` only looked the cache up by digest, so seq-only lookups (which pass a zero digest) missed blocks that were verified but not yet finalized. Scan the cache by seq for those lookups.

Related to the upcoming auxiliary info dissemination work: the aux history traversal retrieves blocks by seq with a zero digest, so this should merge before or alongside that stack.