### PR TITLE
Wire the epoch transition listener into the instance

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -313,6 +313,14 @@ func (i *Instance) HandleMessage(msg *common.Message, from common.NodeID) error 
 	if i.e != nil {
 		switch {
 		case msg.AuxiliaryInfo != nil:
+			if msg.AuxiliaryInfo.Epoch != i.e.Epoch {
+				i.Config.Logger.Debug(
+					"Received an auxiliary info from an old epoch",
+					zap.Uint64("Aux Info Epoch", msg.AuxiliaryInfo.Epoch),
+					zap.Uint64("Our Epoch", i.e.Epoch),
+					zap.Stringer("From", from))
+				return nil
+			}
 			i.msm.HandleAuxiliaryInfo(*msg.AuxiliaryInfo, avalanchego.NodeID(from))
 		case msg.EpochTransitionApproval != nil:
 			// TODO: pass in time.Now() rather than uint64

--- a/instance.go
+++ b/instance.go
@@ -332,7 +332,7 @@ func (i *Instance) HandleMessage(msg *common.Message, from common.NodeID) error 
 			i.msm.HandleAuxiliaryInfo(*msg.AuxiliaryInfo, avalanchego.NodeID(from))
 		case msg.EpochTransitionApproval != nil:
 			// TODO: pass in time.Now() rather than uint64
-			i.msm.HandleApproval(msg.EpochTransitionApproval, uint64(time.Now().Unix()))
+			i.msm.HandleApproval(msg.EpochTransitionApproval, uint64(time.Now().UnixMilli()))
 		}
 		return i.e.HandleMessage(msg, from)
 	}

--- a/instance.go
+++ b/instance.go
@@ -56,10 +56,6 @@ type epochChange struct {
 	epoch      uint64
 	validators common.Nodes
 }
-
-// TODO: replace noop-index with a function that checks whether we need to send approvals or auxiliary information
-func noopOnIndex(*ParsedBlock) error { return nil }
-
 type timeAdvancer interface {
 	AdvanceTime(t time.Time)
 }
@@ -67,24 +63,40 @@ type timeAdvancer interface {
 type Instance struct {
 	Config Config
 
-	lock         sync.Mutex
-	started      bool
-	cs           *CachedStorage
-	wal          *wal.GarbageCollectedWAL
-	msm          *metadata.StateMachine
-	e            *simplex.Epoch
-	nv           *nonvalidator.NonValidator
-	epochOrNV    timeAdvancer
-	epochChanges chan epochChange
-	stopCh       chan struct{}
+	lock               sync.Mutex
+	started            bool
+	cs                 *CachedStorage
+	transitionListener *epochTransitionListener
+	wal                *wal.GarbageCollectedWAL
+	msm                *metadata.StateMachine
+	e                  *simplex.Epoch
+	nv                 *nonvalidator.NonValidator
+	epochOrNV          timeAdvancer
+	epochChanges       chan epochChange
+	stopCh             chan struct{}
 }
 
 func NewInstance(config Config) *Instance {
+	cs := NewCachedStorage(config.Storage)
+	// Non-validators have no block builder, so they pass a nil approval handler:
+	// they broadcast approvals but do not need to record their own locally.
+	transitionListener := newEpochTransitionListener(
+		config.Logger,
+		config.Broadcaster,
+		avalanchego.NodeID(config.ID),
+		config.PlatformChain.GetValidatorSet,
+		cs.RetrieveBlock,
+		config.CryptoOps,
+		&NoopAuxiliaryInfoApp{}, // TODO: set this in the config
+		nil,
+	)
+
 	return &Instance{
-		Config:       config,
-		stopCh:       make(chan struct{}),
-		epochChanges: make(chan epochChange, 1),
-		cs:           NewCachedStorage(config.Storage),
+		Config:             config,
+		stopCh:             make(chan struct{}),
+		epochChanges:       make(chan epochChange, 1),
+		cs:                 cs,
+		transitionListener: transitionListener,
 	}
 }
 
@@ -172,7 +184,7 @@ func (i *Instance) createNonValidatorConfig() (nonvalidator.Config, error) {
 		Config: &metadata.Config{},
 	}
 	i.cs.msm = i.msm
-	instanceStorage := NewCallbackStorage(i.cs, i.msm, noopOnIndex)
+	instanceStorage := NewCallbackStorage(i.cs, i.msm, i.transitionListener.onIndex)
 
 	config := nonvalidator.Config{
 		ID:                         i.Config.ID,
@@ -299,6 +311,13 @@ func (i *Instance) HandleMessage(msg *common.Message, from common.NodeID) error 
 	}
 
 	if i.e != nil {
+		switch {
+		case msg.AuxiliaryInfo != nil:
+			i.msm.HandleAuxiliaryInfo(*msg.AuxiliaryInfo, avalanchego.NodeID(from))
+		case msg.EpochTransitionApproval != nil:
+			// TODO: pass in time.Now() rather than uint64
+			i.msm.HandleApproval(msg.EpochTransitionApproval, uint64(time.Now().Unix()))
+		}
 		return i.e.HandleMessage(msg, from)
 	}
 
@@ -463,6 +482,9 @@ func (i *Instance) createEpochConfig(epoch uint64, validators common.Nodes) (*ep
 	comm := newCommunication(i.Config.Sender, i.Config.Broadcaster, validators)
 
 	instanceStorage := NewCallbackStorage(i.cs, msm, func(block *ParsedBlock) error {
+		if err := i.transitionListener.onIndex(block); err != nil {
+			return err
+		}
 		if block.Type() == metadata.BlockTypeSealing {
 			blockBuilder.stop()
 			i.notifyEpochChange(block.BlockHeader().Seq, block.SealingBlockInfo().ValidatorSet)

--- a/instance.go
+++ b/instance.go
@@ -82,7 +82,7 @@ func NewInstance(config Config) *Instance {
 	// they broadcast approvals but do not need to record their own locally.
 	transitionListener := newEpochTransitionListener(
 		config.Logger,
-		config.Broadcaster,
+		config.Sender,
 		avalanchego.NodeID(config.ID),
 		config.PlatformChain.GetValidatorSet,
 		cs.RetrieveBlock,

--- a/instance.go
+++ b/instance.go
@@ -333,6 +333,7 @@ func (i *Instance) HandleMessage(msg *common.Message, from common.NodeID) error 
 		case msg.EpochTransitionApproval != nil:
 			// TODO: pass in time.Now() rather than uint64
 			i.msm.HandleApproval(msg.EpochTransitionApproval, uint64(time.Now().UnixMilli()))
+			return nil
 		}
 		return i.e.HandleMessage(msg, from)
 	}

--- a/instance.go
+++ b/instance.go
@@ -184,7 +184,15 @@ func (i *Instance) createNonValidatorConfig() (nonvalidator.Config, error) {
 		Config: &metadata.Config{},
 	}
 	i.cs.msm = i.msm
-	instanceStorage := NewCallbackStorage(i.cs, i.msm, i.transitionListener.onIndex)
+	instanceStorage := NewCallbackStorage(i.cs, i.msm, func(block *ParsedBlock) error {
+		switch {
+		case block.Type() == metadata.BlockTypeTransitioning:
+			if err := i.transitionListener.handleTransitionBlock(block); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 
 	config := nonvalidator.Config{
 		ID:                         i.Config.ID,
@@ -489,12 +497,18 @@ func (i *Instance) createEpochConfig(epoch uint64, validators common.Nodes) (*ep
 
 	comm := newCommunication(i.Config.Sender, i.Config.Broadcaster, validators)
 
+	// set the handle approval method so that the MSM can receive self approvals
+	i.transitionListener.handleApproval = msm.HandleApproval
 	instanceStorage := NewCallbackStorage(i.cs, msm, func(block *ParsedBlock) error {
-		if err := i.transitionListener.onIndex(block); err != nil {
-			return err
-		}
-		if block.Type() == metadata.BlockTypeSealing {
+		switch {
+		case block.Type() == metadata.BlockTypeTransitioning:
+			if err := i.transitionListener.handleTransitionBlock(block); err != nil {
+				return err
+			}
+		case block.Type() == metadata.BlockTypeSealing:
 			blockBuilder.stop()
+
+			i.transitionListener.handleApproval = nil
 			i.notifyEpochChange(block.BlockHeader().Seq, block.SealingBlockInfo().ValidatorSet)
 		}
 		return nil

--- a/transition_listener.go
+++ b/transition_listener.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package simplex
 
 import (
@@ -15,9 +18,9 @@ import (
 // Non-validators should also use this listener, since they may become
 // validators after the transition.
 type epochTransitionListener struct {
-	// broadcaster is used for broadcasting potential approvals and auxiliary information.
-	// It should be broadcast to the validators of the current epoch.
-	broadcaster Broadcaster
+	// sender is used for sending potential approvals and auxiliary information
+	// individually to the validators of the next epoch.
+	sender Sender
 
 	myNodeID avalanchego.NodeID
 
@@ -39,7 +42,7 @@ type epochTransitionListener struct {
 
 func newEpochTransitionListener(
 	logger common.Logger,
-	broadcaster Broadcaster,
+	sender Sender,
 	myNodeID avalanchego.NodeID,
 	getValidatorSet metadata.ValidatorSetRetriever,
 	getBlock metadata.BlockRetriever,
@@ -48,7 +51,7 @@ func newEpochTransitionListener(
 	handleApproval func(approval *common.ValidatorSetApproval, timestamp uint64),
 ) *epochTransitionListener {
 	return &epochTransitionListener{
-		broadcaster:     broadcaster,
+		sender:          sender,
 		myNodeID:        myNodeID,
 		getValidatorSet: getValidatorSet,
 		getBlock:        getBlock,
@@ -86,7 +89,7 @@ func (a *epochTransitionListener) handleTransitionBlock(block *ParsedBlock) erro
 	if isSufficient {
 		// no more auxiliary info to send, maybe send our approval
 		lastAuxInfoDigest := auxInfoHistory.LastHistoryDigest()
-		return a.maybeSendApprovals(block, lastAuxInfoDigest)
+		return a.maybeSendApprovals(block, nextEpochValidatorSet, lastAuxInfoDigest)
 	}
 
 	// we need more auxiliary information, attempt to generate
@@ -107,12 +110,22 @@ func (a *epochTransitionListener) handleTransitionBlock(block *ParsedBlock) erro
 		},
 	}
 
-	a.broadcaster.Broadcast(auxInfoMessage)
+	a.bulkSend(nextEpochValidatorSet, auxInfoMessage)
 	return nil
 }
 
+// bulkSend sends the message individually to every validator in the set except ourselves.
+func (a *epochTransitionListener) bulkSend(validators metadata.NodeBLSMappings, msg *common.Message) {
+	for _, validator := range validators {
+		if validator.NodeID == a.myNodeID {
+			continue
+		}
+		a.sender.Send(msg, common.NodeID(validator.NodeID[:]))
+	}
+}
+
 // TODO: use common.Digest
-func (a *epochTransitionListener) maybeSendApprovals(block *ParsedBlock, auxInfoDigest [32]byte) error {
+func (a *epochTransitionListener) maybeSendApprovals(block *ParsedBlock, nextEpochValidatorSet metadata.NodeBLSMappings, auxInfoDigest [32]byte) error {
 	nextEpochPChainReference := block.Metadata.SimplexEpochInfo.NextPChainReferenceHeight
 
 	sig, err := metadata.SignApproval(a.signer, nextEpochPChainReference, auxInfoDigest)
@@ -131,7 +144,7 @@ func (a *epochTransitionListener) maybeSendApprovals(block *ParsedBlock, auxInfo
 		EpochTransitionApproval: &approval,
 	}
 
-	a.broadcaster.Broadcast(&approvalMessage)
+	a.bulkSend(nextEpochValidatorSet, &approvalMessage)
 
 	// Validators also record their own approval locally so the next block they build
 	// includes it. Non-validators have no block builder, so handleApproval is nil.

--- a/transition_listener.go
+++ b/transition_listener.go
@@ -110,6 +110,7 @@ func (a *epochTransitionListener) handleTransitionBlock(block *ParsedBlock) erro
 
 	auxInfoMessage := &common.Message{
 		AuxiliaryInfo: &common.AuxiliaryInfo{
+			Epoch:   block.BlockHeader().Epoch,
 			Version: auxInfoHistory.OldestVersionID,
 			Data:    generatedAuxInfo,
 		},

--- a/transition_listener.go
+++ b/transition_listener.go
@@ -1,0 +1,151 @@
+package simplex
+
+import (
+	"time"
+
+	"github.com/ava-labs/simplex/avalanchego"
+	"github.com/ava-labs/simplex/common"
+
+	metadata "github.com/ava-labs/simplex/msm"
+)
+
+// epochTransitionListener reacts to blocks committed to storage. When a
+// transition block is indexed, it performs any tasks required of this node to
+// complete the epoch transition, such as sending out approval messages.
+// Non-validators should also use this listener, since they may become
+// validators after the transition.
+type epochTransitionListener struct {
+	// broadcaster is used for broadcasting potential approvals and auxiliary information.
+	// It should be broadcast to the validators of the current epoch.
+	broadcaster Broadcaster
+
+	myNodeID avalanchego.NodeID
+
+	// getValidatorSet returns the validator set at a given P-chain height.
+	getValidatorSet metadata.ValidatorSetRetriever
+	// getBlock retrieves a previously finalized block, used to traverse the auxiliary info history.
+	getBlock metadata.BlockRetriever
+	// signer signs epoch transition approvals.
+	signer common.Signer
+	// auxInfoApp decides whether the auxiliary info history is sufficient and generates new entries.
+	auxInfoApp metadata.AuxiliaryInfoGenVerifier
+	// handleApproval records our own broadcast approval in the local approval store.
+	// It is set for validators (whose MSM builds the next blocks and must include the
+	// approval) and nil for non-validators, which have no block builder to feed.
+	handleApproval func(approval *common.ValidatorSetApproval, timestamp uint64) error
+
+	logger common.Logger
+}
+
+func newEpochTransitionListener(
+	logger common.Logger,
+	broadcaster Broadcaster,
+	myNodeID avalanchego.NodeID,
+	getValidatorSet metadata.ValidatorSetRetriever,
+	getBlock metadata.BlockRetriever,
+	signer common.Signer,
+	auxInfoApp metadata.AuxiliaryInfoGenVerifier,
+	handleApproval func(approval *common.ValidatorSetApproval, timestamp uint64) error,
+) *epochTransitionListener {
+	return &epochTransitionListener{
+		broadcaster:     broadcaster,
+		myNodeID:        myNodeID,
+		getValidatorSet: getValidatorSet,
+		getBlock:        getBlock,
+		signer:          signer,
+		auxInfoApp:      auxInfoApp,
+		handleApproval:  handleApproval,
+		logger:          logger,
+	}
+}
+
+func (a *epochTransitionListener) onIndex(block *ParsedBlock) error {
+	switch block.Type() {
+	case metadata.BlockTypeTransitioning:
+		return a.handleTransitionBlock(block)
+	}
+
+	return nil
+}
+
+func (a *epochTransitionListener) handleTransitionBlock(block *ParsedBlock) error {
+	nextEpochPChainReference := block.Metadata.SimplexEpochInfo.NextPChainReferenceHeight
+
+	// if our node is not in the next validator set, no need to send anything.
+	nextEpochValidatorSet, err := a.getValidatorSet(nextEpochPChainReference)
+	if err != nil {
+		return err
+	}
+
+	indexes := nextEpochValidatorSet.IndexByNodeID()
+	if _, ok := indexes[a.myNodeID]; !ok {
+		return nil // we are not in the next validator set
+	}
+
+	auxInfoHistory, err := metadata.GetAuxiliaryHistory(&block.StateMachineBlock, block.BlockHeader().Seq, a.getBlock, a.auxInfoApp.DefaultVersionID())
+	if err != nil {
+		return err
+	}
+
+	isSufficient, err := a.auxInfoApp.IsSufficient(auxInfoHistory.OldestVersionID, nextEpochValidatorSet, auxInfoHistory.Data)
+	if err != nil {
+		return err
+	}
+
+	if isSufficient {
+		// no more auxiliary info to send, maybe send our approval
+		lastAuxInfoDigest := auxInfoHistory.LastHistoryDigest()
+		return a.maybeSendApprovals(block, lastAuxInfoDigest)
+	}
+
+	// we need more auxiliary information, attempt to generate
+	generatedAuxInfo, err := a.auxInfoApp.Generate(auxInfoHistory.OldestVersionID, nextEpochValidatorSet, auxInfoHistory.Data)
+	if err != nil {
+		return err
+	}
+
+	if generatedAuxInfo == nil {
+		return nil
+	}
+
+	auxInfoMessage := &common.Message{
+		AuxiliaryInfo: &common.AuxiliaryInfo{
+			Version: auxInfoHistory.OldestVersionID,
+			Data:    generatedAuxInfo,
+		},
+	}
+
+	a.broadcaster.Broadcast(auxInfoMessage)
+	return nil
+}
+
+// TODO: use common.Digest
+func (a *epochTransitionListener) maybeSendApprovals(block *ParsedBlock, auxInfoDigest [32]byte) error {
+	nextEpochPChainReference := block.Metadata.SimplexEpochInfo.NextPChainReferenceHeight
+
+	sig, err := metadata.SignApproval(a.signer, nextEpochPChainReference, auxInfoDigest)
+	if err != nil {
+		return err
+	}
+
+	approval := common.ValidatorSetApproval{
+		NodeID:        a.myNodeID,
+		PChainHeight:  nextEpochPChainReference,
+		AuxInfoDigest: auxInfoDigest,
+		Signature:     sig,
+	}
+
+	approvalMessage := common.Message{
+		EpochTransitionApproval: &approval,
+	}
+
+	a.broadcaster.Broadcast(&approvalMessage)
+
+	// Validators also record their own approval locally so the next block they build
+	// includes it. Non-validators have no block builder, so handleApproval is nil.
+	if a.handleApproval == nil {
+		return nil
+	}
+	timestamp := uint64(time.Now().UnixMilli())
+	return a.handleApproval(&approval, timestamp)
+}

--- a/transition_listener.go
+++ b/transition_listener.go
@@ -110,12 +110,12 @@ func (a *epochTransitionListener) handleTransitionBlock(block *ParsedBlock) erro
 		},
 	}
 
-	a.bulkSend(nextEpochValidatorSet, auxInfoMessage)
+	a.sendToValidators(nextEpochValidatorSet, auxInfoMessage)
 	return nil
 }
 
-// bulkSend sends the message individually to every validator in the set except ourselves.
-func (a *epochTransitionListener) bulkSend(validators metadata.NodeBLSMappings, msg *common.Message) {
+// sendToValidators sends the message individually to every validator in the set except ourselves.
+func (a *epochTransitionListener) sendToValidators(validators metadata.NodeBLSMappings, msg *common.Message) {
 	for _, validator := range validators {
 		if validator.NodeID == a.myNodeID {
 			continue
@@ -144,7 +144,7 @@ func (a *epochTransitionListener) maybeSendApprovals(block *ParsedBlock, nextEpo
 		EpochTransitionApproval: &approval,
 	}
 
-	a.bulkSend(nextEpochValidatorSet, &approvalMessage)
+	a.sendToValidators(nextEpochValidatorSet, &approvalMessage)
 
 	// Validators also record their own approval locally so the next block they build
 	// includes it. Non-validators have no block builder, so handleApproval is nil.

--- a/transition_listener.go
+++ b/transition_listener.go
@@ -32,7 +32,7 @@ type epochTransitionListener struct {
 	// handleApproval records our own broadcast approval in the local approval store.
 	// It is set for validators (whose MSM builds the next blocks and must include the
 	// approval) and nil for non-validators, which have no block builder to feed.
-	handleApproval func(approval *common.ValidatorSetApproval, timestamp uint64) error
+	handleApproval func(approval *common.ValidatorSetApproval, timestamp uint64)
 
 	logger common.Logger
 }
@@ -45,7 +45,7 @@ func newEpochTransitionListener(
 	getBlock metadata.BlockRetriever,
 	signer common.Signer,
 	auxInfoApp metadata.AuxiliaryInfoGenVerifier,
-	handleApproval func(approval *common.ValidatorSetApproval, timestamp uint64) error,
+	handleApproval func(approval *common.ValidatorSetApproval, timestamp uint64),
 ) *epochTransitionListener {
 	return &epochTransitionListener{
 		broadcaster:     broadcaster,
@@ -57,15 +57,6 @@ func newEpochTransitionListener(
 		handleApproval:  handleApproval,
 		logger:          logger,
 	}
-}
-
-func (a *epochTransitionListener) onIndex(block *ParsedBlock) error {
-	switch block.Type() {
-	case metadata.BlockTypeTransitioning:
-		return a.handleTransitionBlock(block)
-	}
-
-	return nil
 }
 
 func (a *epochTransitionListener) handleTransitionBlock(block *ParsedBlock) error {
@@ -148,5 +139,7 @@ func (a *epochTransitionListener) maybeSendApprovals(block *ParsedBlock, auxInfo
 		return nil
 	}
 	timestamp := uint64(time.Now().UnixMilli())
-	return a.handleApproval(&approval, timestamp)
+
+	a.handleApproval(&approval, timestamp)
+	return nil
 }

--- a/transition_listener_test.go
+++ b/transition_listener_test.go
@@ -14,7 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testNodeID = avalanchego.NodeID{1}
+var (
+	testNodeID    = avalanchego.NodeID{1}
+	stubSignature = []byte("signature")
+)
 
 type recordingSender struct {
 	messages     []*common.Message
@@ -84,7 +87,7 @@ func newListenerTestEnv(t *testing.T, nextEpochValidatorSet metadata.NodeBLSMapp
 		testNodeID,
 		getValidatorSet,
 		getBlock,
-		stubSigner{sig: []byte("signature")},
+		stubSigner{sig: stubSignature},
 		auxApp,
 		handleApproval,
 	)
@@ -217,5 +220,5 @@ func TestNonValidatorContributesApproval(t *testing.T) {
 	approval := msg.EpochTransitionApproval
 	require.Equal(t, testNodeID, approval.NodeID)
 	require.Equal(t, nextPChainRef, approval.PChainHeight)
-	require.Equal(t, []byte("signature"), approval.Signature)
+	require.Equal(t, stubSignature, approval.Signature)
 }

--- a/transition_listener_test.go
+++ b/transition_listener_test.go
@@ -69,9 +69,8 @@ func newListenerTestEnv(t *testing.T, nextEpochValidatorSet metadata.NodeBLSMapp
 		return metadata.StateMachineBlock{}, nil, nil
 	}
 
-	handleApproval := func(approval *common.ValidatorSetApproval, _ uint64) error {
+	handleApproval := func(approval *common.ValidatorSetApproval, _ uint64) {
 		env.approvals = append(env.approvals, *approval)
-		return nil
 	}
 
 	env.listener = newEpochTransitionListener(
@@ -105,33 +104,6 @@ func newTransitionBlock(t *testing.T, nextPChainRef uint64) *ParsedBlock {
 	return block
 }
 
-func TestListenerIgnoresSealingBlock(t *testing.T) {
-	const sealingSeq = uint64(42)
-
-	env := newListenerTestEnv(t, nil, nil)
-
-	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, BLSKey: []byte("bls-key"), Weight: 5}}
-	block := &ParsedBlock{
-		StateMachineBlock: metadata.StateMachineBlock{
-			Metadata: metadata.StateMachineMetadata{
-				SimplexProtocolMetadata: (common.ProtocolMetadata{Seq: sealingSeq}),
-				SimplexEpochInfo: metadata.SimplexEpochInfo{
-					// a non-empty PrevSealingBlockHash distinguishes a sealing block from the zero block
-					PrevSealingBlockHash: [32]byte{1},
-					BlockValidationDescriptor: &metadata.BlockValidationDescriptor{
-						AggregatedMembership: metadata.AggregatedMembership{Members: validatorSet},
-					},
-				},
-			},
-		},
-	}
-	require.Equal(t, metadata.BlockTypeSealing, block.Type())
-
-	// the listener only reacts to transitioning blocks, a sealing block is ignored
-	require.NoError(t, env.listener.onIndex(block))
-	require.Empty(t, env.broadcaster.messages)
-}
-
 func TestTransitionNotInValidatorSet(t *testing.T) {
 	// the next validator set does not contain our node
 	otherValidator := metadata.NodeBLSMappings{{NodeID: avalanchego.NodeID{2}, Weight: 1}}
@@ -140,7 +112,7 @@ func TestTransitionNotInValidatorSet(t *testing.T) {
 
 	block := newTransitionBlock(t, 100)
 
-	require.NoError(t, env.listener.onIndex(block))
+	require.NoError(t, env.listener.handleTransitionBlock(block))
 	require.Empty(t, env.broadcaster.messages)
 	require.Empty(t, env.approvals)
 }
@@ -152,7 +124,7 @@ func TestTransitionNotEnoughAuxiliary(t *testing.T) {
 
 	block := newTransitionBlock(t, 100)
 
-	require.NoError(t, env.listener.onIndex(block))
+	require.NoError(t, env.listener.handleTransitionBlock(block))
 
 	// the generated auxiliary info should be broadcast instead of an approval
 	require.Len(t, env.broadcaster.messages, 1)
@@ -172,7 +144,7 @@ func TestTransitionBroadcastsApproval(t *testing.T) {
 
 	block := newTransitionBlock(t, nextPChainRef)
 
-	require.NoError(t, env.listener.onIndex(block))
+	require.NoError(t, env.listener.handleTransitionBlock(block))
 
 	require.Len(t, env.broadcaster.messages, 1)
 	msg := env.broadcaster.messages[0]
@@ -200,7 +172,7 @@ func TestNonValidatorContributesAuxiliaryInfo(t *testing.T) {
 
 	block := newTransitionBlock(t, 100)
 
-	require.NoError(t, env.listener.onIndex(block))
+	require.NoError(t, env.listener.handleTransitionBlock(block))
 
 	require.Len(t, env.broadcaster.messages, 1)
 	msg := env.broadcaster.messages[0]
@@ -222,7 +194,7 @@ func TestNonValidatorContributesApproval(t *testing.T) {
 
 	block := newTransitionBlock(t, nextPChainRef)
 
-	require.NoError(t, env.listener.onIndex(block))
+	require.NoError(t, env.listener.handleTransitionBlock(block))
 
 	require.Len(t, env.broadcaster.messages, 1)
 	msg := env.broadcaster.messages[0]

--- a/transition_listener_test.go
+++ b/transition_listener_test.go
@@ -1,0 +1,236 @@
+package simplex
+
+import (
+	"testing"
+
+	"github.com/ava-labs/simplex/avalanchego"
+	"github.com/ava-labs/simplex/common"
+	metadata "github.com/ava-labs/simplex/msm"
+	"github.com/ava-labs/simplex/testutil"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testNodeID = avalanchego.NodeID{1}
+
+type recordingBroadcaster struct {
+	messages []*common.Message
+}
+
+func (rb *recordingBroadcaster) Broadcast(msg *common.Message) {
+	rb.messages = append(rb.messages, msg)
+}
+
+type stubSigner struct {
+	sig []byte
+}
+
+func (s stubSigner) Sign([]byte) ([]byte, error) {
+	return s.sig, nil
+}
+
+type stubAuxInfoApp struct {
+	sufficient bool
+	generated  []byte
+}
+
+func (s *stubAuxInfoApp) IsLegalAppend(common.VersionID, metadata.NodeBLSMappings, [][]byte, []byte) error {
+	return nil
+}
+
+func (s *stubAuxInfoApp) IsSufficient(common.VersionID, metadata.NodeBLSMappings, [][]byte) (bool, error) {
+	return s.sufficient, nil
+}
+
+func (s *stubAuxInfoApp) Generate(common.VersionID, metadata.NodeBLSMappings, [][]byte) ([]byte, error) {
+	return s.generated, nil
+}
+
+func (s *stubAuxInfoApp) DefaultVersionID() common.VersionID {
+	return 7
+}
+
+type listenerTestEnv struct {
+	broadcaster *recordingBroadcaster
+	// approvals records the approvals fed via the handleApproval callback.
+	approvals []common.ValidatorSetApproval
+	listener  *epochTransitionListener
+}
+
+// newListenerTestEnv builds a listener wired to the given next-epoch validator set and auxApp.
+func newListenerTestEnv(t *testing.T, nextEpochValidatorSet metadata.NodeBLSMappings, auxApp metadata.AuxiliaryInfoGenVerifier) *listenerTestEnv {
+	env := &listenerTestEnv{broadcaster: &recordingBroadcaster{}}
+
+	getValidatorSet := func(uint64) (metadata.NodeBLSMappings, error) {
+		return nextEpochValidatorSet, nil
+	}
+	getBlock := func(seq uint64, _ common.Digest) (metadata.StateMachineBlock, *common.Finalization, error) {
+		require.Fail(t, "unexpected getBlock call", "seq %d", seq)
+		return metadata.StateMachineBlock{}, nil, nil
+	}
+
+	handleApproval := func(approval *common.ValidatorSetApproval, _ uint64) error {
+		env.approvals = append(env.approvals, *approval)
+		return nil
+	}
+
+	env.listener = newEpochTransitionListener(
+		testutil.MakeLogger(t, 1),
+		env.broadcaster,
+		testNodeID,
+		getValidatorSet,
+		getBlock,
+		stubSigner{sig: []byte("signature")},
+		auxApp,
+		handleApproval,
+	)
+	return env
+}
+
+// newTransitionBlock returns a ParsedBlock of type BlockTypeTransitioning carrying the
+// given next-epoch P-chain reference height. The listener supplies the validator set and
+// auxiliary info app, so the block itself needs no MSM.
+func newTransitionBlock(t *testing.T, nextPChainRef uint64) *ParsedBlock {
+	block := &ParsedBlock{
+		StateMachineBlock: metadata.StateMachineBlock{
+			Metadata: metadata.StateMachineMetadata{
+				SimplexProtocolMetadata: common.ProtocolMetadata{Seq: 10},
+				SimplexEpochInfo: metadata.SimplexEpochInfo{
+					NextPChainReferenceHeight: nextPChainRef,
+				},
+			},
+		},
+	}
+	require.Equal(t, metadata.BlockTypeTransitioning, block.Type())
+	return block
+}
+
+func TestListenerIgnoresSealingBlock(t *testing.T) {
+	const sealingSeq = uint64(42)
+
+	env := newListenerTestEnv(t, nil, nil)
+
+	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, BLSKey: []byte("bls-key"), Weight: 5}}
+	block := &ParsedBlock{
+		StateMachineBlock: metadata.StateMachineBlock{
+			Metadata: metadata.StateMachineMetadata{
+				SimplexProtocolMetadata: (common.ProtocolMetadata{Seq: sealingSeq}),
+				SimplexEpochInfo: metadata.SimplexEpochInfo{
+					// a non-empty PrevSealingBlockHash distinguishes a sealing block from the zero block
+					PrevSealingBlockHash: [32]byte{1},
+					BlockValidationDescriptor: &metadata.BlockValidationDescriptor{
+						AggregatedMembership: metadata.AggregatedMembership{Members: validatorSet},
+					},
+				},
+			},
+		},
+	}
+	require.Equal(t, metadata.BlockTypeSealing, block.Type())
+
+	// the listener only reacts to transitioning blocks, a sealing block is ignored
+	require.NoError(t, env.listener.onIndex(block))
+	require.Empty(t, env.broadcaster.messages)
+}
+
+func TestTransitionNotInValidatorSet(t *testing.T) {
+	// the next validator set does not contain our node
+	otherValidator := metadata.NodeBLSMappings{{NodeID: avalanchego.NodeID{2}, Weight: 1}}
+	auxApp := &stubAuxInfoApp{sufficient: false, generated: []byte("more aux info")}
+	env := newListenerTestEnv(t, otherValidator, auxApp)
+
+	block := newTransitionBlock(t, 100)
+
+	require.NoError(t, env.listener.onIndex(block))
+	require.Empty(t, env.broadcaster.messages)
+	require.Empty(t, env.approvals)
+}
+
+func TestTransitionNotEnoughAuxiliary(t *testing.T) {
+	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}, {NodeID: avalanchego.NodeID{2}, Weight: 1}}
+	auxApp := &stubAuxInfoApp{sufficient: false, generated: []byte("more aux info")}
+	env := newListenerTestEnv(t, validatorSet, auxApp)
+
+	block := newTransitionBlock(t, 100)
+
+	require.NoError(t, env.listener.onIndex(block))
+
+	// the generated auxiliary info should be broadcast instead of an approval
+	require.Len(t, env.broadcaster.messages, 1)
+	msg := env.broadcaster.messages[0]
+	require.Nil(t, msg.EpochTransitionApproval)
+	require.NotNil(t, msg.AuxiliaryInfo)
+	require.Equal(t, auxApp.DefaultVersionID(), msg.AuxiliaryInfo.Version)
+	require.Equal(t, auxApp.generated, msg.AuxiliaryInfo.Data)
+	require.Empty(t, env.approvals)
+}
+
+func TestTransitionBroadcastsApproval(t *testing.T) {
+	const nextPChainRef = uint64(100)
+
+	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}}
+	env := newListenerTestEnv(t, validatorSet, &stubAuxInfoApp{sufficient: true})
+
+	block := newTransitionBlock(t, nextPChainRef)
+
+	require.NoError(t, env.listener.onIndex(block))
+
+	require.Len(t, env.broadcaster.messages, 1)
+	msg := env.broadcaster.messages[0]
+	require.Nil(t, msg.AuxiliaryInfo)
+	require.NotNil(t, msg.EpochTransitionApproval)
+
+	approval := msg.EpochTransitionApproval
+	require.Equal(t, testNodeID, approval.NodeID)
+	require.Equal(t, nextPChainRef, approval.PChainHeight)
+	require.Equal(t, [32]byte{}, approval.AuxInfoDigest) // no auxiliary info was collected
+	require.Equal(t, []byte("signature"), approval.Signature)
+
+	// a validator also records its own approval locally so its next block includes it
+	require.Equal(t, []common.ValidatorSetApproval{*approval}, env.approvals)
+}
+
+// TestNonValidatorContributesAuxiliaryInfo asserts that a node still on the outside of the
+// current validator set but present in the NEXT one contributes auxiliary info during the
+// transition, exactly like a validator does. Non-validators pass a nil handleApproval, so
+// nothing is recorded locally, but the auxiliary info is still broadcast.
+func TestNonValidatorContributesAuxiliaryInfo(t *testing.T) {
+	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}, {NodeID: avalanchego.NodeID{2}, Weight: 1}}
+	auxApp := &stubAuxInfoApp{sufficient: false, generated: []byte("non-validator aux")}
+	env := newListenerTestEnv(t, validatorSet, auxApp)
+
+	block := newTransitionBlock(t, 100)
+
+	require.NoError(t, env.listener.onIndex(block))
+
+	require.Len(t, env.broadcaster.messages, 1)
+	msg := env.broadcaster.messages[0]
+	require.Nil(t, msg.EpochTransitionApproval)
+	require.NotNil(t, msg.AuxiliaryInfo)
+	require.Equal(t, auxApp.DefaultVersionID(), msg.AuxiliaryInfo.Version)
+	require.Equal(t, auxApp.generated, msg.AuxiliaryInfo.Data)
+}
+
+// TestNonValidatorContributesApproval asserts that once the auxiliary info history is
+// sufficient, a non-validator that belongs to the next validator set broadcasts its
+// epoch transition approval. It does not record the approval locally (nil handleApproval),
+// since it has no block builder to include it.
+func TestNonValidatorContributesApproval(t *testing.T) {
+	const nextPChainRef = uint64(100)
+
+	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}}
+	env := newListenerTestEnv(t, validatorSet, &stubAuxInfoApp{sufficient: true})
+
+	block := newTransitionBlock(t, nextPChainRef)
+
+	require.NoError(t, env.listener.onIndex(block))
+
+	require.Len(t, env.broadcaster.messages, 1)
+	msg := env.broadcaster.messages[0]
+	require.Nil(t, msg.AuxiliaryInfo)
+	require.NotNil(t, msg.EpochTransitionApproval)
+
+	approval := msg.EpochTransitionApproval
+	require.Equal(t, testNodeID, approval.NodeID)
+	require.Equal(t, nextPChainRef, approval.PChainHeight)
+	require.Equal(t, []byte("signature"), approval.Signature)
+}

--- a/transition_listener_test.go
+++ b/transition_listener_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package simplex
 
 import (
@@ -13,12 +16,14 @@ import (
 
 var testNodeID = avalanchego.NodeID{1}
 
-type recordingBroadcaster struct {
-	messages []*common.Message
+type recordingSender struct {
+	messages     []*common.Message
+	destinations []common.NodeID
 }
 
-func (rb *recordingBroadcaster) Broadcast(msg *common.Message) {
-	rb.messages = append(rb.messages, msg)
+func (rs *recordingSender) Send(msg *common.Message, destination common.NodeID) {
+	rs.messages = append(rs.messages, msg)
+	rs.destinations = append(rs.destinations, destination)
 }
 
 type stubSigner struct {
@@ -51,7 +56,7 @@ func (s *stubAuxInfoApp) DefaultVersionID() common.VersionID {
 }
 
 type listenerTestEnv struct {
-	broadcaster *recordingBroadcaster
+	sender *recordingSender
 	// approvals records the approvals fed via the handleApproval callback.
 	approvals []common.ValidatorSetApproval
 	listener  *epochTransitionListener
@@ -59,7 +64,7 @@ type listenerTestEnv struct {
 
 // newListenerTestEnv builds a listener wired to the given next-epoch validator set and auxApp.
 func newListenerTestEnv(t *testing.T, nextEpochValidatorSet metadata.NodeBLSMappings, auxApp metadata.AuxiliaryInfoGenVerifier) *listenerTestEnv {
-	env := &listenerTestEnv{broadcaster: &recordingBroadcaster{}}
+	env := &listenerTestEnv{sender: &recordingSender{}}
 
 	getValidatorSet := func(uint64) (metadata.NodeBLSMappings, error) {
 		return nextEpochValidatorSet, nil
@@ -75,7 +80,7 @@ func newListenerTestEnv(t *testing.T, nextEpochValidatorSet metadata.NodeBLSMapp
 
 	env.listener = newEpochTransitionListener(
 		testutil.MakeLogger(t, 1),
-		env.broadcaster,
+		env.sender,
 		testNodeID,
 		getValidatorSet,
 		getBlock,
@@ -113,12 +118,14 @@ func TestTransitionNotInValidatorSet(t *testing.T) {
 	block := newTransitionBlock(t, 100)
 
 	require.NoError(t, env.listener.handleTransitionBlock(block))
-	require.Empty(t, env.broadcaster.messages)
+	require.Empty(t, env.sender.messages)
 	require.Empty(t, env.approvals)
 }
 
 func TestTransitionNotEnoughAuxiliary(t *testing.T) {
-	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}, {NodeID: avalanchego.NodeID{2}, Weight: 1}}
+	peer1 := avalanchego.NodeID{2}
+	peer2 := avalanchego.NodeID{3}
+	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}, {NodeID: peer1, Weight: 1}, {NodeID: peer2, Weight: 1}}
 	auxApp := &stubAuxInfoApp{sufficient: false, generated: []byte("more aux info")}
 	env := newListenerTestEnv(t, validatorSet, auxApp)
 
@@ -126,28 +133,33 @@ func TestTransitionNotEnoughAuxiliary(t *testing.T) {
 
 	require.NoError(t, env.listener.handleTransitionBlock(block))
 
-	// the generated auxiliary info should be broadcast instead of an approval
-	require.Len(t, env.broadcaster.messages, 1)
-	msg := env.broadcaster.messages[0]
-	require.Nil(t, msg.EpochTransitionApproval)
-	require.NotNil(t, msg.AuxiliaryInfo)
-	require.Equal(t, auxApp.DefaultVersionID(), msg.AuxiliaryInfo.Version)
-	require.Equal(t, auxApp.generated, msg.AuxiliaryInfo.Data)
+	// the generated auxiliary info is sent to every other validator instead of an approval
+	require.Len(t, env.sender.messages, 2)
+	require.Equal(t, []common.NodeID{common.NodeID(peer1[:]), common.NodeID(peer2[:])}, env.sender.destinations)
+	for _, msg := range env.sender.messages {
+		require.Nil(t, msg.EpochTransitionApproval)
+		require.NotNil(t, msg.AuxiliaryInfo)
+		require.Equal(t, auxApp.DefaultVersionID(), msg.AuxiliaryInfo.Version)
+		require.Equal(t, auxApp.generated, msg.AuxiliaryInfo.Data)
+	}
 	require.Empty(t, env.approvals)
 }
 
-func TestTransitionBroadcastsApproval(t *testing.T) {
+func TestTransitionSendsApproval(t *testing.T) {
 	const nextPChainRef = uint64(100)
 
-	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}}
+	peer := avalanchego.NodeID{2}
+	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}, {NodeID: peer, Weight: 1}}
 	env := newListenerTestEnv(t, validatorSet, &stubAuxInfoApp{sufficient: true})
 
 	block := newTransitionBlock(t, nextPChainRef)
 
 	require.NoError(t, env.listener.handleTransitionBlock(block))
 
-	require.Len(t, env.broadcaster.messages, 1)
-	msg := env.broadcaster.messages[0]
+	// the approval is sent to the other validator, not to ourselves
+	require.Len(t, env.sender.messages, 1)
+	require.Equal(t, []common.NodeID{common.NodeID(peer[:])}, env.sender.destinations)
+	msg := env.sender.messages[0]
 	require.Nil(t, msg.AuxiliaryInfo)
 	require.NotNil(t, msg.EpochTransitionApproval)
 
@@ -164,7 +176,7 @@ func TestTransitionBroadcastsApproval(t *testing.T) {
 // TestNonValidatorContributesAuxiliaryInfo asserts that a node still on the outside of the
 // current validator set but present in the NEXT one contributes auxiliary info during the
 // transition, exactly like a validator does. Non-validators pass a nil handleApproval, so
-// nothing is recorded locally, but the auxiliary info is still broadcast.
+// nothing is recorded locally, but the auxiliary info is still sent.
 func TestNonValidatorContributesAuxiliaryInfo(t *testing.T) {
 	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}, {NodeID: avalanchego.NodeID{2}, Weight: 1}}
 	auxApp := &stubAuxInfoApp{sufficient: false, generated: []byte("non-validator aux")}
@@ -174,8 +186,8 @@ func TestNonValidatorContributesAuxiliaryInfo(t *testing.T) {
 
 	require.NoError(t, env.listener.handleTransitionBlock(block))
 
-	require.Len(t, env.broadcaster.messages, 1)
-	msg := env.broadcaster.messages[0]
+	require.Len(t, env.sender.messages, 1)
+	msg := env.sender.messages[0]
 	require.Nil(t, msg.EpochTransitionApproval)
 	require.NotNil(t, msg.AuxiliaryInfo)
 	require.Equal(t, auxApp.DefaultVersionID(), msg.AuxiliaryInfo.Version)
@@ -183,21 +195,21 @@ func TestNonValidatorContributesAuxiliaryInfo(t *testing.T) {
 }
 
 // TestNonValidatorContributesApproval asserts that once the auxiliary info history is
-// sufficient, a non-validator that belongs to the next validator set broadcasts its
+// sufficient, a non-validator that belongs to the next validator set sends its
 // epoch transition approval. It does not record the approval locally (nil handleApproval),
 // since it has no block builder to include it.
 func TestNonValidatorContributesApproval(t *testing.T) {
 	const nextPChainRef = uint64(100)
 
-	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}}
+	validatorSet := metadata.NodeBLSMappings{{NodeID: testNodeID, Weight: 1}, {NodeID: avalanchego.NodeID{2}, Weight: 1}}
 	env := newListenerTestEnv(t, validatorSet, &stubAuxInfoApp{sufficient: true})
 
 	block := newTransitionBlock(t, nextPChainRef)
 
 	require.NoError(t, env.listener.handleTransitionBlock(block))
 
-	require.Len(t, env.broadcaster.messages, 1)
-	msg := env.broadcaster.messages[0]
+	require.Len(t, env.sender.messages, 1)
+	msg := env.sender.messages[0]
 	require.Nil(t, msg.AuxiliaryInfo)
 	require.NotNil(t, msg.EpochTransitionApproval)
 

--- a/transition_listener_test.go
+++ b/transition_listener_test.go
@@ -122,6 +122,8 @@ func TestTransitionNotInValidatorSet(t *testing.T) {
 	require.Empty(t, env.approvals)
 }
 
+// TestTransitionNotEnoughAuxiliary tests that if we do not have a sufficient amount of auxiliary information
+// we will broadcast our own before sending any approvals.
 func TestTransitionNotEnoughAuxiliary(t *testing.T) {
 	peer1 := avalanchego.NodeID{2}
 	peer2 := avalanchego.NodeID{3}

--- a/transition_listener_test.go
+++ b/transition_listener_test.go
@@ -198,8 +198,7 @@ func TestNonValidatorContributesAuxiliaryInfo(t *testing.T) {
 
 // TestNonValidatorContributesApproval asserts that once the auxiliary info history is
 // sufficient, a non-validator that belongs to the next validator set sends its
-// epoch transition approval. It does not record the approval locally (nil handleApproval),
-// since it has no block builder to include it.
+// epoch transition approval.
 func TestNonValidatorContributesApproval(t *testing.T) {
 	const nextPChainRef = uint64(100)
 


### PR DESCRIPTION
Adds `epochTransitionListener` and hooks it into the instance:

- `NewInstance` constructs the listener and wires its `onIndex` into both the validator and non-validator storage paths (replacing the no-op hook).
- When a transition block is indexed, the listener either generates and broadcasts auxiliary info, or once the history is sufficient, signs and broadcasts an epoch transition approval. Validators also record their own approval locally; non-validators pass a nil handler.
- `HandleMessage` routes incoming `AuxiliaryInfo` and `EpochTransitionApproval` messages into the MSM.
