### PR TITLE
Hold the epoch lock while restoring from the WAL

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -295,14 +295,20 @@ func (e *Epoch) Start() error {
 		return ErrAlreadyStarted
 	}
 
+	// Hold the lock while restoring, since restoring may schedule tasks
+	// that lock the epoch and mutate its state from other goroutines.
+	e.lock.Lock()
 	err := e.restoreFromWal()
 	if err != nil {
+		e.lock.Unlock()
 		return err
 	}
 
 	// Only init receiving messages once you have initialized the data structures required for it.
 	e.Logger.Debug("Epoch is ready to receive messages", zap.Uint64("epoch", e.Epoch))
 	e.canReceiveMessages.Store(true)
+	e.lock.Unlock()
+
 	e.broadcastReplicationSync()
 
 	return nil

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -295,8 +295,7 @@ func (e *Epoch) Start() error {
 		return ErrAlreadyStarted
 	}
 
-	// Hold the lock while restoring, since restoring may schedule tasks
-	// that lock the epoch and mutate its state from other goroutines.
+	// Restoring may schedule tasks that mutate the epoch from other goroutines.
 	e.lock.Lock()
 	err := e.restoreFromWal()
 	if err != nil {


### PR DESCRIPTION
Fixes a data race caught by CI in `TestReplicatedNotarizationRestart`: https://github.com/ava-labs/Simplex/actions/runs/31749442819/job/94611614678

`Epoch.Start()` runs the WAL restore without holding the epoch lock. Restoring can schedule the block building task and arm monitor and timeout callbacks, all of which acquire the lock and mutate epoch state from other goroutines while the restore is still reading it. In the failing test, the restarted node recovers a notarized round from the WAL, becomes leader of the next round mid-restore, and the scheduled block building task writes the rounds map in `storeProposal` while the restore path reads it in `handleFinalizeVoteMessage`.

Every internal handler assumes the lock is held: `HandleMessage` takes it before dispatching, but `restoreFromWal` called the same handlers without it. `Start()` now holds the lock until the restore completes and the epoch is ready to receive messages, so scheduled tasks block until then. `broadcastReplicationSync` acquires the lock itself and stays outside the locked region.

