### PR TITLE
Log the actual deadline when scheduling a future task

### DIFF
--- a/simplex/monitor.go
+++ b/simplex/monitor.go
@@ -149,12 +149,13 @@ func (m *Monitor) CancelFutureTask() {
 
 func (m *Monitor) FutureTask(timeout time.Duration, f func()) {
 	t := m.time.Load()
-	time := t.(time.Time)
+	now := t.(time.Time)
+	deadline := now.Add(timeout)
 
 	m.futureTask.Store(&futureTask{
 		f:        f,
-		deadline: time.Add(timeout),
+		deadline: deadline,
 	})
 
-	m.logger.Verbo("Scheduling task", zap.Duration("timeout", timeout), zap.Time("deadline", time))
+	m.logger.Verbo("Scheduling task", zap.Duration("timeout", timeout), zap.Time("deadline", deadline))
 }

--- a/simplex/monitor_test.go
+++ b/simplex/monitor_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestMonitorDoubleClose(t *testing.T) {
@@ -131,25 +130,6 @@ func TestMonitorAsyncWaitForWithNestedWaitUntil(t *testing.T) {
 		mon.FutureTask(10*time.Millisecond, wg.Done)
 	})
 	wg.Wait()
-}
-
-// TestMonitorFutureTaskLogsDeadline asserts that scheduling a future task logs the
-// task's deadline. FutureTask (monitor.go:159) logged the monitor's current time
-// under the "deadline" field instead of time.Add(timeout).
-func TestMonitorFutureTaskLogsDeadline(t *testing.T) {
-	start := time.Now()
-	core, logs := observer.New(zapcore.DebugLevel)
-	mon := NewMonitor(start, &testLogger{Logger: zap.New(core)})
-	defer mon.Close()
-
-	timeout := time.Hour
-	mon.FutureTask(timeout, func() {})
-
-	entries := logs.FilterMessage("Scheduling task").All()
-	require.Len(t, entries, 1)
-	deadline, ok := entries[0].ContextMap()["deadline"].(time.Time)
-	require.True(t, ok)
-	require.True(t, start.Add(timeout).Equal(deadline))
 }
 
 type testLogger struct {

--- a/simplex/monitor_test.go
+++ b/simplex/monitor_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestMonitorDoubleClose(t *testing.T) {
@@ -130,6 +131,25 @@ func TestMonitorAsyncWaitForWithNestedWaitUntil(t *testing.T) {
 		mon.FutureTask(10*time.Millisecond, wg.Done)
 	})
 	wg.Wait()
+}
+
+// TestMonitorFutureTaskLogsDeadline asserts that scheduling a future task logs the
+// task's deadline. FutureTask (monitor.go:159) logged the monitor's current time
+// under the "deadline" field instead of time.Add(timeout).
+func TestMonitorFutureTaskLogsDeadline(t *testing.T) {
+	start := time.Now()
+	core, logs := observer.New(zapcore.DebugLevel)
+	mon := NewMonitor(start, &testLogger{Logger: zap.New(core)})
+	defer mon.Close()
+
+	timeout := time.Hour
+	mon.FutureTask(timeout, func() {})
+
+	entries := logs.FilterMessage("Scheduling task").All()
+	require.Len(t, entries, 1)
+	deadline, ok := entries[0].ContextMap()["deadline"].(time.Time)
+	require.True(t, ok)
+	require.True(t, start.Add(timeout).Equal(deadline))
 }
 
 type testLogger struct {


### PR DESCRIPTION
What was wrong
  Monitor.FutureTask (simplex/monitor.go:159) logged the field "deadline" with the monitor's current base time, while the scheduled task's deadline is time.Add(timeout).

Consequence
  The "Scheduling task" log line reports a "deadline" that is earlier than the real one by the full timeout, and disagrees with the "deadline" logged by tick() for the same task. This misled triage of a CI hang, where the logged "deadline" was read as the actual deadline.

Fix
  Compute the deadline once and log it, instead of the base time.

Found while triaging a CI hang, where the misleading log field derailed the investigation.