### PR TITLE
Extract ComputeICMEpoch interface from VM, and some BlockDeserializer nits

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -233,13 +233,13 @@ type blockDeserializer struct {
 	msm *metadata.StateMachine
 }
 
-func (bp *blockDeserializer) DeserializeBlock(ctx context.Context, bytes []byte) (common.Block, error) {
+func (bd *blockDeserializer) DeserializeBlock(ctx context.Context, bytes []byte) (common.Block, error) {
 	var rawBlock metadata.RawBlock
 	if err := rawBlock.UnmarshalCanoto(bytes); err != nil {
 		return nil, err
 	}
 
-	block, err := bp.vm.ParseBlock(ctx, rawBlock.InnerBlockBytes)
+	block, err := bd.vm.ParseBlock(ctx, rawBlock.InnerBlockBytes)
 	if err != nil {
 		return nil, err
 	}
@@ -248,6 +248,6 @@ func (bp *blockDeserializer) DeserializeBlock(ctx context.Context, bytes []byte)
 			InnerBlock: block,
 			Metadata:   rawBlock.Metadata,
 		},
-		msm: bp.msm,
+		msm: bd.msm,
 	}, nil
 }

--- a/config.go
+++ b/config.go
@@ -56,9 +56,6 @@ type VM interface {
 
 	// ParseBlock parses the given block bytes into a VMBlock.
 	ParseBlock(context.Context, []byte) (avalanchego.VMBlock, error)
-
-	// ComputeICMEpoch computes the ICM epoch transition given the input parameters.
-	ComputeICMEpoch(input metadata.ICMEpochInput) metadata.ICMEpochInfo
 }
 
 type Storage interface {

--- a/instance.go
+++ b/instance.go
@@ -39,12 +39,13 @@ type Config struct {
 	// WalCreator is the interface to create new write-ahead logs for the simplex instance.
 	WalCreator wal.Creator
 	// Storage is the interface to the block storage layer for the simplex instance.
-	Storage Storage
-	Logger  common.Logger
-	Sender  Sender
-	WALs    []wal.DeletableWAL
-	VM      VM
-	ID      common.NodeID
+	Storage        Storage
+	Logger         common.Logger
+	Sender         Sender
+	WALs           []wal.DeletableWAL
+	VM             VM
+	ICMETransition metadata.ICMEpochTransition
+	ID             common.NodeID
 }
 
 type nodeRole byte
@@ -461,7 +462,7 @@ func (i *Instance) createEpochConfig() (simplex.EpochConfig, error) {
 		GetPChainHeightForProposing:     i.Config.PlatformChain.GetMinimumHeight,
 		GetPChainHeightForVerifying:     i.Config.PlatformChain.GetCurrentHeight,
 		AuxiliaryInfoApp:                &NoopAuxiliaryInfoApp{},
-		ComputeICMEpoch:                 i.Config.VM.ComputeICMEpoch,
+		ComputeICMEpoch:                 i.Config.ICMETransition,
 		GetBlock:                        i.cs.RetrieveBlock,
 	})
 	if err != nil {

--- a/instance_test.go
+++ b/instance_test.go
@@ -873,13 +873,14 @@ func newInstance(t *testing.T, nodeID common.NodeID, storage *MockStorage, net *
 
 // newInstanceWithVM is like newInstance but uses a caller-supplied VM, so a test
 // can share one controllable VM across restarts of the same node.
-func newInstanceWithVM(t *testing.T, nodeID common.NodeID, storage *MockStorage, net *inMemNetwork, pChain *testPlatformChain, cops *testCryptoOps, genesisBlock *testInnerBlock, vm VM) *Instance {
+func newInstanceWithVM(t *testing.T, nodeID common.NodeID, storage *MockStorage, net *inMemNetwork, pChain *testPlatformChain, cops *testCryptoOps, genesisBlock *testInnerBlock, vm *testVM) *Instance {
 	comm := &networkSender{net: net, self: nodeID}
 	config := Config{
 		Logger:                   testutil.MakeLogger(t, int(nodeID[0])),
 		ID:                       nodeID,
 		VM:                       vm,
 		Storage:                  storage,
+		ICMETransition:           vm.ComputeICMEpoch,
 		Sender:                   comm,
 		Broadcaster:              comm,
 		PlatformChain:            pChain,


### PR DESCRIPTION
Replaces the VM ComputeICMEpoch method with a `Config.ICMETransition` function field. 