### PR TITLE
Security Hardening Changes

### DIFF
--- a/adapters_test.go
+++ b/adapters_test.go
@@ -189,9 +189,9 @@ func TestCachedStoragePopulatedByWal(t *testing.T) {
 		LastNonSimplexInnerBlock: genesisBlock,
 		WalCreator:               storage.CreateWAL,
 		ParameterConfig: ParameterConfig{
-			MaxNetworkDelay:  500 * time.Millisecond,
-			MaxRoundWindow:   100,
-			WALMaxEntryCount: 1024,
+			MaxNetworkDelay: 500 * time.Millisecond,
+			MaxRoundWindow:  100,
+			WALMaxSizeBytes: 1024,
 		},
 		WALs: []wal.DeletableWAL{testWAL},
 	}

--- a/avalanchego/misc.go
+++ b/avalanchego/misc.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"math/bits"
 	"time"
 )
 
@@ -90,19 +91,20 @@ func (bm *Bitmask) Difference(bm2 *Bitmask) {
 }
 
 func (bm *Bitmask) Len() int {
-	bmAsBigInt := (*big.Int)(bm)
-	bits := new(big.Int).Set(bmAsBigInt)
+	// Previous version also returned 0 for negative numbers, so we keep that behavior here.
+	if (*big.Int)(bm).Sign() < 0 {
+		return 0
+	}
 
-	result := 0
-	var zero big.Int
-	for bits.Cmp(&zero) > 0 {
-		lsb := bits.Bit(0)
-		if lsb == 1 {
-			result++
-		}
-		bits.Rsh(bits, 1)
+	var result int
+	for _, b := range (*big.Int)(bm).Bytes() {
+		result += bits.OnesCount8(b)
 	}
 	return result
+}
+
+func (bm *Bitmask) BitLen() int {
+	return (*big.Int)(bm).BitLen()
 }
 
 func BitmaskFromBytes(bytes []byte) Bitmask {

--- a/avalanchego/misc_test.go
+++ b/avalanchego/misc_test.go
@@ -5,7 +5,9 @@ package avalanchego
 
 import (
 	"math"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -100,6 +102,67 @@ func TestBitmask(t *testing.T) {
 		for i := 0; i < 8; i++ {
 			require.Equal(t, bm.Contains(i), bm2.Contains(i))
 		}
+	})
+
+	t.Run("BitLen", func(t *testing.T) {
+		empty := BitmaskFromBytes(nil)
+		require.Equal(t, 0, empty.BitLen())
+
+		// 0b00000111 → highest set bit is 2, so 3 bits are needed to represent it.
+		low := BitmaskFromBytes([]byte{7})
+		require.Equal(t, 3, low.BitLen())
+
+		high := BitmaskFromBytes(nil)
+		high.Add(63)
+		require.Equal(t, 64, high.BitLen())
+	})
+
+	// A negative value has no meaning as a bitmask. Nothing in this package can produce
+	// one, but Len reports 0 rather than counting the bits of the magnitude, which keeps
+	// it consistent with how it has always behaved.
+	t.Run("Len reports zero for a negative value", func(t *testing.T) {
+		for _, v := range []int64{-1, -7, -255, -1 << 40} {
+			var bm Bitmask
+			(*big.Int)(&bm).SetInt64(v)
+			require.Equal(t, 0, bm.Len())
+		}
+	})
+
+	// Len counts bits over the byte representation, which strips leading zero bytes and
+	// is unaffected by how wide the input buffer was.
+	t.Run("Len is independent of leading zero bytes", func(t *testing.T) {
+		bare := BitmaskFromBytes([]byte{7})
+		padded := BitmaskFromBytes([]byte{0, 0, 0, 7})
+		require.Equal(t, 3, bare.Len())
+		require.Equal(t, 3, padded.Len())
+
+		zeros := BitmaskFromBytes([]byte{0, 0, 0, 0})
+		require.Equal(t, 0, zeros.Len())
+	})
+
+	t.Run("Len counts every bit across many bytes", func(t *testing.T) {
+		for n := 1; n <= 32; n++ {
+			buff := make([]byte, n)
+			for i := range buff {
+				buff[i] = 0xFF
+			}
+			bm := BitmaskFromBytes(buff)
+			require.Equal(t, n*8, bm.Len())
+			require.Equal(t, n*8, bm.BitLen())
+		}
+	})
+
+	// A wide bitmask costs a proposer almost nothing to produce, so Len has to stay
+	// linear in its size. Counting bits by shifting a big.Int down one position at a
+	// time is quadratic in the position of the highest set bit, and took minutes here.
+	t.Run("Len stays linear over a wide bitmask", func(t *testing.T) {
+		buff := make([]byte, 1<<20) // 1 MiB, ~8.4 million bits
+		buff[0] = 0xFF              // set the highest bits, so the full width is walked
+		bm := BitmaskFromBytes(buff)
+
+		start := time.Now()
+		require.Equal(t, 8, bm.Len())
+		require.Less(t, time.Since(start), 5*time.Second)
 	})
 
 	t.Run("Difference", func(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -13,8 +13,9 @@ import (
 )
 
 type ParameterConfig struct {
-	// WalMaxEntryCount is the maximum number of entries in the write-ahead log before it is closed.
-	WALMaxEntryCount int
+	// WALMaxSizeBytes is the maximum size, in bytes, that a write-ahead log may reach
+	// before it is closed and a new one is started. Zero selects the default.
+	WALMaxSizeBytes int
 	// MaxNetworkDelay is the assumed upper bound on the network delay for messages to be delivered.
 	MaxNetworkDelay time.Duration
 	// MaxRoundWindow is the maximum number of rounds that can be stored in memory.

--- a/instance.go
+++ b/instance.go
@@ -430,7 +430,7 @@ func (i *Instance) createEpochConfig() (*epochConfig, error) {
 		return nil, err
 	}
 
-	wal, err := wal.NewGarbageCollectedWAL(i.Config.WALs, i.Config.WalCreator, &common.WALRetentionReader{}, i.Config.ParameterConfig.WALMaxEntryCount)
+	wal, err := wal.NewGarbageCollectedWAL(i.Config.WALs, i.Config.WalCreator, &common.WALRetentionReader{}, i.Config.ParameterConfig.WALMaxSizeBytes)
 	if err != nil {
 		return nil, fmt.Errorf("error creating garbage collected wal: %w", err)
 	}

--- a/instance_test.go
+++ b/instance_test.go
@@ -954,9 +954,9 @@ func newInstanceWithVM(t *testing.T, nodeID common.NodeID, storage *MockStorage,
 		LastNonSimplexInnerBlock: genesisBlock,
 		WalCreator:               storage.CreateWAL,
 		ParameterConfig: ParameterConfig{
-			MaxNetworkDelay:  500 * time.Millisecond,
-			MaxRoundWindow:   100,
-			WALMaxEntryCount: 1024,
+			MaxNetworkDelay: 500 * time.Millisecond,
+			MaxRoundWindow:  100,
+			WALMaxSizeBytes: 1024,
 		},
 	}
 	return NewInstance(config)

--- a/msm/approvals.go
+++ b/msm/approvals.go
@@ -25,7 +25,7 @@ type approvalAndTimestamp struct {
 }
 
 type ApprovalStore struct {
-	signatureVerifier SignatureVerifier
+	signatureVerifier common.SignatureVerifier
 	validators        NodeBLSMappings
 	logger            common.Logger
 	nodeIDToPK        map[avalanchego.NodeID][]byte
@@ -37,7 +37,7 @@ type ApprovalStore struct {
 	storedCount      int
 }
 
-func NewApprovalStore(signatureVerifier SignatureVerifier, validators NodeBLSMappings, logger common.Logger) *ApprovalStore {
+func NewApprovalStore(signatureVerifier common.SignatureVerifier, validators NodeBLSMappings, logger common.Logger) *ApprovalStore {
 	pkByNodeID := make(map[avalanchego.NodeID][]byte)
 	for _, vdr := range validators {
 		pkByNodeID[vdr.NodeID] = vdr.BLSKey
@@ -153,7 +153,7 @@ func (as *ApprovalStore) checkApprovalSignature(approval *common.ValidatorSetApp
 	}
 
 	// We check if the signature is valid before we store the approval.
-	return as.signatureVerifier.VerifySignature(approval.Signature, toBeSigned, pk)
+	return as.signatureVerifier.VerifySignature(toBeSigned, approval.Signature, pk)
 }
 
 func (as *ApprovalStore) approvalExistsAndUpToDate(approval *common.ValidatorSetApproval, timestamp uint64) bool {

--- a/msm/approvals_test.go
+++ b/msm/approvals_test.go
@@ -32,6 +32,36 @@ func makeValidators(n int) NodeBLSMappings {
 	return vdrs
 }
 
+// TestAggregatePubKeysForBitmaskRejectsWideBitmask ensures an approvals bitmask carrying
+// bits beyond the validator set is rejected. Such bits index no validator, so they convey
+// no approval and are ignored when keys are aggregated and when the subset is selected --
+// but they are free for a proposer to add and make every other node carry the width.
+func TestAggregatePubKeysForBitmaskRejectsWideBitmask(t *testing.T) {
+	sm := &StateMachine{Config: &Config{KeyAggregator: &keyAggregator{}}}
+	validators := makeValidators(4)
+
+	// Every validator approving is the widest legitimate bitmask.
+	all := avalanchego.BitmaskFromBytes(nil)
+	for i := range validators {
+		all.Add(i)
+	}
+	aggPK, err := sm.aggregatePubKeysForBitmask(all.Bytes(), validators)
+	require.NoError(t, err)
+	require.Equal(t, []byte{1, 2, 3, 4}, aggPK)
+
+	// One bit past the end of the validator set.
+	tooWide := all.Clone()
+	tooWide.Add(len(validators))
+	_, err = sm.aggregatePubKeysForBitmask(tooWide.Bytes(), validators)
+	require.ErrorIs(t, err, errApprovalsBitmaskTooWide)
+
+	// A single very high bit, which is the shape that made bitmask operations expensive.
+	huge := avalanchego.BitmaskFromBytes(nil)
+	huge.Add(1 << 20)
+	_, err = sm.aggregatePubKeysForBitmask(huge.Bytes(), validators)
+	require.ErrorIs(t, err, errApprovalsBitmaskTooWide)
+}
+
 func TestApprovalStoreHandleApproval(t *testing.T) {
 	for _, tc := range []struct {
 		name       string

--- a/msm/msm.go
+++ b/msm/msm.go
@@ -115,12 +115,6 @@ type KeyAggregator interface {
 	AggregateKeys(keys ...[]byte) ([]byte, error)
 }
 
-// SignatureVerifier verifies a cryptographic signature against a message and public key.
-// Used to verify Approvals from validators for epoch transitions.
-type SignatureVerifier interface {
-	VerifySignature(signature []byte, message []byte, publicKey []byte) error
-}
-
 // ValidatorSetRetriever retrieves the validator set at a given P-chain height.
 type ValidatorSetRetriever func(pChainHeight uint64) (NodeBLSMappings, error)
 
@@ -198,7 +192,8 @@ type Config struct {
 	// KeyAggregator aggregates public keys from validators.
 	KeyAggregator KeyAggregator
 	// SignatureVerifier verifies signatures from validators.
-	SignatureVerifier SignatureVerifier
+	// Used to verify Approvals from validators for epoch transitions.
+	SignatureVerifier common.SignatureVerifier
 	// PChainProgressListener listens for changes in the P-chain height to trigger block building or epoch transitions.
 	PChainProgressListener PChainProgressListener
 	// LastNonSimplexBlockPChainHeight is the P-chain height of the last block built by a non-Simplex proposer.
@@ -1100,7 +1095,7 @@ func (sm *StateMachine) verifyNextEpochApprovalsSignature(prevMD StateMachineMet
 		return err
 	}
 
-	if err := sm.SignatureVerifier.VerifySignature(next.NextEpochApprovals.Signature, toBeSigned, aggPK); err != nil {
+	if err := sm.SignatureVerifier.VerifySignature(toBeSigned, next.NextEpochApprovals.Signature, aggPK); err != nil {
 		return fmt.Errorf("failed to verify signature: %w", err)
 	}
 	return nil
@@ -1119,6 +1114,7 @@ func assembleApprovalToBeSigned(pChainHeight uint64, auxInfoDigest [32]byte) ([]
 
 func (sm *StateMachine) aggregatePubKeysForBitmask(nodeIDsBitmask []byte, validators NodeBLSMappings) ([]byte, error) {
 	approvingNodes := avalanchego.BitmaskFromBytes(nodeIDsBitmask)
+
 	publicKeys := make([][]byte, 0, len(validators))
 	for i := range validators {
 		if !approvingNodes.Contains(i) {

--- a/msm/msm.go
+++ b/msm/msm.go
@@ -79,6 +79,7 @@ var (
 	errBlockDigestMismatch            = errors.New("does not match proposed block digest")
 	errSealingBlockSeqUnset           = errors.New("cannot build epoch sealed block: sealing block sequence is 0 or undefined")
 	errEmptyNextEpochApprovals        = errors.New("next epoch approvals are empty")
+	errApprovalsBitmaskTooWide        = errors.New("approvals bitmask is wider than the validator set")
 	errPChainReferenceHeightMismatch  = errors.New("unexpected P-chain reference height")
 	errPChainReferenceHeightDecreased = errors.New("p-chain reference height is decreasing")
 	errValidatorSetUnchanged          = errors.New("validator set unchanged; next P-chain reference height should not have advanced")
@@ -1114,6 +1115,12 @@ func assembleApprovalToBeSigned(pChainHeight uint64, auxInfoDigest [32]byte) ([]
 
 func (sm *StateMachine) aggregatePubKeysForBitmask(nodeIDsBitmask []byte, validators NodeBLSMappings) ([]byte, error) {
 	approvingNodes := avalanchego.BitmaskFromBytes(nodeIDsBitmask)
+
+	// Check that the bitmask is not wider than the number of validators, otherwise it would imply that some approving nodes are not in the validator set.
+	if bitLen := approvingNodes.BitLen(); bitLen > len(validators) {
+		return nil, fmt.Errorf("%w: highest set bit implies %d nodes, but there are %d validators",
+			errApprovalsBitmaskTooWide, bitLen, len(validators))
+	}
 
 	publicKeys := make([][]byte, 0, len(validators))
 	for i := range validators {

--- a/msm/msm_test.go
+++ b/msm/msm_test.go
@@ -1728,7 +1728,7 @@ func TestCollectingApprovalsAuxInfoGating(t *testing.T) {
 	// of the final auxiliary info history, which is sha256 of the last vote (vote2).
 	wantSigned, err := assembleApprovalToBeSigned(nextPChainRefHeight, sha256.Sum256(vote2))
 	require.NoError(t, err)
-	require.NoError(t, (&signatureVerifier{}).VerifySignature(approvals(block3).Signature, wantSigned, nil),
+	require.NoError(t, (&signatureVerifier{}).VerifySignature(wantSigned, approvals(block3).Signature, nil),
 		"NextEpochApprovals signature must verify against P-chain height 200 and the digest of vote2")
 
 	// block4: built on the empty-Info block3 while still collecting approvals (1/3 is below

--- a/msm/util_test.go
+++ b/msm/util_test.go
@@ -128,7 +128,7 @@ type signatureVerifier struct {
 	err error
 }
 
-func (sv *signatureVerifier) VerifySignature(signature []byte, message []byte, _ []byte) error {
+func (sv *signatureVerifier) VerifySignature(message []byte, signature []byte, _ []byte) error {
 	if sv.err != nil {
 		return sv.err
 	}

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -1133,7 +1133,6 @@ func (e *Epoch) handleVoteMessage(message *common.Vote, from common.NodeID) erro
 		return nil
 	}
 
-	// Only verify the vote if we haven't verified it in the past.
 	signature := message.Signature
 
 	pk, exists := e.validatorsToPKs[string(signature.Signer)]
@@ -1142,11 +1141,17 @@ func (e *Epoch) handleVoteMessage(message *common.Vote, from common.NodeID) erro
 		return nil
 	}
 
-	if _, exists := round.votes[string(signature.Signer)]; !exists {
-		if err := vote.Verify(signature.Value, e.Verifier, pk); err != nil {
-			e.Logger.Debug("ToBeSignedVote verification failed", zap.Stringer("NodeID", signature.Signer), zap.Error(err))
-			return nil
-		}
+	// A node only gets to vote once per round. Keeping the origional vote
+	if _, exists := round.votes[string(signature.Signer)]; exists {
+		e.Logger.Debug("Already received a vote from this node for the round",
+			zap.Stringer("NodeID", signature.Signer), zap.Uint64("round", vote.Round))
+		e.deleteFutureVote(from, vote.Round)
+		return nil
+	}
+
+	if err := vote.Verify(signature.Value, e.Verifier, pk); err != nil {
+		e.Logger.Debug("ToBeSignedVote verification failed", zap.Stringer("NodeID", signature.Signer), zap.Error(err))
+		return nil
 	}
 
 	e.rounds[vote.Round].votes[string(signature.Signer)] = message

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -2062,3 +2062,73 @@ func TestQuorum(t *testing.T) {
 		})
 	}
 }
+
+// rejectingVerifier accepts every signature except rejected.
+type rejectingVerifier struct {
+	rejected []byte
+}
+
+func (v *rejectingVerifier) VerifySignature(_ []byte, signature []byte, _ []byte) error {
+	if string(signature) == string(v.rejected) {
+		return fmt.Errorf("invalid signature")
+	}
+	return nil
+}
+
+// TestEpochVoteSentTwiceKeepsVerifiedVote ensures a node that has already voted in a round
+// cannot displace the vote we verified by sending a second one. Otherwise a signature that
+// fails verification ends up in the notarization we assemble and broadcast.
+func TestEpochVoteSentTwiceKeepsVerifiedVote(t *testing.T) {
+	bb := testutil.NewTestBlockBuilder()
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+
+	forged := []byte("forged signature")
+
+	comm := &recordingComm{Communication: testutil.NewNoopComm(nodes), BroadcastMessages: make(chan *Message, 100)}
+	conf, _, _ := testutil.DefaultTestNodeEpochConfig(t, nodes[0], comm, bb)
+	conf.Verifier = &rejectingVerifier{rejected: forged}
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	// nodes[0] leads round 0, so it proposes the block and votes for it itself.
+	block := bb.GetBuiltBlock()
+
+	// nodes[1] casts a legitimate vote.
+	vote, err := testutil.NewTestVote(block, nodes[1])
+	require.NoError(t, err)
+	require.NoError(t, e.HandleMessage(&Message{VoteMessage: vote}, nodes[1]))
+
+	// nodes[1] votes a second time for the same round, with a signature that does not
+	// verify. It must be dropped rather than take the place of the vote above.
+	require.NoError(t, e.HandleMessage(&Message{VoteMessage: &Vote{
+		Vote:      vote.Vote,
+		Signature: Signature{Signer: nodes[1], Value: forged},
+	}}, nodes[1]))
+
+	// nodes[2] votes, bringing the round to a quorum so a notarization is assembled.
+	vote2, err := testutil.NewTestVote(block, nodes[2])
+	require.NoError(t, err)
+	require.NoError(t, e.HandleMessage(&Message{VoteMessage: vote2}, nodes[2]))
+
+	timeout := time.After(time.Minute)
+	for {
+		select {
+		case msg := <-comm.BroadcastMessages:
+			if msg.Notarization == nil {
+				continue
+			}
+			qc, ok := msg.Notarization.QC.(testutil.TestQC)
+			require.True(t, ok)
+			for _, sig := range qc {
+				require.NotEqual(t, forged, sig.Value,
+					"notarization QC contains a signature that failed verification, signer %x", sig.Signer)
+			}
+			return
+		case <-timeout:
+			t.Fatal("timed out waiting for a notarization to be broadcast")
+		}
+	}
+}

--- a/wal/last_record.go
+++ b/wal/last_record.go
@@ -87,7 +87,7 @@ func validateLastRecordFile(lastRecordFilePath string) ([]byte, error) {
 		return nil, nil
 	}
 
-	payload, _, err := readRecord(lastRecordFile, uint32(stat.Size()))
+	payload, _, err := readRecord(lastRecordFile, stat.Size())
 	if err != nil && stat.Size() > 0 {
 		return nil, fmt.Errorf("could not read record index file %s: %w", lastRecordFilePath, err)
 	}

--- a/wal/memwal.go
+++ b/wal/memwal.go
@@ -37,7 +37,7 @@ func (wal *InMemWAL) ReadAll() ([][]byte, error) {
 	r := bytes.NewBuffer(wal.bb.Bytes())
 	var res [][]byte
 	for r.Len() > 0 {
-		payload, _, err := readRecord(r, uint32(r.Len()))
+		payload, _, err := readRecord(r, int64(r.Len()))
 		if err != nil {
 			return nil, fmt.Errorf("failed reading in-memory record: %w", err)
 		}

--- a/wal/record.go
+++ b/wal/record.go
@@ -38,7 +38,7 @@ func writeRecord(w io.Writer, payload []byte) error {
 
 // readRecord reads a length-prefixed and check-summed record from the reader.
 // If the record is read correctly, the number of bytes read is returned.
-func readRecord(r io.Reader, maxSize uint32) ([]byte, uint32, error) {
+func readRecord(r io.Reader, maxSize int64) ([]byte, int64, error) {
 	const tempSpace = max(recordSizeLen, recordChecksumLen)
 	buff := make([]byte, tempSpace)
 	crc := crc64.New(crc64.MakeTable(crc64.ECMA))
@@ -52,11 +52,14 @@ func readRecord(r io.Reader, maxSize uint32) ([]byte, uint32, error) {
 	}
 
 	payloadLen := binary.BigEndian.Uint32(sizeBuff)
-	if payloadLen > maxSize {
-		return nil, 0, fmt.Errorf("record indicates payload is %d bytes long", payloadLen)
+	// Widened to 64 bits so that a payload length near MaxUint32 cannot wrap around
+	// and understate the size of the record or of the allocation below.
+	recordLen := int64(recordSizeLen) + int64(payloadLen) + int64(recordChecksumLen)
+	if recordLen > maxSize {
+		return nil, 0, fmt.Errorf("record indicates payload is %d bytes long, but only %d bytes remain", payloadLen, maxSize)
 	}
 
-	payloadAndChecksum := make([]byte, payloadLen+recordChecksumLen)
+	payloadAndChecksum := make([]byte, int64(payloadLen)+int64(recordChecksumLen))
 	if _, err := io.ReadFull(r, payloadAndChecksum); err != nil {
 		return nil, 0, err
 	}
@@ -70,5 +73,5 @@ func readRecord(r io.Reader, maxSize uint32) ([]byte, uint32, error) {
 	if !bytes.Equal(checksum, expectedChecksum) {
 		return nil, 0, ErrInvalidCRC
 	}
-	return payload, recordSizeLen + payloadLen + recordChecksumLen, nil
+	return payload, recordLen, nil
 }

--- a/wal/record_test.go
+++ b/wal/record_test.go
@@ -48,6 +48,39 @@ func TestReadRecord(t *testing.T) {
 	require.ErrorIs(err, ErrInvalidCRC)
 }
 
+// TestReadRecordRejectsOversizedPayload ensures a record declaring a payload that cannot
+// fit in the bytes that remain is rejected. A declared length near MaxUint32 used to wrap
+// around when the checksum length was added to it, sizing the allocation far below the
+// declared length, so slicing the payload back out of it panicked.
+func TestReadRecordRejectsOversizedPayload(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		payloadLen uint32
+		maxSize    int64
+	}{
+		{
+			name:       "declared length wraps when the checksum length is added",
+			payloadLen: math.MaxUint32,
+			maxSize:    math.MaxUint32,
+		},
+		{
+			name:       "declared length exceeds the bytes that remain",
+			payloadLen: 4096,
+			maxSize:    64,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			buff := make([]byte, recordSizeLen+recordChecksumLen+8)
+			binary.BigEndian.PutUint32(buff, testCase.payloadLen)
+
+			payload, n, err := readRecord(bytes.NewReader(buff), testCase.maxSize)
+			require.ErrorContains(t, err, "bytes remain")
+			require.Nil(t, payload)
+			require.Zero(t, n)
+		})
+	}
+}
+
 func FuzzRecord(f *testing.F) {
 	f.Fuzz(func(t *testing.T, payload []byte, badCRCVal uint64) {
 		require := require.New(t)

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -83,13 +83,13 @@ func (w *WriteAheadLog) ReadAll() ([][]byte, error) {
 
 	var payloads [][]byte
 	for bytesToRead > 0 {
-		payload, bytesRead, err := readRecord(w.file, uint32(bytesToRead))
+		payload, bytesRead, err := readRecord(w.file, bytesToRead)
 		// record was corrupted in wal
 		if err != nil {
 			return payloads, w.truncateAt(fileInfo.Size() - bytesToRead)
 		}
 
-		bytesToRead -= int64(bytesRead)
+		bytesToRead -= bytesRead
 		payloads = append(payloads, payload)
 	}
 

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -4,6 +4,7 @@
 package wal
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
@@ -123,6 +124,54 @@ func TestCorruptedFile(t *testing.T) {
 	readRecords, err := wal.ReadAll()
 	require.NoError(err)
 	require.Equal(records[:n-1], readRecords)
+}
+
+// TestPartiallyWrittenRecord covers a crash in the middle of an Append: the record's
+// length prefix made it to disk but its payload and checksum did not. ReadAll must return
+// the records that were written in full and truncate the torn tail away.
+func TestPartiallyWrittenRecord(t *testing.T) {
+	require := require.New(t)
+
+	fileName := filepath.Join(t.TempDir(), "simplex.wal")
+	wal := New(fileName)
+	defer func() {
+		require.NoError(wal.Close())
+	}()
+
+	const n = 3
+	records := make([][]byte, n)
+	for i := range records {
+		records[i] = []byte{byte(i), byte(i), byte(i)}
+		require.NoError(wal.Append(records[i]))
+	}
+
+	recordSize := recordSizeLen + len(records[0]) + recordChecksumLen
+
+	// Append a torn record: a prefix declaring a 3 byte payload, followed by only 2 of
+	// the 11 bytes that should follow it.
+	torn := make([]byte, recordSizeLen)
+	binary.BigEndian.PutUint32(torn, 3)
+	torn = append(torn, 0xAA, 0xBB)
+
+	file, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY, 0666)
+	require.NoError(err)
+	_, err = file.Write(torn)
+	require.NoError(err)
+	require.NoError(file.Close())
+
+	readRecords, err := wal.ReadAll()
+	require.NoError(err)
+	require.Equal(records, readRecords)
+
+	// The torn tail must be gone, so the next Append starts from a clean boundary.
+	info, err := os.Stat(fileName)
+	require.NoError(err)
+	require.Equal(int64(n*recordSize), info.Size())
+
+	require.NoError(wal.Append([]byte{9, 9, 9}))
+	readRecords, err = wal.ReadAll()
+	require.NoError(err)
+	require.Equal(append(records, []byte{9, 9, 9}), readRecords)
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION

Here are a list of the changes. 

260dc20  Reject a second vote from a node that already voted in the round
09b47c7  Unify msm on the common SignatureVerifier argument order
dbd6d0b  Count Bitmask bits in linear time and add BitLen
64ce9db  Reject an approvals bitmask wider than the validator set
9cf4a8d  Compute WAL record lengths in 64 bits. Prevent Overflow issue
6d8ce20  Rename WALMaxEntryCount to WALMaxSizeBytes. It was counting bytes so just renamed the variable name