### PR TITLE
Rename WALMaxEntryCount to WALMaxSizeBytes

### DIFF
--- a/adapters_test.go
+++ b/adapters_test.go
@@ -189,9 +189,9 @@ func TestCachedStoragePopulatedByWal(t *testing.T) {
 		LastNonSimplexInnerBlock: genesisBlock,
 		WalCreator:               storage.CreateWAL,
 		ParameterConfig: ParameterConfig{
-			MaxNetworkDelay:  500 * time.Millisecond,
-			MaxRoundWindow:   100,
-			WALMaxEntryCount: 1024,
+			MaxNetworkDelay: 500 * time.Millisecond,
+			MaxRoundWindow:  100,
+			WALMaxSizeBytes: 1024,
 		},
 		WALs: []wal.DeletableWAL{testWAL},
 	}

--- a/config.go
+++ b/config.go
@@ -13,8 +13,9 @@ import (
 )
 
 type ParameterConfig struct {
-	// WalMaxEntryCount is the maximum number of entries in the write-ahead log before it is closed.
-	WALMaxEntryCount int
+	// WALMaxSizeBytes is the maximum size, in bytes, that a write-ahead log may reach
+	// before it is closed and a new one is started. Zero selects the default.
+	WALMaxSizeBytes int
 	// MaxNetworkDelay is the assumed upper bound on the network delay for messages to be delivered.
 	MaxNetworkDelay time.Duration
 	// MaxRoundWindow is the maximum number of rounds that can be stored in memory.

--- a/instance.go
+++ b/instance.go
@@ -426,7 +426,7 @@ func (i *Instance) createEpochConfig() (*epochConfig, error) {
 		return nil, err
 	}
 
-	wal, err := wal.NewGarbageCollectedWAL(i.Config.WALs, i.Config.WalCreator, &common.WALRetentionReader{}, i.Config.ParameterConfig.WALMaxEntryCount)
+	wal, err := wal.NewGarbageCollectedWAL(i.Config.WALs, i.Config.WalCreator, &common.WALRetentionReader{}, i.Config.ParameterConfig.WALMaxSizeBytes)
 	if err != nil {
 		return nil, fmt.Errorf("error creating garbage collected wal: %w", err)
 	}

--- a/instance_test.go
+++ b/instance_test.go
@@ -954,9 +954,9 @@ func newInstanceWithVM(t *testing.T, nodeID common.NodeID, storage *MockStorage,
 		LastNonSimplexInnerBlock: genesisBlock,
 		WalCreator:               storage.CreateWAL,
 		ParameterConfig: ParameterConfig{
-			MaxNetworkDelay:  500 * time.Millisecond,
-			MaxRoundWindow:   100,
-			WALMaxEntryCount: 1024,
+			MaxNetworkDelay: 500 * time.Millisecond,
+			MaxRoundWindow:  100,
+			WALMaxSizeBytes: 1024,
 		},
 	}
 	return NewInstance(config)


### PR DESCRIPTION
The variable always was the max bytes that is accepted just changed the name so support that change