### PR TITLE
Compute WAL record lengths in 64 bits

### DIFF
--- a/wal/last_record.go
+++ b/wal/last_record.go
@@ -87,7 +87,7 @@ func validateLastRecordFile(lastRecordFilePath string) ([]byte, error) {
 		return nil, nil
 	}
 
-	payload, _, err := readRecord(lastRecordFile, uint32(stat.Size()))
+	payload, _, err := readRecord(lastRecordFile, stat.Size())
 	if err != nil && stat.Size() > 0 {
 		return nil, fmt.Errorf("could not read record index file %s: %w", lastRecordFilePath, err)
 	}

--- a/wal/memwal.go
+++ b/wal/memwal.go
@@ -37,7 +37,7 @@ func (wal *InMemWAL) ReadAll() ([][]byte, error) {
 	r := bytes.NewBuffer(wal.bb.Bytes())
 	var res [][]byte
 	for r.Len() > 0 {
-		payload, _, err := readRecord(r, uint32(r.Len()))
+		payload, _, err := readRecord(r, int64(r.Len()))
 		if err != nil {
 			return nil, fmt.Errorf("failed reading in-memory record: %w", err)
 		}

--- a/wal/record.go
+++ b/wal/record.go
@@ -38,7 +38,7 @@ func writeRecord(w io.Writer, payload []byte) error {
 
 // readRecord reads a length-prefixed and check-summed record from the reader.
 // If the record is read correctly, the number of bytes read is returned.
-func readRecord(r io.Reader, maxSize uint32) ([]byte, uint32, error) {
+func readRecord(r io.Reader, maxSize int64) ([]byte, int64, error) {
 	const tempSpace = max(recordSizeLen, recordChecksumLen)
 	buff := make([]byte, tempSpace)
 	crc := crc64.New(crc64.MakeTable(crc64.ECMA))
@@ -52,11 +52,14 @@ func readRecord(r io.Reader, maxSize uint32) ([]byte, uint32, error) {
 	}
 
 	payloadLen := binary.BigEndian.Uint32(sizeBuff)
-	if payloadLen > maxSize {
-		return nil, 0, fmt.Errorf("record indicates payload is %d bytes long", payloadLen)
+	// Widened to 64 bits so that a payload length near MaxUint32 cannot wrap around
+	// and understate the size of the record or of the allocation below.
+	recordLen := int64(recordSizeLen) + int64(payloadLen) + int64(recordChecksumLen)
+	if recordLen > maxSize {
+		return nil, 0, fmt.Errorf("record indicates payload is %d bytes long, but only %d bytes remain", payloadLen, maxSize)
 	}
 
-	payloadAndChecksum := make([]byte, payloadLen+recordChecksumLen)
+	payloadAndChecksum := make([]byte, int64(payloadLen)+int64(recordChecksumLen))
 	if _, err := io.ReadFull(r, payloadAndChecksum); err != nil {
 		return nil, 0, err
 	}
@@ -70,5 +73,5 @@ func readRecord(r io.Reader, maxSize uint32) ([]byte, uint32, error) {
 	if !bytes.Equal(checksum, expectedChecksum) {
 		return nil, 0, ErrInvalidCRC
 	}
-	return payload, recordSizeLen + payloadLen + recordChecksumLen, nil
+	return payload, recordLen, nil
 }

--- a/wal/record_test.go
+++ b/wal/record_test.go
@@ -48,6 +48,39 @@ func TestReadRecord(t *testing.T) {
 	require.ErrorIs(err, ErrInvalidCRC)
 }
 
+// TestReadRecordRejectsOversizedPayload ensures a record declaring a payload that cannot
+// fit in the bytes that remain is rejected. A declared length near MaxUint32 used to wrap
+// around when the checksum length was added to it, sizing the allocation far below the
+// declared length, so slicing the payload back out of it panicked.
+func TestReadRecordRejectsOversizedPayload(t *testing.T) {
+	for _, testCase := range []struct {
+		name       string
+		payloadLen uint32
+		maxSize    int64
+	}{
+		{
+			name:       "declared length wraps when the checksum length is added",
+			payloadLen: math.MaxUint32,
+			maxSize:    math.MaxUint32,
+		},
+		{
+			name:       "declared length exceeds the bytes that remain",
+			payloadLen: 4096,
+			maxSize:    64,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			buff := make([]byte, recordSizeLen+recordChecksumLen+8)
+			binary.BigEndian.PutUint32(buff, testCase.payloadLen)
+
+			payload, n, err := readRecord(bytes.NewReader(buff), testCase.maxSize)
+			require.ErrorContains(t, err, "bytes remain")
+			require.Nil(t, payload)
+			require.Zero(t, n)
+		})
+	}
+}
+
 func FuzzRecord(f *testing.F) {
 	f.Fuzz(func(t *testing.T, payload []byte, badCRCVal uint64) {
 		require := require.New(t)

--- a/wal/wal.go
+++ b/wal/wal.go
@@ -83,13 +83,13 @@ func (w *WriteAheadLog) ReadAll() ([][]byte, error) {
 
 	var payloads [][]byte
 	for bytesToRead > 0 {
-		payload, bytesRead, err := readRecord(w.file, uint32(bytesToRead))
+		payload, bytesRead, err := readRecord(w.file, bytesToRead)
 		// record was corrupted in wal
 		if err != nil {
 			return payloads, w.truncateAt(fileInfo.Size() - bytesToRead)
 		}
 
-		bytesToRead -= int64(bytesRead)
+		bytesToRead -= bytesRead
 		payloads = append(payloads, payload)
 	}
 

--- a/wal/wal_test.go
+++ b/wal/wal_test.go
@@ -4,6 +4,7 @@
 package wal
 
 import (
+	"encoding/binary"
 	"os"
 	"path/filepath"
 	"testing"
@@ -123,6 +124,54 @@ func TestCorruptedFile(t *testing.T) {
 	readRecords, err := wal.ReadAll()
 	require.NoError(err)
 	require.Equal(records[:n-1], readRecords)
+}
+
+// TestPartiallyWrittenRecord covers a crash in the middle of an Append: the record's
+// length prefix made it to disk but its payload and checksum did not. ReadAll must return
+// the records that were written in full and truncate the torn tail away.
+func TestPartiallyWrittenRecord(t *testing.T) {
+	require := require.New(t)
+
+	fileName := filepath.Join(t.TempDir(), "simplex.wal")
+	wal := New(fileName)
+	defer func() {
+		require.NoError(wal.Close())
+	}()
+
+	const n = 3
+	records := make([][]byte, n)
+	for i := range records {
+		records[i] = []byte{byte(i), byte(i), byte(i)}
+		require.NoError(wal.Append(records[i]))
+	}
+
+	recordSize := recordSizeLen + len(records[0]) + recordChecksumLen
+
+	// Append a torn record: a prefix declaring a 3 byte payload, followed by only 2 of
+	// the 11 bytes that should follow it.
+	torn := make([]byte, recordSizeLen)
+	binary.BigEndian.PutUint32(torn, 3)
+	torn = append(torn, 0xAA, 0xBB)
+
+	file, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY, 0666)
+	require.NoError(err)
+	_, err = file.Write(torn)
+	require.NoError(err)
+	require.NoError(file.Close())
+
+	readRecords, err := wal.ReadAll()
+	require.NoError(err)
+	require.Equal(records, readRecords)
+
+	// The torn tail must be gone, so the next Append starts from a clean boundary.
+	info, err := os.Stat(fileName)
+	require.NoError(err)
+	require.Equal(int64(n*recordSize), info.Size())
+
+	require.NoError(wal.Append([]byte{9, 9, 9}))
+	readRecords, err = wal.ReadAll()
+	require.NoError(err)
+	require.Equal(append(records, []byte{9, 9, 9}), readRecords)
 }
 
 func TestDelete(t *testing.T) {


### PR DESCRIPTION
Makes sure there is not a overflow with the 32bit numbers. 