### PR TITLE
fix data race between AdvanceTime and ReplaceNode in the test network

### DIFF
--- a/testutil/network.go
+++ b/testutil/network.go
@@ -91,7 +91,9 @@ func (b *BasicInMemoryNetwork) Disconnect(node common.NodeID) {
 }
 
 func (b *BasicInMemoryNetwork) AdvanceTime(increment time.Duration) {
-	for _, instance := range b.instances {
+	// iterate a snapshot instead of holding the lock, since advancing time can
+	// send messages, which acquires the lock again
+	for _, instance := range b.GetInstances() {
 		instance.AdvanceTime(increment)
 	}
 }


### PR DESCRIPTION
`BasicInMemoryNetwork.AdvanceTime` iterated the node list without taking the network lock, while `ReplaceNode` swaps an entry under the write lock. The long running network's time updater goroutine ticks `AdvanceTime` every 100ms, so restarting a node via `StartNodes` races with it. Caught by the race detector in `TestLongRunningCrash` on CI (https://github.com/ava-labs/Simplex/actions/runs/33011251485/job/98317799865).

`AdvanceTime` now iterates the snapshot from `GetInstances`, which copies the list under the read lock. It does not hold the lock across the per-node tick: advancing time can send messages, and the send path calls `IsDisconnected`, which takes the same lock again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)