### PR TITLE
Do not query P-chain for current validator set

### DIFF
--- a/msm/msm.go
+++ b/msm/msm.go
@@ -296,24 +296,24 @@ func (sm *StateMachine) WaitForPendingBlock(ctx context.Context, currentRoundMet
 	// In order to know whether we're transitioning to a new epoch, or should transition to one,
 	// we need to look at the previous block's metadata.
 
-	prevBlockSeq := currentRoundMetadata.Seq - 1
+	lastBlockSeq := currentRoundMetadata.Seq - 1
 
-	parentBlock, finalization, err := sm.GetBlock(prevBlockSeq, currentRoundMetadata.Prev)
+	lastBlock, finalization, err := sm.GetBlock(lastBlockSeq, currentRoundMetadata.Prev)
 	if err != nil {
 		sm.Logger.Debug(
 			"WaitForPendingBlock failed to get block",
 			zap.Uint64("Current Seq", currentRoundMetadata.Seq),
 			zap.Uint64("Current Round", currentRoundMetadata.Round),
-			zap.Uint64("seq", prevBlockSeq),
+			zap.Uint64("seq", lastBlockSeq),
 			zap.Error(err),
 		)
 		sm.BlockBuilder.WaitForPendingBlock(ctx)
 		return
 	}
 
-	// In case the parent block is a Telock, we want to look at the sealing block's metadata instead.
-	if parentBlock.Type() == BlockTypeTelock {
-		sealingBlockSeq := parentBlock.Metadata.SimplexEpochInfo.SealingBlockSeq
+	// In case the last block is a Telock, we want to look at the sealing block's metadata instead.
+	if lastBlock.Type() == BlockTypeTelock {
+		sealingBlockSeq := lastBlock.Metadata.SimplexEpochInfo.SealingBlockSeq
 		var sealingBlock StateMachineBlock
 		sealingBlock, finalization, err = sm.GetBlock(sealingBlockSeq, common.Digest{})
 		if err != nil {
@@ -328,10 +328,11 @@ func (sm *StateMachine) WaitForPendingBlock(ctx context.Context, currentRoundMet
 		}
 		// Else, err is nil and the sealing block is finalized,
 		// so we can use the sealing block's metadata to determine whether we should build a block immediately or not.
-		parentBlock = sealingBlock
+		lastBlock = sealingBlock
+		lastBlockSeq = sealingBlockSeq
 	}
 
-	currentState := parentBlock.Metadata.SimplexEpochInfo.NextState()
+	currentState := lastBlock.Metadata.SimplexEpochInfo.NextState()
 
 	// We first check if we have obvious signs that we need to build a block immediately:
 	var shouldObviouslyBuildBlockImmediately bool
@@ -364,13 +365,28 @@ func (sm *StateMachine) WaitForPendingBlock(ctx context.Context, currentRoundMet
 	// so we initialize a blockBuildingDecider and listen while waiting for the VM.
 	// We return when either the VM signals that a block is ready to be built,
 	// or that the blockBuildingDecider detects that we should transition to a new epoch.
-	pChainReferenceHeight := parentBlock.Metadata.SimplexEpochInfo.PChainReferenceHeight
-	if parentBlock.Type() == BlockTypeSealing {
-		// We've moved to a new epoch, so we need to use the next P-chain reference height of the sealing block,
-		// because the P-chain reference height of the next epoch is inherited from the P-chain reference height of the sealing block.
-		pChainReferenceHeight = parentBlock.Metadata.SimplexEpochInfo.NextPChainReferenceHeight
+	var currentValidatorSet NodeBLSMappings
+	if lastBlock.Type() == BlockTypeSealing {
+		// We've moved to a new epoch, so the current validator set is the one the sealing block
+		// itself carries; getCurrentValidatorSet would instead look up the sealed (previous) epoch.
+		bvd := lastBlock.Metadata.SimplexEpochInfo.BlockValidationDescriptor
+		if bvd == nil || len(bvd.AggregatedMembership.Members) == 0 {
+			sm.Logger.Debug("Sealing block has no validator set, cannot determine current validator set for next epoch", zap.Uint64("seq", lastBlockSeq))
+			sm.BlockBuilder.WaitForPendingBlock(ctx)
+			return
+		}
+		currentValidatorSet = bvd.AggregatedMembership.Members
+	} else {
+		// If the last block is not a sealing block, we need to look up the current validator set encoded in the sealing block of the previous epoch.
+		currentValidatorSet, err = getCurrentValidatorSet(&lastBlock, sm.GetBlock)
+		if err != nil {
+			sm.Logger.Debug("WaitForPendingBlock failed to get current validator set", zap.Uint64("seq", lastBlockSeq), zap.Error(err))
+			sm.BlockBuilder.WaitForPendingBlock(ctx)
+			return
+		}
 	}
-	blockBuildingDecider := sm.createBlockBuildingDecider(pChainReferenceHeight)
+
+	blockBuildingDecider := sm.createBlockBuildingDecider(currentValidatorSet)
 	_, err = blockBuildingDecider.shouldBuildBlock(ctx)
 	if err != nil {
 		sm.Logger.Debug(
@@ -551,17 +567,23 @@ func (sm *StateMachine) buildBlockNormalOp(ctx context.Context, parentBlock *Sta
 
 // buildBlockOrTransitionEpoch builds a block and decides whether to transition to a new epoch based on the P-chain height and validator set changes.
 func (sm *StateMachine) buildBlockOrTransitionEpoch(ctx context.Context, parentBlock *StateMachineBlock, simplexMetadata common.ProtocolMetadata, simplexBlacklist common.Blacklist, newSimplexEpochInfo SimplexEpochInfo) (*StateMachineBlock, error) {
-	var isSealingBlockFinalized bool
-	sealingBlockSeq := parentBlock.Metadata.SimplexEpochInfo.EpochNumber
-	_, finalization, err := sm.GetBlock(sealingBlockSeq, [32]byte{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve sealing block for previous epoch (%d): %w", sealingBlockSeq, err)
-	}
-	if finalization != nil {
-		isSealingBlockFinalized = true
+	var currentValidatorSet NodeBLSMappings
+	var err error
+
+	if parentBlock.Type() != BlockTypeSealing {
+		currentValidatorSet, err = getCurrentValidatorSet(parentBlock, sm.GetBlock)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get current validator set: %w", err)
+		}
+	} else {
+		bvd := parentBlock.Metadata.SimplexEpochInfo.BlockValidationDescriptor
+		if bvd == nil || len(bvd.AggregatedMembership.Members) == 0 {
+			return nil, fmt.Errorf("sealing block has no validator set, cannot determine current validator set for next epoch")
+		}
+		currentValidatorSet = bvd.AggregatedMembership.Members
 	}
 
-	blockBuildingDecider := sm.createBlockBuildingDecider(newSimplexEpochInfo.PChainReferenceHeight)
+	blockBuildingDecider := sm.createBlockBuildingDecider(currentValidatorSet)
 	decisionToBuildBlock, err := blockBuildingDecider.shouldBuildBlock(ctx)
 	if err != nil {
 		if errors.Is(context.Cause(ctx), common.ErrShouldBuildEmptyBlock) {
@@ -578,10 +600,21 @@ func (sm *StateMachine) buildBlockOrTransitionEpoch(ctx context.Context, parentB
 		zap.Bool("transition epoch", decisionToBuildBlock.transitionEpoch),
 		zap.Uint64("P-chain height", decisionToBuildBlock.pChainHeight))
 
-	if decisionToBuildBlock.transitionEpoch && isSealingBlockFinalized {
-		sm.Logger.Debug("Transitioning epoch after building block", zap.Uint64("newPChainRefHeight", decisionToBuildBlock.pChainHeight))
-		newSimplexEpochInfo.NextPChainReferenceHeight = decisionToBuildBlock.pChainHeight
-		sm.maybeInitializeApprovalStore(decisionToBuildBlock.validatorSet)
+	if decisionToBuildBlock.transitionEpoch {
+		sealingBlockSeq := parentBlock.Metadata.SimplexEpochInfo.EpochNumber
+		if parentBlock.Type() == BlockTypeSealing {
+			sealingBlockSeq = parentBlock.Metadata.SimplexProtocolMetadata.Seq
+		}
+		isSealingBlockFinalized, err := sm.isFinalized(sealingBlockSeq)
+		if err != nil {
+			return nil, err
+		}
+
+		if isSealingBlockFinalized {
+			sm.Logger.Debug("Transitioning epoch after building block", zap.Uint64("newPChainRefHeight", decisionToBuildBlock.pChainHeight))
+			newSimplexEpochInfo.NextPChainReferenceHeight = decisionToBuildBlock.pChainHeight
+			sm.maybeInitializeApprovalStore(decisionToBuildBlock.validatorSet)
+		}
 	}
 
 	now := sm.GetTime()
@@ -600,6 +633,14 @@ func (sm *StateMachine) buildBlockOrTransitionEpoch(ctx context.Context, parentB
 	}
 
 	return wrapBlock(innerBlock, newSimplexEpochInfo, decisionToBuildBlock.pChainHeight, simplexMetadata, simplexBlacklist, now, icmEpochInfo, nil), nil
+}
+
+func (sm *StateMachine) isFinalized(blockSeq uint64) (bool, error) {
+	_, finalization, err := sm.GetBlock(blockSeq, [32]byte{})
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve block (%d): %w", blockSeq, err)
+	}
+	return finalization != nil, nil
 }
 
 func computeICMEpochInfo(parentBlock *StateMachineBlock, computeICMEpoch ICMEpochTransition, childTimestamp time.Time) ICMEpochInfo {
@@ -660,7 +701,7 @@ func (sm *StateMachine) verifyNormalBlock(ctx context.Context, parentBlock *Stat
 
 	icmEpochInfo := computeICMEpochInfo(parentBlock, sm.ComputeICMEpoch, timestamp)
 
-	if err := sm.verifyNextPChainRefHeightNormal(ctx, parentBlock.Metadata, nextBlock.Metadata.SimplexEpochInfo); err != nil {
+	if err := sm.verifyNextPChainRefHeightNormal(parentBlock, nextBlock.Metadata.SimplexEpochInfo); err != nil {
 		return fmt.Errorf("failed to verify next P-chain reference height for normal block: %w", err)
 	}
 	newSimplexEpochInfo.NextPChainReferenceHeight = nextBlock.Metadata.SimplexEpochInfo.NextPChainReferenceHeight
@@ -681,7 +722,8 @@ func verifyPChainHeight(proposedPChainHeight uint64, currentPChainHeight uint64,
 	return nil
 }
 
-func (sm *StateMachine) verifyNextPChainRefHeightNormal(ctx context.Context, prevMD StateMachineMetadata, next SimplexEpochInfo) error {
+func (sm *StateMachine) verifyNextPChainRefHeightNormal(parentBlock *StateMachineBlock, next SimplexEpochInfo) error {
+	prevMD := parentBlock.Metadata
 	prev := prevMD.SimplexEpochInfo
 	// Next P-chain height can only increase, not decrease.
 	if next.NextPChainReferenceHeight > 0 && prev.PChainReferenceHeight > next.NextPChainReferenceHeight {
@@ -721,9 +763,17 @@ func (sm *StateMachine) verifyNextPChainRefHeightNormal(ctx context.Context, pre
 	// It might be that this block is the first block that has set the next P-chain reference height for the epoch,
 	// so check if it has done so correctly by observing whether the validator set has indeed changed.
 
-	currentValidatorSet, err := sm.GetValidatorSet(prevMD.SimplexEpochInfo.PChainReferenceHeight)
+	// Else, !currentValidatorSet.Equal(newValidatorSet) || next.NextPChainReferenceHeight == 0
+	// We first check the case for next.NextPChainReferenceHeight == 0,
+	// because if it is, then we don't need to check the validator set at all and we return early.
+	if next.NextPChainReferenceHeight == 0 {
+		return nil
+	}
+
+	// parentBlock cannot be a sealing block because if it were, then prev.NextPChainReferenceHeight would be > 0, and we would have returned above.
+	currentValidatorSet, err := getCurrentValidatorSet(parentBlock, sm.GetBlock)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get current validator set: %w", err)
 	}
 
 	newValidatorSet, err := sm.GetValidatorSet(next.NextPChainReferenceHeight)
@@ -732,19 +782,13 @@ func (sm *StateMachine) verifyNextPChainRefHeightNormal(ctx context.Context, pre
 	}
 
 	// If the validator set doesn't change, we shouldn't have increased the next P-chain reference height.
-	if currentValidatorSet.Equal(newValidatorSet) && next.NextPChainReferenceHeight > 0 {
+	if currentValidatorSet.Equal(newValidatorSet) {
 		return fmt.Errorf("%w: validator set at proposed next P-chain reference height %d matches previous block's P-chain reference height %d",
 			errValidatorSetUnchanged, next.NextPChainReferenceHeight, prev.PChainReferenceHeight)
 	}
 
-	// Else, !currentValidatorSet.Equal(newValidatorSet) || next.NextPChainReferenceHeight == 0
-	// so if next.NextPChainReferenceHeight > 0, we should initialize the approval store for the new validator set.
-	if next.NextPChainReferenceHeight > 0 {
-		sm.maybeInitializeApprovalStore(newValidatorSet)
-	}
-
-	// Else, either the validator set has changed, or the next P-chain reference height is still 0.
-	// Both of these cases are fine.
+	// we should initialize the approval store for the new validator set.
+	sm.maybeInitializeApprovalStore(newValidatorSet)
 
 	return nil
 }
@@ -755,7 +799,7 @@ func (sm *StateMachine) verifyNextPChainRefHeightNormal(ctx context.Context, pre
 // We cannot reuse verifyNextPChainRefHeightNormal here — the baseline
 // for the validator-set change check is the new epoch's PChainReferenceHeight, not the parent's,
 // as in verifyNextPChainRefHeightNormal.
-func (sm *StateMachine) verifyNextPChainRefHeightForNewEpoch(ctx context.Context, expectedEpochInfo SimplexEpochInfo, next SimplexEpochInfo) error {
+func (sm *StateMachine) verifyNextPChainRefHeightForNewEpoch(expectedEpochInfo SimplexEpochInfo, next SimplexEpochInfo, currentValidatorSet NodeBLSMappings) error {
 	// The first block of the epoch doesn't trigger an epoch change, we're all set.
 	if next.NextPChainReferenceHeight == 0 {
 		return nil
@@ -776,11 +820,6 @@ func (sm *StateMachine) verifyNextPChainRefHeightForNewEpoch(ctx context.Context
 		return fmt.Errorf("%w: target %d, current %d", errPChainHeightNotReached, next.NextPChainReferenceHeight, pChainHeight)
 	}
 
-	currentValidatorSet, err := sm.GetValidatorSet(expectedEpochInfo.PChainReferenceHeight)
-	if err != nil {
-		return err
-	}
-
 	newValidatorSet, err := sm.GetValidatorSet(next.NextPChainReferenceHeight)
 	if err != nil {
 		return err
@@ -796,7 +835,7 @@ func (sm *StateMachine) verifyNextPChainRefHeightForNewEpoch(ctx context.Context
 	return nil
 }
 
-func (sm *StateMachine) createBlockBuildingDecider(pChainReferenceHeight uint64) blockBuildingDecider {
+func (sm *StateMachine) createBlockBuildingDecider(currentValidatorSet NodeBLSMappings) blockBuildingDecider {
 	blockBuildingDecider := blockBuildingDecider{
 		logger:                   sm.Logger,
 		maxBlockBuildingWaitTime: sm.MaxBlockBuildingWaitTime,
@@ -809,11 +848,6 @@ func (sm *StateMachine) createBlockBuildingDecider(pChainReferenceHeight uint64)
 			// and the new validator set defined by the given pChainHeight.
 			// If they are different, then we should transition to a new epoch.
 
-			currentValidatorSet, err := sm.GetValidatorSet(pChainReferenceHeight)
-			if err != nil {
-				return false, nil, err
-			}
-
 			newValidatorSet, err := sm.GetValidatorSet(pChainHeight)
 			if err != nil {
 				return false, nil, err
@@ -823,7 +857,6 @@ func (sm *StateMachine) createBlockBuildingDecider(pChainReferenceHeight uint64)
 				sm.Logger.Debug("Validator set has changed, should transition epoch",
 					zap.String("currentValidatorSet", fmt.Sprintf("%v", currentValidatorSet.Nodes())),
 					zap.String("newValidatorSet", fmt.Sprintf("%v", newValidatorSet.Nodes())),
-					zap.Uint64("currentPChainRefHeight", pChainReferenceHeight),
 					zap.Uint64("newPChainHeight", pChainHeight))
 				return true, newValidatorSet, nil
 			}
@@ -1322,6 +1355,38 @@ func (sm *StateMachine) computeSimplexEpochInfoForSealingBlock(simplexEpochInfo 
 	return simplexEpochInfo, nil
 }
 
+// getCurrentValidatorSet retrieves the validator set corresponding to the epoch of the given block.
+// The given block must not be a sealing block or a Telock, because the method is expected to be called on the parent block of a block,
+// and therefore the validator set of the block is determined by the sealing block, not what is returned from this function.
+// Calling this function on a Telock or a sealing block will return an error.
+func getCurrentValidatorSet(parentBlock *StateMachineBlock, getBlock BlockRetriever) (NodeBLSMappings, error) {
+	if parentBlock.Type() == BlockTypeSealing || parentBlock.Type() == BlockTypeTelock {
+		return nil, fmt.Errorf("getCurrentValidatorSet: did not expect block %d to be a sealing block or a Telock",
+			parentBlock.Metadata.SimplexProtocolMetadata.Seq)
+	}
+	epoch := parentBlock.Metadata.SimplexEpochInfo.EpochNumber
+	block, finalization, err := getBlock(epoch, [32]byte{}) // The sealing block of the current epoch should be finalized.
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve sealing block %d: %w", epoch, err)
+	}
+
+	var bvd *BlockValidationDescriptor
+	if block.Type() == BlockTypeZero {
+		bvd = block.Metadata.SimplexEpochInfo.BlockValidationDescriptor
+	} else {
+		if finalization == nil {
+			return nil, fmt.Errorf("sealing block %d is not finalized", epoch)
+		}
+		bvd = block.Metadata.SimplexEpochInfo.BlockValidationDescriptor
+	}
+
+	if bvd == nil || len(bvd.AggregatedMembership.Members) == 0 {
+		return nil, fmt.Errorf("block %d has no validators", epoch)
+	}
+
+	return bvd.AggregatedMembership.Members, nil
+}
+
 // wrapBlock creates a new StateMachineBlock by wrapping the VM block (if applicable) and adding the appropriate metadata.
 func wrapBlock(
 	innerBlock avalanchego.VMBlock,
@@ -1429,7 +1494,7 @@ func computeSimplexEpochInfoForTelock(parentBlock *StateMachineBlock, sealingBlo
 }
 
 func (sm *StateMachine) verifyBlockEpochSealed(ctx context.Context, parentBlock *StateMachineBlock, nextBlock *StateMachineBlock, prevBlockSeq uint64) error {
-	isSealingBlockFinalized, sealingBlockSeq, _, err := sm.areWeReadyToTransitionEpoch(parentBlock, prevBlockSeq)
+	isSealingBlockFinalized, sealingBlockSeq, sealingBlock, err := sm.areWeReadyToTransitionEpoch(parentBlock, prevBlockSeq)
 	if err != nil {
 		return err
 	}
@@ -1444,6 +1509,13 @@ func (sm *StateMachine) verifyBlockEpochSealed(ctx context.Context, parentBlock 
 		return verifyAgainstExpected(ctx, nil, newSimplexEpochInfo, nextBlock.Metadata.PChainHeight, nextBlock, timestamp, icmEpochInfo, nil)
 	}
 
+	bvd := sealingBlock.Metadata.SimplexEpochInfo.BlockValidationDescriptor
+	if bvd == nil || len(bvd.AggregatedMembership.Members) == 0 {
+		return fmt.Errorf("sealing block %d has no BlockValidationDescriptor", sealingBlockSeq)
+	}
+
+	currentValidatorSet := bvd.AggregatedMembership.Members
+
 	// Else, it's a new epoch.
 	newSimplexEpochInfo = computeSimplexEpochInfoForNewEpoch(parentBlock, sealingBlockSeq, prevBlockSeq)
 
@@ -1457,7 +1529,7 @@ func (sm *StateMachine) verifyBlockEpochSealed(ctx context.Context, parentBlock 
 		return fmt.Errorf("failed to verify P-chain height: %w", err)
 	}
 
-	if err := sm.verifyNextPChainRefHeightForNewEpoch(ctx, newSimplexEpochInfo, nextBlock.Metadata.SimplexEpochInfo); err != nil {
+	if err := sm.verifyNextPChainRefHeightForNewEpoch(newSimplexEpochInfo, nextBlock.Metadata.SimplexEpochInfo, currentValidatorSet); err != nil {
 		return fmt.Errorf("failed to verify next P-chain reference height for new epoch block: %w", err)
 	}
 	newSimplexEpochInfo.NextPChainReferenceHeight = nextBlock.Metadata.SimplexEpochInfo.NextPChainReferenceHeight

--- a/msm/msm_test.go
+++ b/msm/msm_test.go
@@ -230,6 +230,9 @@ func TestMSMBuildBlockRejectsZeroSeq(t *testing.T) {
 }
 
 func TestMSMNormalOp(t *testing.T) {
+	// The chain's zero block sits at simplexStartHeight and opens the epoch every later block belongs to.
+	const simplexStartHeight, chainEndHeight = 5, 10
+
 	newPChainHeight := uint64(200)
 	newValidatorSet := NodeBLSMappings{
 		{BLSKey: []byte{5}, Weight: 1}, {BLSKey: []byte{6}, Weight: 1}, {BLSKey: []byte{7}, Weight: 1},
@@ -243,6 +246,9 @@ func TestMSMNormalOp(t *testing.T) {
 		expectedPChainHeight        uint64
 		expectedNextPChainRefHeight uint64
 		expectedICMEpochInfo        ICMEpochInfo
+		// expectApprovalStore is whether building the block initialized the approval store,
+		// which only happens when the block starts an epoch transition.
+		expectApprovalStore bool
 	}{
 		{
 			name:                 "correct information",
@@ -335,12 +341,33 @@ func TestMSMNormalOp(t *testing.T) {
 			expectedPChainHeight:        newPChainHeight,
 			expectedNextPChainRefHeight: newPChainHeight,
 			expectedICMEpochInfo:        ICMEpochInfo{PChainEpochHeight: 100, EpochNumber: 1},
+			expectApprovalStore:         true,
+		},
+		{
+			// The validator set changed, but the block that opened the epoch is not finalized yet,
+			// so the builder must not start the transition: a verifier would reject a block that
+			// does, since it requires that block to be finalized. The block is still built, at
+			// the new P-chain height, and the transition waits for a later block.
+			// This is needed when building blocks on top of the first ever simplex block.
+			name: "validator set change not acted upon while the epoch's opening block is not finalized",
+			setup: func(sm *StateMachine, tc *testConfig) {
+				tc.validatorSetRetriever.resultMap = map[uint64]NodeBLSMappings{
+					newPChainHeight: newValidatorSet,
+				}
+				sm.GetPChainHeightForProposing = func() uint64 { return newPChainHeight }
+				sm.GetPChainHeightForVerifying = func() uint64 { return newPChainHeight }
+				tc.blockStore[simplexStartHeight].finalization = nil
+			},
+			expectedPChainHeight:        newPChainHeight,
+			expectedNextPChainRefHeight: 0,
+			expectedICMEpochInfo:        ICMEpochInfo{PChainEpochHeight: 100, EpochNumber: 1},
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			chain := makeChain(t, 5, 10)
 			sm1, testConfig1 := newStateMachine(t)
 			sm2, testConfig2 := newStateMachine(t)
+
+			chain := makeChain(t, simplexStartHeight, chainEndHeight, testConfig1.validatorSetRetriever.result)
 
 			for i, block := range chain {
 				testConfig1.blockStore[uint64(i)] = &outerBlock{block: block, finalization: &common.Finalization{}}
@@ -381,6 +408,8 @@ func TestMSMNormalOp(t *testing.T) {
 			block1, err := sm1.BuildBlock(context.Background(), md, blacklist)
 			require.NoError(t, err)
 			require.NotNil(t, block1)
+			require.Equal(t, testCase.expectApprovalStore, sm1.approvalStore != nil,
+				"the approval store is initialized exactly when the built block starts an epoch transition")
 
 			if testCase.mutateBlock != nil {
 				testCase.mutateBlock(block1)
@@ -406,7 +435,7 @@ func TestMSMNormalOp(t *testing.T) {
 					SimplexProtocolMetadata: md,
 					SimplexEpochInfo: SimplexEpochInfo{
 						PChainReferenceHeight:     100,
-						EpochNumber:               1,
+						EpochNumber:               lastBlock.Metadata.SimplexEpochInfo.EpochNumber,
 						PrevVMBlockSeq:            lastBlock.InnerBlock.Height(),
 						NextPChainReferenceHeight: testCase.expectedNextPChainRefHeight,
 					},
@@ -1041,6 +1070,23 @@ func TestVerifyNextPChainRefHeightNormal(t *testing.T) {
 		}
 	}
 
+	// The current validator set is now read from the parent epoch's sealing block, stored at
+	// the parent's EpochNumber. It must carry a validator descriptor and be finalized.
+	currentEpochSealingBlock := func(finalized bool) *outerBlock {
+		ob := &outerBlock{block: StateMachineBlock{Metadata: StateMachineMetadata{
+			SimplexEpochInfo: SimplexEpochInfo{
+				BlockValidationDescriptor: &BlockValidationDescriptor{
+					AggregatedMembership: AggregatedMembership{Members: setA},
+				},
+				PrevSealingBlockHash: [32]byte{0xaa},
+			},
+		}}}
+		if finalized {
+			ob.finalization = &common.Finalization{}
+		}
+		return ob
+	}
+
 	tests := []struct {
 		name  string
 		next  SimplexEpochInfo
@@ -1050,13 +1096,16 @@ func TestVerifyNextPChainRefHeightNormal(t *testing.T) {
 		{
 			name: "next height zero returns nil",
 			next: SimplexEpochInfo{NextPChainReferenceHeight: 0},
+			setup: func(tc *testConfig) {
+				tc.blockStore[sealingBlockSeq] = currentEpochSealingBlock(true)
+			},
 		},
 		{
 			name: "next height set, sealing block finalized",
 			next: SimplexEpochInfo{NextPChainReferenceHeight: nextPChainRefHeight},
 			setup: func(tc *testConfig) {
 				withChangedValidatorSet(tc)
-				tc.blockStore[sealingBlockSeq] = &outerBlock{finalization: &common.Finalization{}}
+				tc.blockStore[sealingBlockSeq] = currentEpochSealingBlock(true)
 			},
 		},
 		{
@@ -1086,7 +1135,7 @@ func TestVerifyNextPChainRefHeightNormal(t *testing.T) {
 				tt.setup(tc)
 			}
 
-			err := sm.verifyNextPChainRefHeightNormal(t.Context(), prevMD, tt.next)
+			err := sm.verifyNextPChainRefHeightNormal(&StateMachineBlock{Metadata: prevMD}, tt.next)
 			if tt.err == nil {
 				require.NoError(t, err)
 				return
@@ -2028,12 +2077,16 @@ func (b *blockingBlockBuilder) WaitForPendingBlock(ctx context.Context) {
 func TestMSMWaitForPendingBlock(t *testing.T) {
 	const waitTime = 500 * time.Millisecond
 
+	// The current validator set is now read from a block's BlockValidationDescriptor rather than
+	// from GetValidatorSet(refHeight), so every block whose set we consult must carry one.
+	defaultSet := NodeBLSMappings{{BLSKey: []byte{1}, Weight: 1}, {BLSKey: []byte{2}, Weight: 1}}
+
 	var (
 		normal     = SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 100}
 		collecting = SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 100, NextPChainReferenceHeight: 200}
 		telock     = SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 100, NextPChainReferenceHeight: 200, SealingBlockSeq: 5}
 		sealing    = SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 100, NextPChainReferenceHeight: 200,
-			BlockValidationDescriptor: &BlockValidationDescriptor{}, PrevSealingBlockHash: [32]byte{0xaa}}
+			BlockValidationDescriptor: &BlockValidationDescriptor{AggregatedMembership: AggregatedMembership{Members: defaultSet}}, PrevSealingBlockHash: [32]byte{0xaa}}
 	)
 
 	block := func(sei SimplexEpochInfo, finalized bool) *outerBlock {
@@ -2044,6 +2097,17 @@ func TestMSMWaitForPendingBlock(t *testing.T) {
 		return ob
 	}
 
+	// zeroBlock is the finalized first simplex block that opens epoch 1 and records its validator set.
+	zeroBlock := func(set NodeBLSMappings) *outerBlock {
+		return &outerBlock{
+			finalization: &common.Finalization{},
+			block: StateMachineBlock{Metadata: StateMachineMetadata{SimplexEpochInfo: SimplexEpochInfo{
+				EpochNumber:               1,
+				BlockValidationDescriptor: &BlockValidationDescriptor{AggregatedMembership: AggregatedMembership{Members: set}},
+			}}},
+		}
+	}
+
 	for _, tt := range []struct {
 		name string
 		// blocks seeds the block store with parent blocks, keyed by their sequence.
@@ -2052,6 +2116,9 @@ func TestMSMWaitForPendingBlock(t *testing.T) {
 		seq uint64
 		// validatorSets seeds the validator set retriever, keyed by P-chain reference height.
 		validatorSets map[uint64]NodeBLSMappings
+		// pChainHeight, when non-zero, overrides the P-chain height used for proposing/verifying,
+		// i.e. the height whose validator set is compared against the current epoch's set.
+		pChainHeight uint64
 		// vmHasBlock indicates the underlying VM has a pending block ready to build.
 		vmHasBlock bool
 		// returnsOnItsOwn is true when WaitForPendingBlock is expected to return without
@@ -2093,12 +2160,13 @@ func TestMSMWaitForPendingBlock(t *testing.T) {
 			blocks: blockStore{1: block(sealing, true)},
 		},
 		{
-			// The new epoch inherits its P-chain reference height from the sealing block's
-			// NextPChainReferenceHeight, so that is the height whose validator set we compare
-			// against. Comparing against the sealed epoch's height would miss this change.
+			// We just moved to the new epoch, whose validator set is the one the sealing block
+			// carries. If the set at the latest P-chain height differs from it, another transition
+			// is due, so WaitForPendingBlock returns on its own.
 			name:            "sealing block parent, finalized, validator set changed again",
 			seq:             2,
 			blocks:          blockStore{1: block(sealing, true)},
+			pChainHeight:    200,
 			validatorSets:   map[uint64]NodeBLSMappings{200: {{BLSKey: []byte{9}, Weight: 1}}},
 			returnsOnItsOwn: true,
 		},
@@ -2137,11 +2205,13 @@ func TestMSMWaitForPendingBlock(t *testing.T) {
 		},
 		{
 			// The validator set changed, so a block must record the new P-chain reference height
-			// even if the VM has nothing to put in it.
+			// even if the VM has nothing to put in it. The current set is read from the epoch's
+			// zero block (seq 1); the set at the latest P-chain height differs from it.
 			name:            "normal operation, validator set changed",
-			seq:             2,
-			blocks:          blockStore{1: block(SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 50}, false)},
-			validatorSets:   map[uint64]NodeBLSMappings{50: {{BLSKey: []byte{9}, Weight: 1}}},
+			seq:             3,
+			blocks:          blockStore{1: zeroBlock(defaultSet), 2: block(SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 100}, false)},
+			pChainHeight:    200,
+			validatorSets:   map[uint64]NodeBLSMappings{200: {{BLSKey: []byte{9}, Weight: 1}}},
 			returnsOnItsOwn: true,
 		},
 	} {
@@ -2155,6 +2225,10 @@ func TestMSMWaitForPendingBlock(t *testing.T) {
 			sm, cfg := newStateMachine(t)
 			sm.BlockBuilder = bb
 			sm.MaxBlockBuildingWaitTime = waitTime
+			if tt.pChainHeight != 0 {
+				sm.GetPChainHeightForProposing = func() uint64 { return tt.pChainHeight }
+				sm.GetPChainHeightForVerifying = func() uint64 { return tt.pChainHeight }
+			}
 			cfg.validatorSetRetriever.resultMap = tt.validatorSets
 			for seq, blk := range tt.blocks {
 				cfg.blockStore[seq] = blk
@@ -2304,4 +2378,141 @@ func TestMSMBuildBlockBuildsEmptyBlockWhenInnerBlockBuildingCancelled(t *testing
 		require.ErrorIs(t, err, errVMBuildFailed)
 		require.Nil(t, block)
 	})
+}
+
+func TestGetCurrentValidatorSet(t *testing.T) {
+	validators := NodeBLSMappings{{BLSKey: []byte{1}, Weight: 1}, {BLSKey: []byte{2}, Weight: 1}}
+	finalized := &common.Finalization{}
+
+	descriptor := func(members NodeBLSMappings) *BlockValidationDescriptor {
+		return &BlockValidationDescriptor{AggregatedMembership: AggregatedMembership{Members: members}}
+	}
+
+	// zeroBlock opens the first epoch: it carries a descriptor and points to no previous sealing block.
+	zeroBlock := func(bvd *BlockValidationDescriptor, finalization *common.Finalization) *outerBlock {
+		return &outerBlock{
+			finalization: finalization,
+			block: StateMachineBlock{Metadata: StateMachineMetadata{
+				SimplexEpochInfo: SimplexEpochInfo{EpochNumber: 1, BlockValidationDescriptor: bvd},
+			}},
+		}
+	}
+
+	// sealingBlock at seq opens the epoch numbered seq: it carries a descriptor and points to the previous sealing block.
+	sealingBlock := func(seq uint64, bvd *BlockValidationDescriptor, finalization *common.Finalization) *outerBlock {
+		return &outerBlock{
+			finalization: finalization,
+			block: StateMachineBlock{Metadata: StateMachineMetadata{
+				SimplexProtocolMetadata: common.ProtocolMetadata{Seq: seq},
+				SimplexEpochInfo:        SimplexEpochInfo{PrevSealingBlockHash: [32]byte{1}, BlockValidationDescriptor: bvd},
+			}},
+		}
+	}
+
+	// normalBlock is a block in the epoch that neither opens nor seals it.
+	normalBlock := func(seq, epoch uint64) *outerBlock {
+		return &outerBlock{
+			finalization: finalized,
+			block: StateMachineBlock{Metadata: StateMachineMetadata{
+				SimplexProtocolMetadata: common.ProtocolMetadata{Seq: seq},
+				SimplexEpochInfo:        SimplexEpochInfo{EpochNumber: epoch},
+			}},
+		}
+	}
+
+	for _, testCase := range []struct {
+		name string
+		// parent is the epoch info of the block whose epoch's validator set is looked up.
+		parent SimplexEpochInfo
+		blocks blockStore
+
+		expected NodeBLSMappings
+		// expectedErr is a substring of the expected error message.
+		expectedErr string
+		// expectedErrIs is a sentinel the expected error must wrap.
+		expectedErrIs error
+	}{
+		{
+			name:     "normal block in the first epoch reads the zero block",
+			parent:   SimplexEpochInfo{EpochNumber: 1},
+			blocks:   blockStore{1: zeroBlock(descriptor(validators), finalized)},
+			expected: validators,
+		},
+		{
+			name:     "the zero block is read even before it is finalized",
+			parent:   SimplexEpochInfo{EpochNumber: 1},
+			blocks:   blockStore{1: zeroBlock(descriptor(validators), nil)},
+			expected: validators,
+		},
+		{
+			name:     "normal block in a later epoch reads the finalized sealing block",
+			parent:   SimplexEpochInfo{EpochNumber: 10},
+			blocks:   blockStore{10: sealingBlock(10, descriptor(validators), finalized)},
+			expected: validators,
+		},
+		{
+			name:     "transitioning block reads the sealing block of its epoch",
+			parent:   SimplexEpochInfo{EpochNumber: 10, NextPChainReferenceHeight: 300},
+			blocks:   blockStore{10: sealingBlock(10, descriptor(validators), finalized)},
+			expected: validators,
+		},
+		{
+			name:        "sealing block that is not finalized is rejected",
+			parent:      SimplexEpochInfo{EpochNumber: 10},
+			blocks:      blockStore{10: sealingBlock(10, descriptor(validators), nil)},
+			expectedErr: "sealing block 10 is not finalized",
+		},
+		{
+			name:          "missing epoch block",
+			parent:        SimplexEpochInfo{EpochNumber: 10},
+			blocks:        blockStore{},
+			expectedErrIs: common.ErrBlockNotFound,
+		},
+		{
+			name:        "sealing block without validators",
+			parent:      SimplexEpochInfo{EpochNumber: 10},
+			blocks:      blockStore{10: sealingBlock(10, descriptor(nil), finalized)},
+			expectedErr: "block 10 has no validators",
+		},
+		{
+			name:        "epoch block that carries no descriptor",
+			parent:      SimplexEpochInfo{EpochNumber: 10},
+			blocks:      blockStore{10: normalBlock(10, 1)},
+			expectedErr: "block 10 has no validators",
+		},
+		{
+			name:        "sealing block as parent is rejected",
+			parent:      SimplexEpochInfo{EpochNumber: 1, PrevSealingBlockHash: [32]byte{1}, BlockValidationDescriptor: descriptor(validators)},
+			blocks:      blockStore{1: zeroBlock(descriptor(validators), finalized)},
+			expectedErr: "did not expect block 20 to be a sealing block or a Telock",
+		},
+		{
+			name:        "Telock as parent is rejected",
+			parent:      SimplexEpochInfo{EpochNumber: 1, SealingBlockSeq: 15},
+			blocks:      blockStore{1: zeroBlock(descriptor(validators), finalized)},
+			expectedErr: "did not expect block 20 to be a sealing block or a Telock",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			parent := &StateMachineBlock{Metadata: StateMachineMetadata{
+				SimplexProtocolMetadata: common.ProtocolMetadata{Seq: 20},
+				SimplexEpochInfo:        testCase.parent,
+			}}
+
+			got, err := getCurrentValidatorSet(parent, testCase.blocks.getBlock)
+
+			if testCase.expectedErrIs != nil {
+				require.ErrorIs(t, err, testCase.expectedErrIs)
+				require.Nil(t, got)
+				return
+			}
+			if testCase.expectedErr != "" {
+				require.ErrorContains(t, err, testCase.expectedErr)
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, testCase.expected, got)
+		})
+	}
 }

--- a/msm/util_test.go
+++ b/msm/util_test.go
@@ -242,7 +242,10 @@ var (
 	}
 )
 
-func makeChain(t *testing.T, simplexStartHeight uint64, endHeight uint64) []StateMachineBlock {
+// makeChain builds a chain of endHeight+1 blocks whose heights double as sequence numbers: genesis at
+// height 0, non-Simplex blocks below simplexStartHeight, the zero block at simplexStartHeight that opens
+// the first epoch with the given validator set, and normal Simplex blocks of that epoch above it.
+func makeChain(t *testing.T, simplexStartHeight uint64, endHeight uint64, validatorSet NodeBLSMappings) []StateMachineBlock {
 	startTime := time.Now().Add(-time.Duration(endHeight+2) * time.Second)
 	blocks := make([]StateMachineBlock, 0, endHeight+1)
 	var round, seq uint64
@@ -261,21 +264,46 @@ func makeChain(t *testing.T, simplexStartHeight uint64, endHeight uint64) []Stat
 
 		seq = uint64(index)
 
-		blocks = append(blocks, makeNormalSimplexBlock(t, index, blocks, startTime, h, round, seq))
+		if h == simplexStartHeight {
+			blocks = append(blocks, makeZeroBlock(blocks, validatorSet, round, seq))
+		} else {
+			blocks = append(blocks, makeNormalSimplexBlock(t, index, blocks, startTime, h, round, seq))
+		}
 		round++
 	}
 	return blocks
 }
 
+// makeZeroBlock builds the first Simplex block on top of the last block in blocks the way buildBlockZero
+// does: it has no inner block, carries its parent's timestamp, and opens the first epoch, numbered by
+// its own sequence, with the given validator set as its block validation descriptor.
+func makeZeroBlock(blocks []StateMachineBlock, validatorSet NodeBLSMappings, round uint64, seq uint64) StateMachineBlock {
+	parent := blocks[len(blocks)-1]
+	epochInfo := constructSimplexZeroBlockSimplexEpochInfo(100, validatorSet, parent.InnerBlock.Height())
+
+	return StateMachineBlock{
+		Metadata: StateMachineMetadata{
+			Timestamp:    uint64(parent.InnerBlock.Timestamp().UnixMilli()),
+			PChainHeight: 100,
+			SimplexProtocolMetadata: common.ProtocolMetadata{
+				Round: round,
+				Seq:   seq,
+				Epoch: epochInfo.EpochNumber,
+				Prev:  parent.Digest(),
+			},
+			SimplexEpochInfo: epochInfo,
+		},
+	}
+}
+
+// makeNormalSimplexBlock builds a normal block of the epoch its parent, the last block in blocks, belongs to.
 func makeNormalSimplexBlock(t *testing.T, index int, blocks []StateMachineBlock, start time.Time, h uint64, round uint64, seq uint64) StateMachineBlock {
 	content := make([]byte, 10)
 	_, err := rand.Read(content)
 	require.NoError(t, err)
 
-	prev := genesisBlock.Digest()
-	if index > 0 {
-		prev = blocks[index-1].Digest()
-	}
+	parent := blocks[index-1]
+	epoch := parent.Metadata.SimplexEpochInfo.EpochNumber
 
 	return StateMachineBlock{
 		InnerBlock: &InnerBlock{
@@ -288,14 +316,14 @@ func makeNormalSimplexBlock(t *testing.T, index int, blocks []StateMachineBlock,
 			SimplexProtocolMetadata: common.ProtocolMetadata{
 				Round: round,
 				Seq:   seq,
-				Epoch: 1,
-				Prev:  prev,
+				Epoch: epoch,
+				Prev:  parent.Digest(),
 			},
 			SimplexEpochInfo: SimplexEpochInfo{
 				PrevSealingBlockHash:  [32]byte{},
 				PChainReferenceHeight: 100,
-				EpochNumber:           1,
-				PrevVMBlockSeq:        uint64(index),
+				EpochNumber:           epoch,
+				PrevVMBlockSeq:        computePrevVMBlockSeq(&parent, uint64(index-1)),
 			},
 		},
 	}
@@ -352,7 +380,10 @@ func newStateMachineWithLogger(tb testing.TB, logger common.Logger) (*StateMachi
 	}
 
 	smConfig := Config{
-		GenesisValidatorSet:             NodeBLSMappings{{BLSKey: []byte{1}, Weight: 1}, {BLSKey: []byte{2}, Weight: 1}},
+		GenesisValidatorSet: NodeBLSMappings{
+			{BLSKey: []byte{1}, Weight: 1, NodeID: [20]byte{1}},
+			{BLSKey: []byte{2}, Weight: 1, NodeID: [20]byte{2}},
+		},
 		LastNonSimplexBlockPChainHeight: 100,
 		GetTime:                         time.Now,
 		TimeSkewLimit:                   time.Second * 5,


### PR DESCRIPTION
This commit makes the MSM not need to query the P-chain for the current validator set when transitioning epochs.

Instead, it just looks at the block validation descriptor of the sealing block.