### PR TITLE
Verify QR's block matches finalization/notarization reported header

### DIFF
--- a/common/msg.go
+++ b/common/msg.go
@@ -349,22 +349,30 @@ func (q *QuorumRound) VerifyQCConsistentWithBlock() error {
 	}
 
 	// if an empty notarization is included, ensure the round is equal to the block round
-	if q.EmptyNotarization != nil && q.EmptyNotarization.Vote.Round != q.Block.BlockHeader().Round {
+	header := q.Block.BlockHeader()
+
+	if q.EmptyNotarization != nil && q.EmptyNotarization.Vote.Round != header.Round {
 		return fmt.Errorf("empty round does not match block round")
 	}
 
 	// ensure the finalization or notarization we get relates to the block
-	blockDigest := q.Block.BlockHeader().Digest
+	blockDigest := header.Digest
 
 	if q.Finalization != nil {
 		if !bytes.Equal(blockDigest[:], q.Finalization.Finalization.Digest[:]) {
-			return fmt.Errorf("finalization does not match the block")
+			return fmt.Errorf("finalization does not match the block digest")
+		}
+		if !q.Finalization.Finalization.Equals(&header) {
+			return fmt.Errorf("finalization does not match the block header")
 		}
 	}
 
 	if q.Notarization != nil {
 		if !bytes.Equal(blockDigest[:], q.Notarization.Vote.Digest[:]) {
-			return fmt.Errorf("notarization does not match the block")
+			return fmt.Errorf("notarization does not match the block digest")
+		}
+		if !q.Notarization.Vote.Equals(&header) {
+			return fmt.Errorf("notarization does not match the block header")
 		}
 	}
 

--- a/common/msg_test.go
+++ b/common/msg_test.go
@@ -267,3 +267,119 @@ func TestSizeMatchesBytes(t *testing.T) {
 	require.Equal(t, len(emptyNotarization.Vote.Bytes())+len(emptyNotarization.QC.Bytes()), emptyNotarization.Size())
 
 }
+
+func TestVerifyQCConsistentWithBlock(t *testing.T) {
+	block := testutil.NewTestBlock(common.ProtocolMetadata{
+		Version: 1,
+		Epoch:   2,
+		Round:   5,
+		Seq:     4,
+		Prev:    common.Digest{7},
+	}, common.Blacklist{})
+	bh := block.BlockHeader()
+
+	finalization := func(bh common.BlockHeader) *common.Finalization {
+		return &common.Finalization{Finalization: common.ToBeSignedFinalization{BlockHeader: bh}}
+	}
+	notarization := func(bh common.BlockHeader) *common.Notarization {
+		return &common.Notarization{Vote: common.ToBeSignedVote{BlockHeader: bh}}
+	}
+	emptyNotarization := func(round uint64) *common.EmptyNotarization {
+		return &common.EmptyNotarization{Vote: common.ToBeSignedEmptyVote{EmptyVoteMetadata: common.EmptyVoteMetadata{Round: round, Epoch: bh.Epoch}}}
+	}
+	// mutateHeader returns the block's header with one field changed, so the digest still matches the block.
+	mutateHeader := func(mutate func(*common.BlockHeader)) common.BlockHeader {
+		mutated := bh
+		mutate(&mutated)
+		return mutated
+	}
+
+	tests := []struct {
+		name        string
+		qr          common.QuorumRound
+		expectedErr bool
+	}{
+		{
+			name: "finalization matches block",
+			qr:   common.QuorumRound{Block: block, Finalization: finalization(bh)},
+		},
+		{
+			name: "notarization matches block",
+			qr:   common.QuorumRound{Block: block, Notarization: notarization(bh)},
+		},
+		{
+			name: "notarization and empty notarization of the block's round",
+			qr:   common.QuorumRound{Block: block, Notarization: notarization(bh), EmptyNotarization: emptyNotarization(bh.Round)},
+		},
+		{
+			name: "empty notarization without block",
+			qr:   common.QuorumRound{EmptyNotarization: emptyNotarization(bh.Round)},
+		},
+		{
+			name:        "malformed: finalization without block",
+			qr:          common.QuorumRound{Finalization: finalization(bh)},
+			expectedErr: true,
+		},
+		{
+			name:        "finalization digest mismatch",
+			qr:          common.QuorumRound{Block: block, Finalization: finalization(mutateHeader(func(h *common.BlockHeader) { h.Digest = common.Digest{9} }))},
+			expectedErr: true,
+		},
+		{
+			name:        "finalization round mismatch",
+			qr:          common.QuorumRound{Block: block, Finalization: finalization(mutateHeader(func(h *common.BlockHeader) { h.Round++ }))},
+			expectedErr: true,
+		},
+		{
+			name:        "finalization seq mismatch",
+			qr:          common.QuorumRound{Block: block, Finalization: finalization(mutateHeader(func(h *common.BlockHeader) { h.Seq++ }))},
+			expectedErr: true,
+		},
+		{
+			name:        "finalization epoch mismatch",
+			qr:          common.QuorumRound{Block: block, Finalization: finalization(mutateHeader(func(h *common.BlockHeader) { h.Epoch++ }))},
+			expectedErr: true,
+		},
+		{
+			name:        "finalization prev mismatch",
+			qr:          common.QuorumRound{Block: block, Finalization: finalization(mutateHeader(func(h *common.BlockHeader) { h.Prev = common.Digest{8} }))},
+			expectedErr: true,
+		},
+		{
+			name:        "finalization version mismatch",
+			qr:          common.QuorumRound{Block: block, Finalization: finalization(mutateHeader(func(h *common.BlockHeader) { h.Version++ }))},
+			expectedErr: true,
+		},
+		{
+			name:        "notarization digest mismatch",
+			qr:          common.QuorumRound{Block: block, Notarization: notarization(mutateHeader(func(h *common.BlockHeader) { h.Digest = common.Digest{9} }))},
+			expectedErr: true,
+		},
+		{
+			name:        "notarization round mismatch",
+			qr:          common.QuorumRound{Block: block, Notarization: notarization(mutateHeader(func(h *common.BlockHeader) { h.Round++ }))},
+			expectedErr: true,
+		},
+		{
+			name:        "notarization seq mismatch",
+			qr:          common.QuorumRound{Block: block, Notarization: notarization(mutateHeader(func(h *common.BlockHeader) { h.Seq++ }))},
+			expectedErr: true,
+		},
+		{
+			name:        "empty notarization round mismatch",
+			qr:          common.QuorumRound{Block: block, Notarization: notarization(bh), EmptyNotarization: emptyNotarization(bh.Round + 1)},
+			expectedErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.qr.VerifyQCConsistentWithBlock()
+			if test.expectedErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/nonvalidator/non_validator_test.go
+++ b/nonvalidator/non_validator_test.go
@@ -1017,3 +1017,50 @@ func TestNonValidatorAcceptsProposalFromUnsortedValidatorSet(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond,
 		"non-validator never committed the block, having dropped the proposal because it ordered the validator set differently than the validators")
 }
+
+func TestNonValidatorRejectsQuorumRoundWithMismatchedHeader(t *testing.T) {
+	tc := newSeededChain(t, testNodes, 4)
+
+	storage := tc.CloneUntil(3)
+	logger := testutil.MakeLogger(t, 1)
+
+	nv, err := NewNonValidator(
+		Config{
+			Storage:                    storage,
+			Comm:                       testutil.NewNoopComm(testNodes.NodeIDs()),
+			Logger:                     logger,
+			SignatureAggregatorCreator: tc.signatureAggregatorCreator,
+			MaxSequenceWindow:          10,
+			ID:                         common.NodeID{16},
+			StartTime:                  time.Now(),
+		},
+	)
+	require.NoError(t, err)
+	nv.Start()
+	defer nv.Stop()
+
+	b4, finalization, err := tc.Retrieve(3)
+	require.NoError(t, err)
+	b3 := b4.(common.Block)
+
+	// Same digest and seq as the b4, but a round the b4 was not finalized in.
+	mismatched := finalization
+	mismatched.Finalization.Round++
+	require.NoError(t, nv.HandleMessage(&common.Message{
+		ReplicationResponse: &common.ReplicationResponse{
+			Data: []common.QuorumRound{{Block: b3, Finalization: &mismatched}},
+		},
+	}, testNodes.NodeIDs()[0]))
+
+	require.NoError(t, nv.HandleMessage(&common.Message{
+		ReplicationResponse: &common.ReplicationResponse{
+			Data: []common.QuorumRound{{Block: b3, Finalization: &finalization}},
+		},
+	}, testNodes.NodeIDs()[1]))
+
+	storage.WaitForBlockCommit(3)
+	_, finalization, err = storage.Retrieve(3)
+	require.NoError(t, err)
+	bh := b3.BlockHeader()
+	require.True(t, finalization.Finalization.Equals(&bh), "b4 was indexed with a finalization that does not match its header")
+}

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -2314,3 +2314,78 @@ func notarizeRoundNotFinalized(t *testing.T, e *Epoch, nodes []NodeID, round uin
 	e.WAL.(*testutil.TestWAL).AssertNotarization(round)
 	return block
 }
+
+// TestEpochRejectsReplicatedQuorumRoundWithMismatchedHeader asserts that a replicated quorum round whose
+// notarization or finalization matches the block's digest but not the rest of its header is rejected before
+// anything is persisted: no block record and no notarization is written to the WAL, and no block is committed.
+// The genuine quorum round for the same block is then accepted.
+func TestEpochRejectsReplicatedQuorumRoundWithMismatchedHeader(t *testing.T) {
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+	blacklist := Blacklist{NodeCount: uint16(len(nodes)), SuspectedNodes: SuspectedNodes{}, Updates: []BlacklistUpdate{}}
+
+	mutations := []struct {
+		name   string
+		mutate func(*BlockHeader)
+	}{
+		{name: "round", mutate: func(h *BlockHeader) { h.Round++ }},
+		{name: "seq", mutate: func(h *BlockHeader) { h.Seq++ }},
+		{name: "epoch", mutate: func(h *BlockHeader) { h.Epoch++ }},
+	}
+
+	for _, quorumType := range []string{"notarization", "finalization"} {
+		for _, m := range mutations {
+			t.Run(quorumType+" with mismatched "+m.name, func(t *testing.T) {
+				// Our node leads round 3 only, so it neither proposes the block below nor builds one after it.
+				conf, wal, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[3], testutil.NewNoopComm(nodes), testutil.NewTestBlockBuilder())
+				conf.ReplicationEnabled = true
+				e, err := NewEpoch(conf)
+				require.NoError(t, err)
+				require.NoError(t, e.Start())
+				t.Cleanup(e.Stop)
+
+				block := testutil.NewTestBlock(ProtocolMetadata{Round: 0, Seq: 0}, blacklist)
+				sigAggr := e.SignatureAggregatorCreator(conf.Comm.Validators())
+				notarization, err := testutil.NewNotarization(e.Logger, sigAggr, block, nodes)
+				require.NoError(t, err)
+				finalization, _ := testutil.NewFinalizationRecord(t, sigAggr, block, nodes)
+
+				// The quorum certificate refers to the block's digest, but one header field disagrees with the block.
+				mismatched := QuorumRound{Block: block}
+				genuine := QuorumRound{Block: block}
+				if quorumType == "notarization" {
+					bad := notarization
+					m.mutate(&bad.Vote.BlockHeader)
+					mismatched.Notarization = &bad
+					genuine.Notarization = &notarization
+				} else {
+					bad := finalization
+					m.mutate(&bad.Finalization.BlockHeader)
+					mismatched.Finalization = &bad
+					genuine.Finalization = &finalization
+				}
+
+				replicate := func(qr QuorumRound) {
+					require.NoError(t, e.HandleMessage(&Message{
+						ReplicationResponse: &ReplicationResponse{Data: []QuorumRound{qr}},
+					}, nodes[0]))
+				}
+
+				replicate(mismatched)
+				require.Never(t, func() bool {
+					records, err := wal.ReadAll()
+					require.NoError(t, err)
+					return len(records) > 0 || storage.NumBlocks() > 0
+				}, 500*time.Millisecond, 50*time.Millisecond,
+					"a %s whose %s does not match the block was persisted", quorumType, m.name)
+
+				// The same block with its genuine quorum certificate is accepted.
+				replicate(genuine)
+				if quorumType == "notarization" {
+					wal.AssertNotarization(block.Metadata.Round)
+				} else {
+					storage.WaitForBlockCommit(block.Metadata.Seq)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
This commit makes sure that when a QR that is replicated, it is checked that the header of the finalization/notarization corresponds to the block's header.