### PR TITLE
Skip parsing an empty VM block

### DIFF
--- a/adapters.go
+++ b/adapters.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/ava-labs/simplex/avalanchego"
 	"github.com/ava-labs/simplex/common"
 	metadata "github.com/ava-labs/simplex/msm"
 	"github.com/ava-labs/simplex/simplex"
@@ -279,14 +280,19 @@ func (bd *blockDeserializer) DeserializeBlock(ctx context.Context, bytes []byte)
 		return nil, err
 	}
 
-	block, err := bd.vm.ParseBlock(ctx, rawBlock.InnerBlockBytes)
-	if err != nil {
-		return nil, err
+	var innerBlock avalanchego.VMBlock
+	if len(rawBlock.InnerBlockBytes) > 0 {
+		block, err := bd.vm.ParseBlock(ctx, rawBlock.InnerBlockBytes)
+		if err != nil {
+			return nil, err
+		}
+		innerBlock = block
 	}
+
 	return &cachedBlock{
 		ParsedBlock: &ParsedBlock{
 			StateMachineBlock: metadata.StateMachineBlock{
-				InnerBlock: block,
+				InnerBlock: innerBlock,
 				Metadata:   rawBlock.Metadata,
 			},
 			msm: bd.cs.msm,

--- a/instance_helpers_test.go
+++ b/instance_helpers_test.go
@@ -549,6 +549,7 @@ func noopICMTransition(_ metadata.ICMEpochInput) metadata.ICMEpochInfo {
 
 type node struct {
 	t       *testing.T
+	stopped bool
 	net     *network
 	id      common.NodeID
 	vm      *blockBuilderVM
@@ -560,8 +561,36 @@ type node struct {
 
 // stop stops the instance, then drains the messages the node was sending.
 func (n *node) stop() {
+	if n.stopped {
+		return
+	}
 	n.inst.Stop()
 	n.comm.stop()
+	n.stopped = true
+}
+
+func (n *node) restart() *node {
+	n.stop()
+
+	var records [][]byte
+	n.wals.lock.Lock()
+	for _, w := range n.wals.wals {
+		walRecords, err := w.ReadAll()
+		require.NoError(n.t, err)
+		records = append(records, walRecords...)
+	}
+	n.wals.lock.Unlock()
+
+	// Come back up over the same storage, restoring a WAL rebuilt from the exported records.
+	restoredWAL := testutil.NewTestWAL(n.t)
+	for _, record := range records {
+		require.NoError(n.t, restoredWAL.Append(record))
+	}
+
+	newNode := n.net.addNodeWithConfig(n.id, nodeConfig{
+		wals: []wal.DeletableWAL{restoredWAL}, storage: n.storage, existingNode: true,
+	})
+	return newNode
 }
 
 // sync syncs a node by waiting for the commit of the latest sequence.
@@ -625,6 +654,8 @@ type nodeConfig struct {
 	storage *testStorage
 	// wals are pre-existing WALs the instance restores on start.
 	wals []wal.DeletableWAL
+	// existingNode indicates whether the node is being added to the network for the first time (false) or is a restart of an existing node (true).
+	existingNode bool
 }
 
 // addNode creates and starts a node in the network.
@@ -637,11 +668,6 @@ func (n *network) addNodeWithConfig(id common.NodeID, cfg nodeConfig) *node {
 	storage := cfg.storage
 	if storage == nil {
 		storage = newTestStorageWithGenesis(n.t)
-	}
-
-	// ensure a unique id; snapshot because nodes may be added concurrently
-	for _, node := range n.nodesSnapshot() {
-		require.NotEqual(n.t, node.id, id)
 	}
 
 	comm := newInstanceComm(n, id)
@@ -677,7 +703,20 @@ func (n *network) addNodeWithConfig(id common.NodeID, cfg nodeConfig) *node {
 	}
 
 	n.lock.Lock()
-	n.nodes = append(n.nodes, node)
+	if cfg.existingNode {
+		for i, existingNode := range n.nodes {
+			if existingNode.id.Equals(id) {
+				n.nodes[i] = node
+				break
+			}
+		}
+	} else {
+		// ensure a unique id; snapshot because nodes may be added concurrently
+		for _, node := range n.nodes {
+			require.NotEqual(n.t, node.id, id)
+		}
+		n.nodes = append(n.nodes, node)
+	}
 	n.lock.Unlock()
 
 	instance.Config.Logger.Debug("Created a node in the test network", zap.Uint64("Seq", n.seq), zap.Uint64("num block", node.storage.NumBlocks()))

--- a/instance_test.go
+++ b/instance_test.go
@@ -11,6 +11,7 @@ import (
 	metadata "github.com/ava-labs/simplex/msm"
 	"github.com/ava-labs/simplex/simplex"
 	"github.com/ava-labs/simplex/testutil"
+	"github.com/ava-labs/simplex/wal"
 	"github.com/stretchr/testify/require"
 )
 
@@ -321,6 +322,61 @@ func TestInstanceValidatorSkipsAnEpoch(t *testing.T) {
 	pChain.advanceHeight(30)
 
 	network.waitUntilSealingBlock(newValidatorSet.Nodes())
+}
+
+func TestInstanceRestartsAfterZeroBlock(t *testing.T) {
+	validator := newNodeMapping(1)
+	pChain := newTestPChain([]metadata.NodeBLSMapping{validator})
+	network := newNetwork(t, pChain)
+
+	// The lone validator builds and commits the zero block on its own.
+	node := network.addNode(validator.NodeID[:]).sync()
+
+	zeroBlock, _, err := node.storage.GetBlock(1)
+	require.NoError(t, err)
+	require.Equal(t, metadata.BlockTypeZero, zeroBlock.Type())
+	require.Nil(t, zeroBlock.InnerBlock)
+
+	// Export the WAL records before the node goes down.
+	var records [][]byte
+	node.wals.lock.Lock()
+	for _, w := range node.wals.wals {
+		walRecords, err := w.ReadAll()
+		require.NoError(t, err)
+		records = append(records, walRecords...)
+	}
+	node.wals.lock.Unlock()
+
+	// Crash the node
+	node.inst.Stop()
+
+	// Come back up over the same storage, restoring a WAL rebuilt from the exported records.
+	restoredWAL := testutil.NewTestWAL(t)
+	for _, record := range records {
+		require.NoError(t, restoredWAL.Append(record))
+	}
+	wc := &walCreator{t: t}
+	restarted := NewInstance(Config{
+		LastNonSimplexInnerBlock: genesisBlock,
+		ParameterConfig:          paramConfig,
+		PlatformChain:            pChain,
+		Broadcaster:              node.comm,
+		Sender:                   node.comm,
+		CryptoOps:                &testCryptoOps{},
+		WalCreator:               wc.createWAL,
+		Storage:                  node.storage,
+		Logger:                   testutil.MakeLogger(t, 1),
+		WALs:                     []wal.DeletableWAL{restoredWAL},
+		VM:                       node.vm,
+		ICMETransition:           noopICMTransition,
+		ID:                       validator.NodeID[:],
+	})
+	t.Cleanup(restarted.Stop)
+	require.NoError(t, restarted.Start(t.Context()), "a node that built the zero block cannot restart")
+
+	// The restarted node keeps the chain going.
+	network.pending.addPendingBlock()
+	node.storage.WaitForBlockCommit(2)
 }
 
 func TestInstanceDoubleStartFails(t *testing.T) {

--- a/instance_test.go
+++ b/instance_test.go
@@ -11,7 +11,6 @@ import (
 	metadata "github.com/ava-labs/simplex/msm"
 	"github.com/ava-labs/simplex/simplex"
 	"github.com/ava-labs/simplex/testutil"
-	"github.com/ava-labs/simplex/wal"
 	"github.com/stretchr/testify/require"
 )
 
@@ -337,46 +336,10 @@ func TestInstanceRestartsAfterZeroBlock(t *testing.T) {
 	require.Equal(t, metadata.BlockTypeZero, zeroBlock.Type())
 	require.Nil(t, zeroBlock.InnerBlock)
 
-	// Export the WAL records before the node goes down.
-	var records [][]byte
-	node.wals.lock.Lock()
-	for _, w := range node.wals.wals {
-		walRecords, err := w.ReadAll()
-		require.NoError(t, err)
-		records = append(records, walRecords...)
-	}
-	node.wals.lock.Unlock()
-
-	// Crash the node
-	node.inst.Stop()
-
-	// Come back up over the same storage, restoring a WAL rebuilt from the exported records.
-	restoredWAL := testutil.NewTestWAL(t)
-	for _, record := range records {
-		require.NoError(t, restoredWAL.Append(record))
-	}
-	wc := &walCreator{t: t}
-	restarted := NewInstance(Config{
-		LastNonSimplexInnerBlock: genesisBlock,
-		ParameterConfig:          paramConfig,
-		PlatformChain:            pChain,
-		Broadcaster:              node.comm,
-		Sender:                   node.comm,
-		CryptoOps:                &testCryptoOps{},
-		WalCreator:               wc.createWAL,
-		Storage:                  node.storage,
-		Logger:                   testutil.MakeLogger(t, 1),
-		WALs:                     []wal.DeletableWAL{restoredWAL},
-		VM:                       node.vm,
-		ICMETransition:           noopICMTransition,
-		ID:                       validator.NodeID[:],
-	})
-	t.Cleanup(restarted.Stop)
-	require.NoError(t, restarted.Start(t.Context()), "a node that built the zero block cannot restart")
+	node.restart()
 
 	// The restarted node keeps the chain going.
-	network.pending.addPendingBlock()
-	node.storage.WaitForBlockCommit(2)
+	network.acceptNewBlock()
 }
 
 func TestInstanceDoubleStartFails(t *testing.T) {


### PR DESCRIPTION
This commit makes DeserializeBlock skip parsing an empty inner block when recovering from the WAL