### PR TITLE
msm: reject a built block whose epoch disagrees with its parent

### DIFF
--- a/msm/msm.go
+++ b/msm/msm.go
@@ -421,18 +421,29 @@ func (sm *StateMachine) BuildBlock(ctx context.Context, metadata common.Protocol
 	// we identify the current state by looking at the parent block's epoch info.
 	currentState := parentBlock.Metadata.SimplexEpochInfo.NextState()
 
+	var block *StateMachineBlock
 	switch currentState {
 	case stateFirstSimplexBlock:
-		return sm.buildBlockZero(parentBlock, metadata, blacklist)
+		block, err = sm.buildBlockZero(parentBlock, metadata, blacklist)
 	case stateBuildBlockNormalOp:
-		return sm.buildBlockNormalOp(ctx, &parentBlock, metadata, blacklist, prevBlockSeq)
+		block, err = sm.buildBlockNormalOp(ctx, &parentBlock, metadata, blacklist, prevBlockSeq)
 	case stateBuildCollectingApprovals:
-		return sm.buildBlockCollectingApprovals(ctx, &parentBlock, metadata, blacklist, prevBlockSeq)
+		block, err = sm.buildBlockCollectingApprovals(ctx, &parentBlock, metadata, blacklist, prevBlockSeq)
 	case stateBuildBlockEpochSealed:
-		return sm.buildBlockEpochSealed(ctx, &parentBlock, metadata, blacklist, prevBlockSeq)
+		block, err = sm.buildBlockEpochSealed(ctx, &parentBlock, metadata, blacklist, prevBlockSeq)
 	default:
 		return nil, fmt.Errorf("%w: %d", errUnknownState, currentState)
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure the epoch number of the built block matches the parent
+	if err := sm.verifyEpochNumber(block); err != nil {
+		return nil, err
+	}
+
+	return block, nil
 }
 
 // VerifyBlock validates a proposed block by checking its metadata, epoch info,

--- a/msm/msm_test.go
+++ b/msm/msm_test.go
@@ -229,6 +229,34 @@ func TestMSMBuildBlockRejectsZeroSeq(t *testing.T) {
 	require.Nil(t, block)
 }
 
+// TestMSMBuildBlockRejectsMismatchingEpoch asserts that a node refuses to build a block
+// whose ProtocolMetadata epoch disagrees with the epoch derived from its parent.
+func TestMSMBuildBlockRejectsMismatchingEpoch(t *testing.T) {
+	preSimplexParent := StateMachineBlock{
+		InnerBlock: &testutil.InnerBlock{
+			TS:          time.Now(),
+			BlockHeight: 42,
+			Content:     []byte{4, 5, 6},
+		},
+	}
+
+	sm, testConfig := newStateMachine(t)
+	testConfig.blockStore[42] = &outerBlock{block: preSimplexParent}
+	sm.LastNonSimplexInnerBlock = preSimplexParent.InnerBlock
+
+	// The parent sits at height 42, so the epoch derived from the chain is 43.
+	md := common.ProtocolMetadata{
+		Round: 0,
+		Seq:   43,
+		Epoch: 1,
+		Prev:  preSimplexParent.Digest(),
+	}
+
+	block, err := sm.BuildBlock(context.Background(), md, emptyBlacklist)
+	require.ErrorIs(t, err, errInvalidProtocolMetadataEpoch)
+	require.Nil(t, block)
+}
+
 func TestMSMNormalOp(t *testing.T) {
 	newPChainHeight := uint64(200)
 	newValidatorSet := NodeBLSMappings{


### PR DESCRIPTION
## Problem

`verifyEpochNumber` compares a block's `SimplexProtocolMetadata.Epoch` against its `SimplexEpochInfo.EpochNumber`. The two are derived independently — the consensus layer supplies the former, the block chain propagates the latter — but the check was only reachable from `verifyNonZeroBlock`.

So the build path never applied it. A node whose own epoch was wrong would build a block it would itself reject on receipt, broadcast it, and every peer would fail verification and empty-vote. Nothing pointed at the node that was actually wrong.

## Change

`BuildBlock` now assigns the built block from the state switch and runs `verifyEpochNumber` on it before returning. All four build states are covered, including `stateFirstSimplexBlock`, where `verifyBlockZero` has no epoch check of its own.

The check reuses the verifier's function rather than restating the comparison, so build and verify enforce the same predicate by construction and cannot drift.

### Why post-build rather than at entry

`BuildBlock` already holds the parent, so an up-front check looks cheaper. It does not work for `stateBuildBlockEpochSealed`: `areWeReadyToTransitionEpoch` reads storage and branches on `finalization != nil`, so from an identical parent the expected epoch is either `computeSimplexEpochInfoForTelock`'s (the parent's) or `computeSimplexEpochInfoForNewEpoch`'s (the sealing block sequence). A pre-build check would have to repeat that read and could race the real decision, rejecting a correct block if a finalization landed in between. Comparing against the value the block actually carries is exact.

## Transition blocks

Verified that this does not reject valid transition blocks. Sealing blocks and Telocks stay in the *old* epoch; the number advances only on the first block after the sealing block, and both fields advance together. Instrumented `BuildBlock` temporarily to log both values on every build and ran the transition tests: 46 builds, 0 mismatches, covering 12 sealing blocks, 2 Telocks, and 32 normal-op / collecting-approvals blocks. This is also what the diagram above `buildBlockZero` documents.

Independent of that data, `verifyEpochNumber` was already being called unconditionally for every non-zero state — sealing blocks and Telocks included — so the network has always required this equality on transition blocks.

## Test

`TestMSMBuildBlockRejectsMismatchingEpoch` builds a zero block on a height-42 pre-Simplex parent with `Epoch: 1` against a chain-derived 43. Confirmed non-vacuous: with the check removed it fails with `Target error should be in err chain`.

## Verification

`go build ./...` and `go vet ./...` clean. Passing: `TestMSMBuildBlockRejectsMismatchingEpoch`, `TestMSMBuildBlockRejectsZeroSeq`, `TestMSMFullEpochLifecycle`, `TestMSMNormalOp`, `TestMSMFirstSimplexBlockAfterPreSimplexBlocks`, `TestMSMBuildAndVerifyBlocksAfterGenesis`, `TestCollectingApprovalsAuxInfoGating`, and at instance level `TestValidatorValidatorSetDecreased`, `TestNonValidatorBecomesValidator`, `TestInstanceOfflineDuringTransition`, `TestValidatorRequestsGenesis`.

## Note

This check is what surfaced a live epoch-derivation bug on the `remove-epoch` branch, where dropping `EpochConfig.Epoch` left `Epoch.setMetadataFromStorage` deriving 0 instead of 1 for a genesis-only ledger. That fix is separate and not included here.
