### PR TITLE
Keep the first held vote for a round instead of the last

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -1202,8 +1202,6 @@ func (e *Epoch) storeFutureVote(message *common.Vote, from common.NodeID, round 
 		e.futureMessages[string(from)][round] = msgsForRound
 	}
 
-	// A node only gets to vote once per round. The vote is only verified once the round
-	// exists, so a second one must not displace the one we stored.
 	if msgsForRound.vote != nil {
 		e.Logger.Debug("Already received a vote from this node for the round",
 			zap.Stringer("NodeID", from), zap.Uint64("round", round))

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -1201,6 +1201,15 @@ func (e *Epoch) storeFutureVote(message *common.Vote, from common.NodeID, round 
 		msgsForRound = &messagesForRound{}
 		e.futureMessages[string(from)][round] = msgsForRound
 	}
+
+	// A node only gets to vote once per round. The vote is only verified once the round
+	// exists, so a second one must not displace the one we stored.
+	if msgsForRound.vote != nil {
+		e.Logger.Debug("Already received a vote from this node for the round",
+			zap.Stringer("NodeID", from), zap.Uint64("round", round))
+		return
+	}
+
 	msgsForRound.vote = message
 }
 

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -2740,3 +2740,59 @@ func TestEpochIgnoresReplicatedQuorumRoundsFromOtherEpochs(t *testing.T) {
 	testutil.WaitToEnterRound(t, e, md.Round+2)
 	require.Equal(t, int32(3), ignored.Load(), "quorum rounds from our own epoch must not be ignored")
 }
+
+// TestEpochVoteSentTwiceKeepsBufferedVote asserts that a node which voted before we had
+// the round cannot displace that vote by sending a second one. A held vote is only
+// verified once the round exists, so a second one that fails verification costs the round
+// a vote and no notarization is assembled.
+func TestEpochVoteSentTwiceKeepsBufferedVote(t *testing.T) {
+	bb := testutil.NewTestBlockBuilder()
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+
+	forged := []byte("forged signature")
+
+	// nodes[0] leads round 0, so we hold messages for that round until its proposal lands.
+	comm := &recordingComm{Communication: testutil.NewNoopComm(nodes), BroadcastMessages: make(chan *Message, 100)}
+	conf, _, _ := testutil.DefaultTestNodeEpochConfig(t, nodes[1], comm, bb)
+	conf.Verifier = &rejectingVerifier{rejected: forged}
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	b, ok := bb.BuildBlock(context.Background(), e.Metadata(), emptyBlacklist)
+	require.True(t, ok)
+	block := b.(Block)
+
+	// We have no round for these votes yet, so they are held without being verified.
+	vote, err := testutil.NewTestVote(block, nodes[2])
+	require.NoError(t, err)
+	require.NoError(t, e.HandleMessage(&Message{VoteMessage: vote}, nodes[2]))
+	require.NoError(t, e.HandleMessage(&Message{VoteMessage: &Vote{
+		Vote:      vote.Vote,
+		Signature: Signature{Signer: nodes[2], Value: forged},
+	}}, nodes[2]))
+
+	// The leader's proposal gives us the round along with its own vote, and the held vote
+	// is processed. Together with our own vote that is a quorum.
+	leaderVote, err := testutil.NewTestVote(block, nodes[0])
+	require.NoError(t, err)
+	require.NoError(t, e.HandleMessage(&Message{BlockMessage: &BlockMessage{
+		Vote:  *leaderVote,
+		Block: block,
+	}}, nodes[0]))
+
+	timeout := time.After(10 * time.Second)
+	for {
+		select {
+		case msg := <-comm.BroadcastMessages:
+			if msg.Notarization == nil {
+				continue
+			}
+			return
+		case <-timeout:
+			t.Fatal("timed out waiting for a notarization to be broadcast")
+		}
+	}
+}

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -2742,9 +2742,7 @@ func TestEpochIgnoresReplicatedQuorumRoundsFromOtherEpochs(t *testing.T) {
 }
 
 // TestEpochVoteSentTwiceKeepsBufferedVote asserts that a node which voted before we had
-// the round cannot displace that vote by sending a second one. A held vote is only
-// verified once the round exists, so a second one that fails verification costs the round
-// a vote and no notarization is assembled.
+// the round cannot displace that vote by sending a second one.
 func TestEpochVoteSentTwiceKeepsBufferedVote(t *testing.T) {
 	bb := testutil.NewTestBlockBuilder()
 	nodes := []NodeID{{1}, {2}, {3}, {4}}


### PR DESCRIPTION
Store only the first received vote in future messages. `TestEpochVoteSentTwiceKeepsVerifiedVote` was flaking without it.