### PR TITLE
fix TestWalWritesFinalization: wait for the block record before reading the WAL

### DIFF
--- a/simplex/recovery_test.go
+++ b/simplex/recovery_test.go
@@ -336,6 +336,9 @@ func TestWalWritesFinalization(t *testing.T) {
 	for i := 1; i < quorum; i++ {
 		testutil.InjectTestVote(t, e, firstBlock, nodes[i])
 	}
+
+	wal.AssertWALSize(2)
+
 	records, err := e.WAL.ReadAll()
 	require.NoError(t, err)
 	require.Len(t, records, 2)


### PR DESCRIPTION
`TestWalWritesFinalization` read the WAL without waiting for it to be written, so it could observe an empty WAL and fail with `"[]" should have 2 item(s), but has 0`.

`Start` schedules block building on `buildBlockScheduler`, a separate goroutine. That task calls `BuildBlock`, which pushes the block onto the test builder's `built` channel and returns, so `GetBuiltBlock` unblocks the test there. The task then still has to take the epoch lock and call `proposeBlock` -> `storeProposal`, which is where the block record actually reaches the WAL. `GetBuiltBlock` returning is not a happens-before edge for that append, so the test could race ahead and read an empty WAL.

Fixed by waiting on `AssertWALSize(2)` before the read, which is what the same test already does before its second read and what `TestWalWritesBlockRecord` does before its own.

The test's third read needs no wait: that finalization record is appended by `persistFinalization` on the synchronous `HandleMessage` path, so it is written before `InjectTestFinalizeVote` returns.

Pre-existing on main, not introduced by any open PR. Surfaced in CI on an unrelated PR's run.

## Verification

Reproduced on clean `origin/main` by wrapping the test body in a 20-iteration loop and running under `-race` with `GOMAXPROCS=4`; it failed on iteration 6 with the same message. With the fix, 3 runs x 20 iterations were clean, then the loop was removed and the test re-run clean.