### PR TITLE
Remove the Epoch From Simplex Epoch Info

### DIFF
--- a/msm/block_test.go
+++ b/msm/block_test.go
@@ -21,7 +21,6 @@ func TestIdentifyBlockType(t *testing.T) {
 		{
 			name: "zero block: descriptor set, empty prev sealing block hash",
 			sei: SimplexEpochInfo{
-				EpochNumber:               1,
 				BlockValidationDescriptor: bvd,
 			},
 			expected: BlockTypeZero,
@@ -29,7 +28,6 @@ func TestIdentifyBlockType(t *testing.T) {
 		{
 			name: "sealing block: descriptor set, prev sealing block hash set",
 			sei: SimplexEpochInfo{
-				EpochNumber:               1,
 				NextPChainReferenceHeight: 200,
 				BlockValidationDescriptor: bvd,
 				PrevSealingBlockHash:      prevSealingBlockHash,
@@ -39,7 +37,6 @@ func TestIdentifyBlockType(t *testing.T) {
 		{
 			name: "telock: sealing block seq set, no descriptor",
 			sei: SimplexEpochInfo{
-				EpochNumber:               1,
 				NextPChainReferenceHeight: 200,
 				SealingBlockSeq:           8,
 			},
@@ -48,22 +45,18 @@ func TestIdentifyBlockType(t *testing.T) {
 		{
 			name: "transitioning block: next p-chain reference height set, epoch not yet sealed",
 			sei: SimplexEpochInfo{
-				EpochNumber:               1,
 				NextPChainReferenceHeight: 200,
 			},
 			expected: BlockTypeTransitioning,
 		},
 		{
-			name: "normal block in the middle of an epoch",
-			sei: SimplexEpochInfo{
-				EpochNumber: 5,
-			},
+			name:     "normal block in the middle of an epoch",
+			sei:      SimplexEpochInfo{},
 			expected: BlockTypeNormal,
 		},
 		{
 			name: "first block of a new epoch is a normal block",
 			sei: SimplexEpochInfo{
-				EpochNumber:           8,
 				PChainReferenceHeight: 200,
 			},
 			expected: BlockTypeNormal,

--- a/msm/encoding.canoto.go
+++ b/msm/encoding.canoto.go
@@ -633,20 +633,20 @@ func (c *ICMEpochInfo) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 
 const (
 	canotoNumber_SimplexEpochInfo__PChainReferenceHeight     = 1
-	canotoNumber_SimplexEpochInfo__PrevSealingBlockHash      = 3
-	canotoNumber_SimplexEpochInfo__NextPChainReferenceHeight = 4
-	canotoNumber_SimplexEpochInfo__PrevVMBlockSeq            = 5
-	canotoNumber_SimplexEpochInfo__BlockValidationDescriptor = 6
-	canotoNumber_SimplexEpochInfo__NextEpochApprovals        = 7
-	canotoNumber_SimplexEpochInfo__SealingBlockSeq           = 8
+	canotoNumber_SimplexEpochInfo__PrevSealingBlockHash      = 2
+	canotoNumber_SimplexEpochInfo__NextPChainReferenceHeight = 3
+	canotoNumber_SimplexEpochInfo__PrevVMBlockSeq            = 4
+	canotoNumber_SimplexEpochInfo__BlockValidationDescriptor = 5
+	canotoNumber_SimplexEpochInfo__NextEpochApprovals        = 6
+	canotoNumber_SimplexEpochInfo__SealingBlockSeq           = 7
 
 	canotoTag_SimplexEpochInfo__PChainReferenceHeight     = "\x08" // canoto.Tag(canotoNumber_SimplexEpochInfo__PChainReferenceHeight, canoto.Varint)
-	canotoTag_SimplexEpochInfo__PrevSealingBlockHash      = "\x1a" // canoto.Tag(canotoNumber_SimplexEpochInfo__PrevSealingBlockHash, canoto.Len)
-	canotoTag_SimplexEpochInfo__NextPChainReferenceHeight = "\x20" // canoto.Tag(canotoNumber_SimplexEpochInfo__NextPChainReferenceHeight, canoto.Varint)
-	canotoTag_SimplexEpochInfo__PrevVMBlockSeq            = "\x28" // canoto.Tag(canotoNumber_SimplexEpochInfo__PrevVMBlockSeq, canoto.Varint)
-	canotoTag_SimplexEpochInfo__BlockValidationDescriptor = "\x32" // canoto.Tag(canotoNumber_SimplexEpochInfo__BlockValidationDescriptor, canoto.Len)
-	canotoTag_SimplexEpochInfo__NextEpochApprovals        = "\x3a" // canoto.Tag(canotoNumber_SimplexEpochInfo__NextEpochApprovals, canoto.Len)
-	canotoTag_SimplexEpochInfo__SealingBlockSeq           = "\x40" // canoto.Tag(canotoNumber_SimplexEpochInfo__SealingBlockSeq, canoto.Varint)
+	canotoTag_SimplexEpochInfo__PrevSealingBlockHash      = "\x12" // canoto.Tag(canotoNumber_SimplexEpochInfo__PrevSealingBlockHash, canoto.Len)
+	canotoTag_SimplexEpochInfo__NextPChainReferenceHeight = "\x18" // canoto.Tag(canotoNumber_SimplexEpochInfo__NextPChainReferenceHeight, canoto.Varint)
+	canotoTag_SimplexEpochInfo__PrevVMBlockSeq            = "\x20" // canoto.Tag(canotoNumber_SimplexEpochInfo__PrevVMBlockSeq, canoto.Varint)
+	canotoTag_SimplexEpochInfo__BlockValidationDescriptor = "\x2a" // canoto.Tag(canotoNumber_SimplexEpochInfo__BlockValidationDescriptor, canoto.Len)
+	canotoTag_SimplexEpochInfo__NextEpochApprovals        = "\x32" // canoto.Tag(canotoNumber_SimplexEpochInfo__NextEpochApprovals, canoto.Len)
+	canotoTag_SimplexEpochInfo__SealingBlockSeq           = "\x38" // canoto.Tag(canotoNumber_SimplexEpochInfo__SealingBlockSeq, canoto.Varint)
 )
 
 type canotoData_SimplexEpochInfo struct {

--- a/msm/encoding.canoto.go
+++ b/msm/encoding.canoto.go
@@ -633,7 +633,6 @@ func (c *ICMEpochInfo) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 
 const (
 	canotoNumber_SimplexEpochInfo__PChainReferenceHeight     = 1
-	canotoNumber_SimplexEpochInfo__EpochNumber               = 2
 	canotoNumber_SimplexEpochInfo__PrevSealingBlockHash      = 3
 	canotoNumber_SimplexEpochInfo__NextPChainReferenceHeight = 4
 	canotoNumber_SimplexEpochInfo__PrevVMBlockSeq            = 5
@@ -642,7 +641,6 @@ const (
 	canotoNumber_SimplexEpochInfo__SealingBlockSeq           = 8
 
 	canotoTag_SimplexEpochInfo__PChainReferenceHeight     = "\x08" // canoto.Tag(canotoNumber_SimplexEpochInfo__PChainReferenceHeight, canoto.Varint)
-	canotoTag_SimplexEpochInfo__EpochNumber               = "\x10" // canoto.Tag(canotoNumber_SimplexEpochInfo__EpochNumber, canoto.Varint)
 	canotoTag_SimplexEpochInfo__PrevSealingBlockHash      = "\x1a" // canoto.Tag(canotoNumber_SimplexEpochInfo__PrevSealingBlockHash, canoto.Len)
 	canotoTag_SimplexEpochInfo__NextPChainReferenceHeight = "\x20" // canoto.Tag(canotoNumber_SimplexEpochInfo__NextPChainReferenceHeight, canoto.Varint)
 	canotoTag_SimplexEpochInfo__PrevVMBlockSeq            = "\x28" // canoto.Tag(canotoNumber_SimplexEpochInfo__PrevVMBlockSeq, canoto.Varint)
@@ -667,12 +665,6 @@ func (*SimplexEpochInfo) CanotoSpec(types ...reflect.Type) *canoto.Spec {
 				Name:        "PChainReferenceHeight",
 				OneOf:       "",
 				TypeUint:    canoto.SizeOf(zero.PChainReferenceHeight),
-			},
-			{
-				FieldNumber: canotoNumber_SimplexEpochInfo__EpochNumber,
-				Name:        "EpochNumber",
-				OneOf:       "",
-				TypeUint:    canoto.SizeOf(zero.EpochNumber),
 			},
 			{
 				FieldNumber:    canotoNumber_SimplexEpochInfo__PrevSealingBlockHash,
@@ -765,17 +757,6 @@ func (c *SimplexEpochInfo) UnmarshalCanotoFrom(r canoto.Reader) error {
 				return err
 			}
 			if canoto.IsZero(c.PChainReferenceHeight) {
-				return canoto.ErrZeroValue
-			}
-		case canotoNumber_SimplexEpochInfo__EpochNumber:
-			if wireType != canoto.Varint {
-				return canoto.ErrUnexpectedWireType
-			}
-
-			if err := canoto.ReadUint(&r, &c.EpochNumber); err != nil {
-				return err
-			}
-			if canoto.IsZero(c.EpochNumber) {
 				return canoto.ErrZeroValue
 			}
 		case canotoNumber_SimplexEpochInfo__PrevSealingBlockHash:
@@ -915,9 +896,6 @@ func (c *SimplexEpochInfo) CalculateCanotoCache() {
 	if !canoto.IsZero(c.PChainReferenceHeight) {
 		size += uint64(len(canotoTag_SimplexEpochInfo__PChainReferenceHeight)) + canoto.SizeUint(c.PChainReferenceHeight)
 	}
-	if !canoto.IsZero(c.EpochNumber) {
-		size += uint64(len(canotoTag_SimplexEpochInfo__EpochNumber)) + canoto.SizeUint(c.EpochNumber)
-	}
 	if !canoto.IsZero(c.PrevSealingBlockHash) {
 		size += uint64(len(canotoTag_SimplexEpochInfo__PrevSealingBlockHash)) + canoto.SizeBytes((&c.PrevSealingBlockHash)[:])
 	}
@@ -981,10 +959,6 @@ func (c *SimplexEpochInfo) MarshalCanotoInto(w canoto.Writer) canoto.Writer {
 	if !canoto.IsZero(c.PChainReferenceHeight) {
 		canoto.Append(&w, canotoTag_SimplexEpochInfo__PChainReferenceHeight)
 		canoto.AppendUint(&w, c.PChainReferenceHeight)
-	}
-	if !canoto.IsZero(c.EpochNumber) {
-		canoto.Append(&w, canotoTag_SimplexEpochInfo__EpochNumber)
-		canoto.AppendUint(&w, c.EpochNumber)
 	}
 	if !canoto.IsZero(c.PrevSealingBlockHash) {
 		canoto.Append(&w, canotoTag_SimplexEpochInfo__PrevSealingBlockHash)

--- a/msm/encoding.go
+++ b/msm/encoding.go
@@ -98,25 +98,25 @@ type SimplexEpochInfo struct {
 	// the hash of the sealing block of the previous epoch.
 	// This is used to be able to quickly fetch and verify the sealing blocks without having to retrieve the interleaving blocks,
 	// which allows to bootstrap the BLS keys of the validator set for each epoch before fully syncing the interleaving blocks.
-	PrevSealingBlockHash [32]byte `canoto:"fixed bytes,3"`
+	PrevSealingBlockHash [32]byte `canoto:"fixed bytes,2"`
 	// NextPChainReferenceHeight is the P-Chain height that the StateMachine uses as a reference for the next epoch.
 	// When the NextPChainReferenceHeight is > 0, it means the StateMachine is on its way to transition to a new epoch
 	// in which the validator set will be based on the given P-chain height.
 	// It sets the PChainReferenceHeight for the next epoch.
-	NextPChainReferenceHeight uint64 `canoto:"uint,4"`
+	NextPChainReferenceHeight uint64 `canoto:"uint,3"`
 	// PrevVMBlockSeq is the block sequence of the previous block that has a VM block (inner block).
 	// This is used to know on which VM block to build the next block.
-	PrevVMBlockSeq uint64 `canoto:"uint,5"`
+	PrevVMBlockSeq uint64 `canoto:"uint,4"`
 	// BlockValidationDescriptor is the metadata that describes the validator set of the next epoch.
 	// It is only set in the sealing block and zero block, and nil in all other blocks.
-	BlockValidationDescriptor *BlockValidationDescriptor `canoto:"pointer,6"`
+	BlockValidationDescriptor *BlockValidationDescriptor `canoto:"pointer,5"`
 	// NextEpochApprovals is the metadata that contains the approvals from validators for the next epoch.
 	// It is set only in the sealing block and the blocks preceding it starting from a block that has a NextPChainReferenceHeight set.
-	NextEpochApprovals *NextEpochApprovals `canoto:"pointer,7"`
+	NextEpochApprovals *NextEpochApprovals `canoto:"pointer,6"`
 	// SealingBlockSeq is the block sequence of the sealing block of the current epoch.
 	// It defines the validator set of the next epoch.
 	// It is set once the first Telock is built and is copied over to subsequent Telocks.
-	SealingBlockSeq uint64 `canoto:"uint,8"`
+	SealingBlockSeq uint64 `canoto:"uint,7"`
 
 	canotoData canotoData_SimplexEpochInfo
 }

--- a/msm/encoding.go
+++ b/msm/encoding.go
@@ -83,7 +83,7 @@ func (ei *ICMEpochInfo) Equal(other *ICMEpochInfo) bool {
 		return other == nil
 	}
 	if other == nil {
-		return ei == nil
+		return false
 	}
 	return ei.EpochStartTime == other.EpochStartTime && ei.EpochNumber == other.EpochNumber && ei.PChainEpochHeight == other.PChainEpochHeight
 }
@@ -93,10 +93,6 @@ type SimplexEpochInfo struct {
 	// PChainReferenceHeight is the P-Chain height that the StateMachine uses as a reference for the current epoch.
 	// The validator set is determined based on the validators on the P-Chain at the PChainReferenceHeight.
 	PChainReferenceHeight uint64 `canoto:"uint,1"`
-	// EpochNumber is the current epoch number.
-	// The first epoch is numbered 1, and each successive epoch is numbered according to the block sequence
-	// of the sealing block of the previous epoch.
-	EpochNumber uint64 `canoto:"uint,2"`
 	// PrevSealingBlockHash is the hash of the sealing block of the previous epoch.
 	// It is set to the hash of the zero block in the first epoch, and in subsequent epochs it is set to be
 	// the hash of the sealing block of the previous epoch.
@@ -130,7 +126,6 @@ type SimplexEpochInfo struct {
 func (sei *SimplexEpochInfo) Clone() SimplexEpochInfo {
 	return SimplexEpochInfo{
 		PChainReferenceHeight:     sei.PChainReferenceHeight,
-		EpochNumber:               sei.EpochNumber,
 		PrevSealingBlockHash:      sei.PrevSealingBlockHash,
 		NextPChainReferenceHeight: sei.NextPChainReferenceHeight,
 		PrevVMBlockSeq:            sei.PrevVMBlockSeq,
@@ -165,7 +160,7 @@ func (sei *SimplexEpochInfo) Equal(other *SimplexEpochInfo) bool {
 		return false
 	}
 
-	if sei.PChainReferenceHeight != other.PChainReferenceHeight || sei.EpochNumber != other.EpochNumber ||
+	if sei.PChainReferenceHeight != other.PChainReferenceHeight ||
 		sei.NextPChainReferenceHeight != other.NextPChainReferenceHeight ||
 		sei.PrevVMBlockSeq != other.PrevVMBlockSeq || sei.SealingBlockSeq != other.SealingBlockSeq {
 		return false
@@ -183,10 +178,12 @@ func (sei *SimplexEpochInfo) Equal(other *SimplexEpochInfo) bool {
 }
 
 // NextState returns the state used to build (or verify) the block that follows the one
-// described by the SimplexEpochInfo.
-func (sei *SimplexEpochInfo) NextState() state {
+// described by the metadata.
+func (smm *StateMachineMetadata) NextState() state {
+	sei := &smm.SimplexEpochInfo
+
 	// No Simplex epoch has started yet: the next block is the first one built by Simplex.
-	if sei.EpochNumber == 0 {
+	if smm.SimplexProtocolMetadata.Epoch == 0 {
 		return stateFirstSimplexBlock
 	}
 

--- a/msm/encoding_test.go
+++ b/msm/encoding_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestSimplexEpochInfoIsZero(t *testing.T) {
 	require.True(t, (&SimplexEpochInfo{}).IsZero())
-	require.False(t, (&SimplexEpochInfo{EpochNumber: 1}).IsZero())
 	require.False(t, (&SimplexEpochInfo{PChainReferenceHeight: 1}).IsZero())
 }
 
@@ -56,7 +55,6 @@ func TestSimplexEpochInfoEqual(t *testing.T) {
 			name: "equal with all fields",
 			a: &SimplexEpochInfo{
 				PChainReferenceHeight:     10,
-				EpochNumber:               2,
 				PrevSealingBlockHash:      hash1,
 				NextPChainReferenceHeight: 20,
 				PrevVMBlockSeq:            5,
@@ -64,7 +62,6 @@ func TestSimplexEpochInfoEqual(t *testing.T) {
 			},
 			b: &SimplexEpochInfo{
 				PChainReferenceHeight:     10,
-				EpochNumber:               2,
 				PrevSealingBlockHash:      hash1,
 				NextPChainReferenceHeight: 20,
 				PrevVMBlockSeq:            5,
@@ -76,12 +73,6 @@ func TestSimplexEpochInfoEqual(t *testing.T) {
 			name:     "different PChainReferenceHeight",
 			a:        &SimplexEpochInfo{PChainReferenceHeight: 1},
 			b:        &SimplexEpochInfo{PChainReferenceHeight: 2},
-			expected: false,
-		},
-		{
-			name:     "different EpochNumber",
-			a:        &SimplexEpochInfo{EpochNumber: 1},
-			b:        &SimplexEpochInfo{EpochNumber: 2},
 			expected: false,
 		},
 		{

--- a/msm/fake_node_test.go
+++ b/msm/fake_node_test.go
@@ -324,7 +324,7 @@ func (fn *fakeNode) Height() uint64 {
 }
 
 func (fn *fakeNode) Epoch() uint64 {
-	return fn.blocks[len(fn.blocks)-1].block.Metadata.SimplexEpochInfo.EpochNumber
+	return fn.blocks[len(fn.blocks)-1].block.Metadata.SimplexProtocolMetadata.Epoch
 }
 
 func (fn *fakeNode) act() {
@@ -366,7 +366,7 @@ func (fn *fakeNode) tryFinalizeNextBlock() {
 	md := block.Metadata.SimplexProtocolMetadata
 
 	fn.sm.LatestPersistedHeight = md.Seq
-	fn.t.Logf("Finalized block at height %d with epoch %d", md.Seq, block.Metadata.SimplexEpochInfo.EpochNumber)
+	fn.t.Logf("Finalized block at height %d with epoch %d", md.Seq, md.Epoch)
 
 	// If we just finalized a sealing block, trim trailing Telock blocks.
 	if block.Metadata.SimplexEpochInfo.BlockValidationDescriptor != nil {
@@ -413,7 +413,7 @@ func (fn *fakeNode) buildBlock() (avalanchego.VMBlock, *StateMachineBlock) {
 		finalizedString = "finalized"
 	}
 
-	fn.t.Logf("Building a block on top of %s parent with epoch %d", finalizedString, parentBlock.Metadata.SimplexEpochInfo.EpochNumber)
+	fn.t.Logf("Building a block on top of %s parent with epoch %d", finalizedString, parentBlock.Metadata.SimplexProtocolMetadata.Epoch)
 
 	block, err := fn.sm.BuildBlock(context.Background(), common.ProtocolMetadata{
 		Seq:   lastMD.Seq + 1,

--- a/msm/fuzz_test.go
+++ b/msm/fuzz_test.go
@@ -40,8 +40,8 @@ var authoritativeFields = []authoritativeField{
 	{"SimplexEpochInfo.PChainReferenceHeight", func(m *StateMachineMetadata, v uint64) {
 		m.SimplexEpochInfo.PChainReferenceHeight = v
 	}},
-	{"SimplexEpochInfo.EpochNumber", func(m *StateMachineMetadata, v uint64) {
-		m.SimplexEpochInfo.EpochNumber = v
+	{"SimplexProtocolMetadata.Epoch", func(m *StateMachineMetadata, v uint64) {
+		m.SimplexProtocolMetadata.Epoch = v
 	}},
 	{"SimplexEpochInfo.PrevVMBlockSeq", func(m *StateMachineMetadata, v uint64) {
 		m.SimplexEpochInfo.PrevVMBlockSeq = v
@@ -276,7 +276,7 @@ func buildEpochChain(tb testing.TB, logger common.Logger) ([]*StateMachineBlock,
 	currentTime = startTime.Add(time.Second + 6*time.Millisecond)
 	tc.blockBuilder.Block = nextInner(6)
 	block6 := build(6, 5, 1, block5)
-	require.Equal(tb, stateBuildBlockEpochSealed, block6.Metadata.SimplexEpochInfo.NextState())
+	require.Equal(tb, stateBuildBlockEpochSealed, block6.Metadata.NextState())
 	// Finalize the sealing block so the epoch transition can proceed.
 	addBlock(6, block6, &common.Finalization{})
 

--- a/msm/msm.go
+++ b/msm/msm.go
@@ -26,7 +26,7 @@ const (
 
 // state encodes the different stages of the epoch transition process, which determines how we build and verify blocks.
 //
-// SimplexEpochInfo.NextState() inspects the parent block's metadata to perform the following state transitions:
+// StateMachineMetadata.NextState() inspects the parent block's metadata to perform the following state transitions:
 //
 //	 (initial state: No Simplex blocks yet)
 //	                  │
@@ -57,7 +57,7 @@ const (
 //	│    stateBuildBlockEpochSealed     │     not finalized yet         │               │
 //	│  emits Telock (no inner block)    │ ──────────────────────────────┘               │
 //	│  until the sealing block is       │                                               │
-//	│  finalized; then opens the new    │ ─── new epoch (EpochNumber advanced) ─────────┘
+//	│  finalized; then opens the new    │ ─── new epoch ────────────────────────────────┘
 //	│  epoch                            │
 //	└───────────────────────────────────┘
 
@@ -326,7 +326,7 @@ func (sm *StateMachine) WaitForPendingBlock(ctx context.Context, currentRoundMet
 		lastBlockSeq = sealingBlockSeq
 	}
 
-	currentState := lastBlock.Metadata.SimplexEpochInfo.NextState()
+	currentState := lastBlock.Metadata.NextState()
 
 	// We first check if we have obvious signs that we need to build a block immediately:
 	var shouldObviouslyBuildBlockImmediately bool
@@ -429,7 +429,7 @@ func (sm *StateMachine) BuildBlock(ctx context.Context, metadata common.Protocol
 
 	// In order to know where in the epoch change process we are,
 	// we identify the current state by looking at the parent block's epoch info.
-	currentState := parentBlock.Metadata.SimplexEpochInfo.NextState()
+	currentState := parentBlock.Metadata.NextState()
 
 	switch currentState {
 	case stateFirstSimplexBlock:
@@ -467,7 +467,7 @@ func (sm *StateMachine) VerifyBlock(ctx context.Context, block *StateMachineBloc
 	}
 
 	prevMD := prevBlock.Metadata
-	currentState := prevMD.SimplexEpochInfo.NextState()
+	currentState := prevMD.NextState()
 
 	switch currentState {
 	case stateFirstSimplexBlock:
@@ -480,7 +480,7 @@ func (sm *StateMachine) VerifyBlock(ctx context.Context, block *StateMachineBloc
 
 func (sm *StateMachine) verifyNonZeroBlock(ctx context.Context, block, prevBlock *StateMachineBlock, prevSeq uint64) error {
 	prevBlockMD := prevBlock.Metadata
-	currentState := prevBlockMD.SimplexEpochInfo.NextState()
+	currentState := prevBlockMD.NextState()
 
 	if err := verifyTimestamp(block, prevBlock, sm.GetTime(), sm.TimeSkewLimit); err != nil {
 		return fmt.Errorf("failed to verify timestamp: %w", err)
@@ -492,10 +492,6 @@ func (sm *StateMachine) verifyNonZeroBlock(ctx context.Context, block, prevBlock
 
 	if err := verifyPChainHeight(proposedPChainHeight, currentPChainHeight, prevPChainHeight); err != nil {
 		return fmt.Errorf("failed to verify P-chain height: %w", err)
-	}
-
-	if err := sm.verifyEpochNumber(block); err != nil {
-		return err
 	}
 
 	switch currentState {
@@ -527,18 +523,10 @@ func verifyTimestamp(block *StateMachineBlock, prevBlock *StateMachineBlock, now
 	return nil
 }
 
-func (sm *StateMachine) verifyEpochNumber(block *StateMachineBlock) error {
-	md := block.Metadata.SimplexProtocolMetadata
-	if md.Epoch != block.Metadata.SimplexEpochInfo.EpochNumber {
-		return fmt.Errorf("%w: got %d, expected %d", errInvalidProtocolMetadataEpoch, md.Epoch, block.Metadata.SimplexEpochInfo.EpochNumber)
-	}
-	return nil
-}
-
 // buildBlockNormalOp builds a block while potentially also transitioning to a new epoch, depending on the P-chain.
 //
-// Relevant SimplexEpochInfo fields (PCH = PChainReferenceHeight,
-// EN = EpochNumber, NPCH = NextPChainReferenceHeight):
+// Relevant fields (PCH = PChainReferenceHeight, NPCH = NextPChainReferenceHeight,
+// EN = SimplexProtocolMetadata.Epoch):
 //
 //	parent (NormalOp)            validator set unchanged    validator set changed at p'
 //	┌─────────────────┐          ┌─────────────────┐        ┌─────────────────┐
@@ -552,7 +540,6 @@ func (sm *StateMachine) buildBlockNormalOp(ctx context.Context, parentBlock *Sta
 	// the P-chain reference height and epoch of the new block should remain the same.
 	newSimplexEpochInfo := SimplexEpochInfo{
 		PChainReferenceHeight: parentBlock.Metadata.SimplexEpochInfo.PChainReferenceHeight,
-		EpochNumber:           parentBlock.Metadata.SimplexEpochInfo.EpochNumber,
 		PrevVMBlockSeq:        computePrevVMBlockSeq(parentBlock, prevBlockSeq),
 	}
 
@@ -595,7 +582,7 @@ func (sm *StateMachine) buildBlockOrTransitionEpoch(ctx context.Context, parentB
 		zap.Uint64("P-chain height", decisionToBuildBlock.pChainHeight))
 
 	if decisionToBuildBlock.transitionEpoch {
-		sealingBlockSeq := parentBlock.Metadata.SimplexEpochInfo.EpochNumber
+		sealingBlockSeq := parentBlock.Metadata.SimplexProtocolMetadata.Epoch
 		if parentBlock.Type() == BlockTypeSealing {
 			sealingBlockSeq = parentBlock.Metadata.SimplexProtocolMetadata.Seq
 		}
@@ -657,13 +644,18 @@ func verifyAgainstExpected(
 	ctx context.Context,
 	innerBlock avalanchego.VMBlock,
 	expectedSimplexEpochInfo SimplexEpochInfo,
+	expectedEpoch uint64,
 	expectedPChainHeight uint64,
 	nextBlock *StateMachineBlock,
 	timestamp time.Time,
 	expectedIcmEpochInfo ICMEpochInfo,
 	auxInfo *AuxiliaryInfoBatch,
 ) error {
-	// First verify the metadata matches the expected values, only afterwards verify the inner block, if any.
+	if epoch := nextBlock.Metadata.SimplexProtocolMetadata.Epoch; epoch != expectedEpoch {
+		return fmt.Errorf("%w: got %d, expected %d", errInvalidProtocolMetadataEpoch, epoch, expectedEpoch)
+	}
+
+	// Verify the metadata matches the expected values, only afterwards verify the inner block, if any.
 	expectedBlock := wrapBlock(
 		innerBlock, expectedSimplexEpochInfo, expectedPChainHeight,
 		nextBlock.Metadata.SimplexProtocolMetadata, nextBlock.Metadata.SimplexBlacklist, timestamp, expectedIcmEpochInfo, auxInfo)
@@ -685,7 +677,6 @@ func verifyAgainstExpected(
 func (sm *StateMachine) verifyNormalBlock(ctx context.Context, parentBlock *StateMachineBlock, nextBlock *StateMachineBlock, prevBlockSeq uint64) error {
 	newSimplexEpochInfo := SimplexEpochInfo{
 		PChainReferenceHeight: parentBlock.Metadata.SimplexEpochInfo.PChainReferenceHeight,
-		EpochNumber:           parentBlock.Metadata.SimplexEpochInfo.EpochNumber,
 		PrevVMBlockSeq:        computePrevVMBlockSeq(parentBlock, prevBlockSeq),
 	}
 
@@ -700,7 +691,7 @@ func (sm *StateMachine) verifyNormalBlock(ctx context.Context, parentBlock *Stat
 	}
 	newSimplexEpochInfo.NextPChainReferenceHeight = nextBlock.Metadata.SimplexEpochInfo.NextPChainReferenceHeight
 
-	return verifyAgainstExpected(ctx, nextBlock.InnerBlock, newSimplexEpochInfo, proposedPChainHeight, nextBlock, timestamp, icmEpochInfo, nil)
+	return verifyAgainstExpected(ctx, nextBlock.InnerBlock, newSimplexEpochInfo, parentBlock.Metadata.SimplexProtocolMetadata.Epoch, proposedPChainHeight, nextBlock, timestamp, icmEpochInfo, nil)
 }
 
 func verifyPChainHeight(proposedPChainHeight uint64, currentPChainHeight uint64, prevPChainHeight uint64) error {
@@ -737,7 +728,7 @@ func (sm *StateMachine) verifyNextPChainRefHeightNormal(parentBlock *StateMachin
 	// If the previous block's next P-chain reference height is 0, and the new block's next P-chain reference height is > 0,
 	// we need to ensure that we have finalized the sealing block of the previous epoch.
 	if next.NextPChainReferenceHeight > 0 {
-		sealingBlockSeq := prev.EpochNumber
+		sealingBlockSeq := prevMD.SimplexProtocolMetadata.Epoch
 		_, finalization, err := sm.GetBlock(sealingBlockSeq, [32]byte{})
 		if err != nil {
 			return fmt.Errorf("failed to retrieve sealing block for previous epoch (%d): %w", sealingBlockSeq, err)
@@ -863,8 +854,8 @@ func (sm *StateMachine) createBlockBuildingDecider(currentValidatorSet NodeBLSMa
 // buildBlockZero builds the first ever block for Simplex,
 // which is a special block that introduces the first validator set and starts the first epoch.
 //
-// How EpochNumber (EN), PrevSealingBlockHash (PSH), and SealingBlockSeq (SBS)
-// evolve along the block chain (Seq = block sequence number; h(n) = digest of
+// How the epoch (EN, carried in SimplexProtocolMetadata), PrevSealingBlockHash (PSH),
+// and SealingBlockSeq (SBS) evolve along the block chain (Seq = block sequence number; h(n) = digest of
 // the block at sequence n):
 //
 //		────────────────── Epoch 1 ────────────────────────────────────│─── Epoch s ────
@@ -914,10 +905,6 @@ func (sm *StateMachine) buildBlockZero(parentBlock StateMachineBlock, simplexMet
 	timestamp := sm.LastNonSimplexInnerBlock.Timestamp().UnixMilli()
 	simplexEpochInfo := constructSimplexZeroBlockSimplexEpochInfo(pChainHeight, validatorSet, prevVMBlockSeq)
 
-	md := simplexMetadata
-	md.Prev = sm.LastNonSimplexInnerBlock.Digest()
-	md.Seq = sm.LastNonSimplexInnerBlock.Height()
-
 	// The zero block carries over the parent's ICM epoch unchanged, just as it carries over the
 	// timestamp. If the parent is a genesis block that predates ICM, the carried-over epoch is empty,
 	// and the first ICM epoch begins on the block built on top of the zero block.
@@ -950,6 +937,12 @@ func (sm *StateMachine) verifyBlockZero(block *StateMachineBlock, prevBlock Stat
 	if block.Metadata.PChainHeight != pChainHeight {
 		return fmt.Errorf("%w: got %d, expected %d",
 			errInvalidPChainHeight, block.Metadata.PChainHeight, pChainHeight)
+	}
+
+	// The zero block opens the first epoch, which is numbered after the zero block's own sequence.
+	expectedEpoch := prevVMBlockSeq + 1
+	if epoch := block.Metadata.SimplexProtocolMetadata.Epoch; epoch != expectedEpoch {
+		return fmt.Errorf("%w: got %d, expected %d", errInvalidProtocolMetadataEpoch, epoch, expectedEpoch)
 	}
 
 	var expectedValidatorSet NodeBLSMappings
@@ -1008,7 +1001,7 @@ func (sm *StateMachine) verifyBlockZero(block *StateMachineBlock, prevBlock Stat
 // buildBlockCollectingApprovals builds either another collecting-approvals block (if not enough approvals yet)
 // or a sealing block (if quorum is reached).
 //
-// Relevant SimplexEpochInfo fields (EN = EpochNumber, NPCH = NextPChainReferenceHeight,
+// Relevant fields (EN = SimplexProtocolMetadata.Epoch, NPCH = NextPChainReferenceHeight,
 // NEA = NextEpochApprovals, BVD = BlockValidationDescriptor, PSH = PrevSealingBlockHash):
 //
 //	parent (Collecting)              not enough approvals yet           quorum of approvals reached: sealing block
@@ -1054,6 +1047,9 @@ func (sm *StateMachine) buildBlockCollectingApprovals(ctx context.Context, paren
 
 	newSimplexEpochInfo := computeSimplexEpochInfoForCollectingApprovalsBlock(parentBlock, prevBlockSeq, newApprovals)
 
+	// The block being built belongs to the epoch of its parent, as the epoch only advances
+	// once the sealing block that follows is finalized.
+	parentEpoch := parentBlock.Metadata.SimplexProtocolMetadata.Epoch
 	pChainHeight := parentBlock.Metadata.PChainHeight
 
 	now := sm.GetTime()
@@ -1073,12 +1069,13 @@ func (sm *StateMachine) buildBlockCollectingApprovals(ctx context.Context, paren
 	sm.Logger.Debug("Have enough approvals to seal epoch, building sealing block")
 
 	// Else, we have enough approvals to seal the epoch, so we create the sealing block.
-	return sm.createSealingBlock(ctx, now, simplexMetadata, simplexBlacklist, newSimplexEpochInfo, pChainHeight, icmEpochInfo, auxInfo)
+	return sm.createSealingBlock(ctx, now, simplexMetadata, simplexBlacklist, newSimplexEpochInfo, parentEpoch, pChainHeight, icmEpochInfo, auxInfo)
 }
 
 func (sm *StateMachine) verifyCollectingApprovalsBlock(ctx context.Context, parentBlock *StateMachineBlock, nextBlock *StateMachineBlock, prevBlockSeq uint64) error {
 	prevEpochInfo := parentBlock.Metadata.SimplexEpochInfo
 	nextEpochInfo := nextBlock.Metadata.SimplexEpochInfo
+	parentEpoch := parentBlock.Metadata.SimplexProtocolMetadata.Epoch
 
 	validators, err := sm.GetValidatorSet(prevEpochInfo.NextPChainReferenceHeight)
 	if err != nil {
@@ -1112,7 +1109,7 @@ func (sm *StateMachine) verifyCollectingApprovalsBlock(ctx context.Context, pare
 		timestamp := time.UnixMilli(int64(nextBlock.Metadata.Timestamp))
 		icmEpochInfo := computeICMEpochInfo(parentBlock, sm.ComputeICMEpoch, timestamp)
 
-		return verifyAgainstExpected(ctx, nextBlock.InnerBlock, newSimplexEpochInfo, nextBlock.Metadata.PChainHeight, nextBlock, timestamp, icmEpochInfo, expectedAuxInfo)
+		return verifyAgainstExpected(ctx, nextBlock.InnerBlock, newSimplexEpochInfo, parentEpoch, nextBlock.Metadata.PChainHeight, nextBlock, timestamp, icmEpochInfo, expectedAuxInfo)
 	}
 
 	newSimplexEpochInfo := computeSimplexEpochInfoForCollectingApprovalsBlock(parentBlock, prevBlockSeq, &approvals{
@@ -1136,7 +1133,7 @@ func (sm *StateMachine) verifyCollectingApprovalsBlock(ctx context.Context, pare
 	canSeal := sigAggr.IsQuorum(validators.SelectSubset(approvals))
 
 	if canSeal {
-		newSimplexEpochInfo, err = sm.computeSimplexEpochInfoForSealingBlock(newSimplexEpochInfo)
+		newSimplexEpochInfo, err = sm.computeSimplexEpochInfoForSealingBlock(newSimplexEpochInfo, parentEpoch)
 		if err != nil {
 			return fmt.Errorf("failed to compute simplex epoch info for sealing block: %w", err)
 		}
@@ -1145,7 +1142,7 @@ func (sm *StateMachine) verifyCollectingApprovalsBlock(ctx context.Context, pare
 	timestamp := time.UnixMilli(int64(nextBlock.Metadata.Timestamp))
 	icmEpochInfo := computeICMEpochInfo(parentBlock, sm.ComputeICMEpoch, timestamp)
 
-	return verifyAgainstExpected(ctx, nextBlock.InnerBlock, newSimplexEpochInfo, nextBlock.Metadata.PChainHeight, nextBlock, timestamp, icmEpochInfo, expectedAuxInfo)
+	return verifyAgainstExpected(ctx, nextBlock.InnerBlock, newSimplexEpochInfo, parentEpoch, nextBlock.Metadata.PChainHeight, nextBlock, timestamp, icmEpochInfo, expectedAuxInfo)
 }
 
 func (sm *StateMachine) verifyNextEpochApprovalsSignature(prevMD StateMachineMetadata, nextMD StateMachineMetadata, validators NodeBLSMappings, auxInfoDigest [32]byte) error {
@@ -1223,12 +1220,11 @@ func (sm *StateMachine) aggregatePubKeysForBitmask(nodeIDsBitmask []byte, valida
 }
 
 func computeSimplexEpochInfoForCollectingApprovalsBlock(parentBlock *StateMachineBlock, prevBlockSeq uint64, newApprovals *approvals) SimplexEpochInfo {
-	// The P-chain reference height and epoch number should remain the same until we transition to the new epoch.
+	// The P-chain reference height should remain the same until we transition to the new epoch.
 	// The next P-chain reference height should have been set in the previous block,
 	// which is the reason why we are collecting approvals in the first place.
 	newSimplexEpochInfo := SimplexEpochInfo{
 		PChainReferenceHeight:     parentBlock.Metadata.SimplexEpochInfo.PChainReferenceHeight,
-		EpochNumber:               parentBlock.Metadata.SimplexEpochInfo.EpochNumber,
 		NextPChainReferenceHeight: parentBlock.Metadata.SimplexEpochInfo.NextPChainReferenceHeight,
 		PrevVMBlockSeq:            computePrevVMBlockSeq(parentBlock, prevBlockSeq),
 	}
@@ -1315,17 +1311,20 @@ func (sm *StateMachine) createSealingBlock(ctx context.Context,
 	simplexMetadata common.ProtocolMetadata,
 	simplexBlacklist common.Blacklist,
 	simplexEpochInfo SimplexEpochInfo,
+	epoch uint64,
 	pChainHeight uint64,
 	icmEpochInfo ICMEpochInfo,
 	auxInfo *AuxiliaryInfoBatch) (*StateMachineBlock, error) {
-	simplexEpochInfo, err := sm.computeSimplexEpochInfoForSealingBlock(simplexEpochInfo)
+	simplexEpochInfo, err := sm.computeSimplexEpochInfoForSealingBlock(simplexEpochInfo, epoch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute simplex epoch info for sealing block: %w", err)
 	}
 	return sm.buildBlockImpatiently(ctx, timestamp, simplexMetadata, simplexBlacklist, simplexEpochInfo, pChainHeight, icmEpochInfo, auxInfo)
 }
 
-func (sm *StateMachine) computeSimplexEpochInfoForSealingBlock(simplexEpochInfo SimplexEpochInfo) (SimplexEpochInfo, error) {
+// computeSimplexEpochInfoForSealingBlock completes the epoch info of a sealing block of the given epoch.
+// The epoch number is the sequence of the previous epoch's sealing block, which the new sealing block points to.
+func (sm *StateMachine) computeSimplexEpochInfoForSealingBlock(simplexEpochInfo SimplexEpochInfo, epoch uint64) (SimplexEpochInfo, error) {
 	validators, err := sm.GetValidatorSet(simplexEpochInfo.NextPChainReferenceHeight)
 	if err != nil {
 		return SimplexEpochInfo{}, err
@@ -1335,14 +1334,14 @@ func (sm *StateMachine) computeSimplexEpochInfoForSealingBlock(simplexEpochInfo 
 	}
 	simplexEpochInfo.BlockValidationDescriptor.AggregatedMembership.Members = validators
 
-	prevSealingBlock, finalization, err := sm.GetBlock(simplexEpochInfo.EpochNumber, [32]byte{})
+	prevSealingBlock, finalization, err := sm.GetBlock(epoch, [32]byte{})
 	if err != nil {
-		sm.Logger.Error("Error retrieving previous sealing block", zap.Uint64("seq", simplexEpochInfo.EpochNumber), zap.Error(err))
-		return SimplexEpochInfo{}, fmt.Errorf("failed to retrieve previous sealing InnerBlock at epoch %d: %w", simplexEpochInfo.EpochNumber, err)
+		sm.Logger.Error("Error retrieving previous sealing block", zap.Uint64("seq", epoch), zap.Error(err))
+		return SimplexEpochInfo{}, fmt.Errorf("failed to retrieve previous sealing InnerBlock at epoch %d: %w", epoch, err)
 	}
 	if finalization == nil {
-		sm.Logger.Error("Previous sealing block is not finalized", zap.Uint64("seq", simplexEpochInfo.EpochNumber))
-		return SimplexEpochInfo{}, fmt.Errorf("%w: epoch %d", errPrevSealingBlockNotFinalized, simplexEpochInfo.EpochNumber)
+		sm.Logger.Error("Previous sealing block is not finalized", zap.Uint64("seq", epoch))
+		return SimplexEpochInfo{}, fmt.Errorf("%w: epoch %d", errPrevSealingBlockNotFinalized, epoch)
 	}
 	simplexEpochInfo.PrevSealingBlockHash = prevSealingBlock.Digest()
 
@@ -1358,7 +1357,7 @@ func getCurrentValidatorSet(parentBlock *StateMachineBlock, getBlock BlockRetrie
 		return nil, fmt.Errorf("getCurrentValidatorSet: did not expect block %d to be a sealing block or a Telock",
 			parentBlock.Metadata.SimplexProtocolMetadata.Seq)
 	}
-	epoch := parentBlock.Metadata.SimplexEpochInfo.EpochNumber
+	epoch := parentBlock.Metadata.SimplexProtocolMetadata.Epoch
 	block, finalization, err := getBlock(epoch, [32]byte{}) // The sealing block of the current epoch should be finalized.
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve sealing block %d: %w", epoch, err)
@@ -1428,7 +1427,7 @@ func (sm *StateMachine) areWeReadyToTransitionEpoch(parentBlock *StateMachineBlo
 
 // buildBlockEpochSealed builds a block where the epoch is being sealed due to a sealing block already created in this epoch.
 //
-// Relevant SimplexEpochInfo fields (PCH = PChainReferenceHeight, EN = EpochNumber,
+// Relevant fields (PCH = PChainReferenceHeight, EN = SimplexProtocolMetadata.Epoch,
 // NPCH = NextPChainReferenceHeight, SBS = SealingBlockSeq, BVD = BlockValidationDescriptor):
 //
 //	parent (sealing block)        sealing block NOT finalized      sealing block IS finalized
@@ -1459,19 +1458,16 @@ func (sm *StateMachine) buildBlockEpochSealed(ctx context.Context, parentBlock *
 	}
 
 	// Else, we build a block for the new epoch.
-	newSimplexEpochInfo := computeSimplexEpochInfoForNewEpoch(parentBlock, sealingBlockSeq, prevBlockSeq)
+	newSimplexEpochInfo := computeSimplexEpochInfoForNewEpoch(parentBlock, prevBlockSeq)
 
 	return sm.buildBlockOrTransitionEpoch(ctx, &sealingBlock, simplexMetadata, simplexBlacklist, newSimplexEpochInfo)
-
 }
 
-func computeSimplexEpochInfoForNewEpoch(parentBlock *StateMachineBlock, sealingBlockSeq uint64, prevBlockSeq uint64) SimplexEpochInfo {
+func computeSimplexEpochInfoForNewEpoch(parentBlock *StateMachineBlock, prevBlockSeq uint64) SimplexEpochInfo {
 	newSimplexEpochInfo := SimplexEpochInfo{
 		// P-chain reference height is previous block's NextPChainReferenceHeight.
 		PChainReferenceHeight: parentBlock.Metadata.SimplexEpochInfo.NextPChainReferenceHeight,
-		// The epoch number is the sequence of the sealing block.
-		EpochNumber:    sealingBlockSeq,
-		PrevVMBlockSeq: computePrevVMBlockSeq(parentBlock, prevBlockSeq),
+		PrevVMBlockSeq:        computePrevVMBlockSeq(parentBlock, prevBlockSeq),
 	}
 	return newSimplexEpochInfo
 }
@@ -1479,7 +1475,6 @@ func computeSimplexEpochInfoForNewEpoch(parentBlock *StateMachineBlock, sealingB
 func computeSimplexEpochInfoForTelock(parentBlock *StateMachineBlock, sealingBlockSeq uint64, prevBlockSeq uint64) SimplexEpochInfo {
 	newSimplexEpochInfo := SimplexEpochInfo{
 		PChainReferenceHeight:     parentBlock.Metadata.SimplexEpochInfo.PChainReferenceHeight,
-		EpochNumber:               parentBlock.Metadata.SimplexEpochInfo.EpochNumber,
 		NextPChainReferenceHeight: parentBlock.Metadata.SimplexEpochInfo.NextPChainReferenceHeight,
 		SealingBlockSeq:           sealingBlockSeq,
 		PrevVMBlockSeq:            computePrevVMBlockSeq(parentBlock, prevBlockSeq),
@@ -1500,7 +1495,7 @@ func (sm *StateMachine) verifyBlockEpochSealed(ctx context.Context, parentBlock 
 	newSimplexEpochInfo := computeSimplexEpochInfoForTelock(parentBlock, sealingBlockSeq, prevBlockSeq)
 
 	if !isSealingBlockFinalized {
-		return verifyAgainstExpected(ctx, nil, newSimplexEpochInfo, nextBlock.Metadata.PChainHeight, nextBlock, timestamp, icmEpochInfo, nil)
+		return verifyAgainstExpected(ctx, nil, newSimplexEpochInfo, parentBlock.Metadata.SimplexProtocolMetadata.Epoch, nextBlock.Metadata.PChainHeight, nextBlock, timestamp, icmEpochInfo, nil)
 	}
 
 	bvd := sealingBlock.Metadata.SimplexEpochInfo.BlockValidationDescriptor
@@ -1511,7 +1506,7 @@ func (sm *StateMachine) verifyBlockEpochSealed(ctx context.Context, parentBlock 
 	currentValidatorSet := bvd.AggregatedMembership.Members
 
 	// Else, it's a new epoch.
-	newSimplexEpochInfo = computeSimplexEpochInfoForNewEpoch(parentBlock, sealingBlockSeq, prevBlockSeq)
+	newSimplexEpochInfo = computeSimplexEpochInfoForNewEpoch(parentBlock, prevBlockSeq)
 
 	// The first block of the new epoch may itself transition again, so trust and validate
 	// the proposed pchain height and (optional) next pchain reference height, mirroring
@@ -1528,7 +1523,7 @@ func (sm *StateMachine) verifyBlockEpochSealed(ctx context.Context, parentBlock 
 	}
 	newSimplexEpochInfo.NextPChainReferenceHeight = nextBlock.Metadata.SimplexEpochInfo.NextPChainReferenceHeight
 
-	return verifyAgainstExpected(ctx, nextBlock.InnerBlock, newSimplexEpochInfo, proposedPChainHeight, nextBlock, timestamp, icmEpochInfo, nil)
+	return verifyAgainstExpected(ctx, nextBlock.InnerBlock, newSimplexEpochInfo, sealingBlockSeq, proposedPChainHeight, nextBlock, timestamp, icmEpochInfo, nil)
 }
 
 // computeExpectedAuxInfoForApprovalCollection computes the expected AuxiliaryInfo that should be included in the proposed block
@@ -1624,7 +1619,6 @@ func (sm *StateMachine) buildAuxInfoBatch(history AuxInfoHistory, parentBlock *S
 func constructSimplexZeroBlockSimplexEpochInfo(pChainHeight uint64, newValidatorSet NodeBLSMappings, prevVMBlockSeq uint64) SimplexEpochInfo {
 	newSimplexEpochInfo := SimplexEpochInfo{
 		PChainReferenceHeight: pChainHeight,
-		EpochNumber:           prevVMBlockSeq + 1,
 		// We treat the zero block as a special case, and we encode in it the block validation descriptor,
 		// despite it not actually being a sealing block. This is because the zero block is the first block that introduces the validator set.
 		BlockValidationDescriptor: &BlockValidationDescriptor{

--- a/msm/msm_test.go
+++ b/msm/msm_test.go
@@ -74,9 +74,9 @@ func TestMSMBuildAndVerifyBlocksAfterGenesis(t *testing.T) {
 			name: "wrong epoch number",
 			md:   validMD,
 			mutateBlock: func(block *StateMachineBlock) {
-				block.Metadata.SimplexEpochInfo.EpochNumber = 2
+				block.Metadata.SimplexProtocolMetadata.Epoch = 2
 			},
-			err: errBlockDigestMismatch,
+			err: errInvalidProtocolMetadataEpoch,
 		},
 		{
 			name: "P-chain height too big",
@@ -202,7 +202,6 @@ func TestMSMFirstSimplexBlockAfterPreSimplexBlocks(t *testing.T) {
 			SimplexProtocolMetadata: md,
 			SimplexEpochInfo: SimplexEpochInfo{
 				PChainReferenceHeight: 100,
-				EpochNumber:           43,
 				PrevVMBlockSeq:        42,
 				BlockValidationDescriptor: &BlockValidationDescriptor{
 					AggregatedMembership: AggregatedMembership{
@@ -290,7 +289,7 @@ func TestMSMNormalOp(t *testing.T) {
 		{
 			name: "wrong epoch number",
 			mutateBlock: func(block *StateMachineBlock) {
-				block.Metadata.SimplexEpochInfo.EpochNumber = 2
+				block.Metadata.SimplexProtocolMetadata.Epoch = 2
 			},
 			err: errInvalidProtocolMetadataEpoch,
 		},
@@ -435,7 +434,6 @@ func TestMSMNormalOp(t *testing.T) {
 					SimplexProtocolMetadata: md,
 					SimplexEpochInfo: SimplexEpochInfo{
 						PChainReferenceHeight:     100,
-						EpochNumber:               lastBlock.Metadata.SimplexEpochInfo.EpochNumber,
 						PrevVMBlockSeq:            lastBlock.InnerBlock.Height(),
 						NextPChainReferenceHeight: testCase.expectedNextPChainRefHeight,
 					},
@@ -653,7 +651,6 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 					SimplexProtocolMetadata: md,
 					SimplexEpochInfo: SimplexEpochInfo{
 						PChainReferenceHeight: pChainHeight1,
-						EpochNumber:           testCase.epochNum,
 						PrevVMBlockSeq:        baseSeq,
 						BlockValidationDescriptor: &BlockValidationDescriptor{
 							AggregatedMembership: AggregatedMembership{
@@ -688,7 +685,6 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 					SimplexProtocolMetadata: md,
 					SimplexEpochInfo: SimplexEpochInfo{
 						PChainReferenceHeight: pChainHeight1,
-						EpochNumber:           testCase.epochNum,
 						PrevVMBlockSeq:        baseSeq,
 					},
 					ICMEpochInfo: icmEpoch1,
@@ -718,7 +714,6 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 					SimplexProtocolMetadata: md,
 					SimplexEpochInfo: SimplexEpochInfo{
 						PChainReferenceHeight:     pChainHeight1,
-						EpochNumber:               testCase.epochNum,
 						PrevVMBlockSeq:            baseSeq + 2,
 						NextPChainReferenceHeight: pChainHeight2,
 					},
@@ -757,7 +752,6 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 					SimplexProtocolMetadata: md,
 					SimplexEpochInfo: SimplexEpochInfo{
 						PChainReferenceHeight:     pChainHeight1,
-						EpochNumber:               testCase.epochNum,
 						PrevVMBlockSeq:            baseSeq + 3,
 						NextPChainReferenceHeight: pChainHeight2,
 						NextEpochApprovals: &NextEpochApprovals{
@@ -799,7 +793,6 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 					SimplexProtocolMetadata: md,
 					SimplexEpochInfo: SimplexEpochInfo{
 						PChainReferenceHeight:     pChainHeight1,
-						EpochNumber:               testCase.epochNum,
 						PrevVMBlockSeq:            baseSeq + 4,
 						NextPChainReferenceHeight: pChainHeight2,
 						NextEpochApprovals: &NextEpochApprovals{
@@ -841,7 +834,6 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 					SimplexProtocolMetadata: md,
 					SimplexEpochInfo: SimplexEpochInfo{
 						PChainReferenceHeight:     pChainHeight1,
-						EpochNumber:               testCase.epochNum,
 						PrevVMBlockSeq:            baseSeq + 5,
 						NextPChainReferenceHeight: pChainHeight2,
 						SealingBlockSeq:           0,
@@ -914,7 +906,6 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 								SimplexProtocolMetadata: md,
 								SimplexEpochInfo: SimplexEpochInfo{
 									PChainReferenceHeight:     pChainHeight1,
-									EpochNumber:               testCase.epochNum,
 									NextPChainReferenceHeight: pChainHeight2,
 									PrevVMBlockSeq:            baseSeq + 6,
 									SealingBlockSeq:           sealingSeq,
@@ -929,9 +920,7 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 
 					// ----- Step 7: Build a new epoch block (sealing block is finalized) -----
 
-					// The first block of the new epoch carries the new EpochNumber
-					// (= sealing block's sequence) in both SimplexEpochInfo.EpochNumber
-					// and the protocol metadata's Epoch field.
+					// The first block of the new epoch is numbered after the sealing block's sequence.
 					md.Epoch = sealingSeq
 
 					currentTime = startTime.Add(time.Second + 7*time.Millisecond)
@@ -945,7 +934,6 @@ func TestMSMFullEpochLifecycle(t *testing.T) {
 							SimplexProtocolMetadata: md,
 							SimplexEpochInfo: SimplexEpochInfo{
 								PChainReferenceHeight: pChainHeight2,
-								EpochNumber:           sealingSeq,
 								PrevVMBlockSeq:        baseSeq + 6,
 							},
 							ICMEpochInfo: icmEpoch2,
@@ -964,38 +952,46 @@ func TestIdentifyCurrentState(t *testing.T) {
 	bvd := &BlockValidationDescriptor{}
 	for _, tc := range []struct {
 		name     string
+		epoch    uint64
 		input    SimplexEpochInfo
 		expected state
 	}{
 		{
 			name:     "epoch 0 is first simplex block",
-			input:    SimplexEpochInfo{EpochNumber: 0},
+			epoch:    0,
 			expected: stateFirstSimplexBlock,
 		},
 		{
 			name:     "no next p-chain ref height means normal op",
-			input:    SimplexEpochInfo{EpochNumber: 1, NextPChainReferenceHeight: 0},
+			epoch:    1,
+			input:    SimplexEpochInfo{NextPChainReferenceHeight: 0},
 			expected: stateBuildBlockNormalOp,
 		},
 		{
 			name:     "has sealing block seq means epoch sealed",
-			input:    SimplexEpochInfo{EpochNumber: 1, NextPChainReferenceHeight: 100, SealingBlockSeq: 5},
+			epoch:    1,
+			input:    SimplexEpochInfo{NextPChainReferenceHeight: 100, SealingBlockSeq: 5},
 			expected: stateBuildBlockEpochSealed,
 		},
 		{
 			name:     "has block validation descriptor means epoch sealed",
-			input:    SimplexEpochInfo{EpochNumber: 1, NextPChainReferenceHeight: 100, BlockValidationDescriptor: bvd},
+			epoch:    1,
+			input:    SimplexEpochInfo{NextPChainReferenceHeight: 100, BlockValidationDescriptor: bvd},
 			expected: stateBuildBlockEpochSealed,
 		},
 		{
 			name:     "next p-chain ref height > 0 without sealing means collecting approvals",
-			input:    SimplexEpochInfo{EpochNumber: 1, NextPChainReferenceHeight: 100},
+			epoch:    1,
+			input:    SimplexEpochInfo{NextPChainReferenceHeight: 100},
 			expected: stateBuildCollectingApprovals,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			result := tc.input.NextState()
-			require.Equal(t, tc.expected, result)
+			md := StateMachineMetadata{
+				SimplexProtocolMetadata: common.ProtocolMetadata{Epoch: tc.epoch},
+				SimplexEpochInfo:        tc.input,
+			}
+			require.Equal(t, tc.expected, md.NextState())
 		})
 	}
 }
@@ -1057,9 +1053,9 @@ func TestVerifyNextPChainRefHeightNormal(t *testing.T) {
 	setB := NodeBLSMappings{{BLSKey: []byte{2}, Weight: 1}}
 
 	prevMD := StateMachineMetadata{
+		SimplexProtocolMetadata: common.ProtocolMetadata{Epoch: sealingBlockSeq},
 		SimplexEpochInfo: SimplexEpochInfo{
 			PChainReferenceHeight: prevPChainRefHeight,
-			EpochNumber:           sealingBlockSeq,
 		},
 	}
 
@@ -1071,7 +1067,7 @@ func TestVerifyNextPChainRefHeightNormal(t *testing.T) {
 	}
 
 	// The current validator set is now read from the parent epoch's sealing block, stored at
-	// the parent's EpochNumber. It must carry a validator descriptor and be finalized.
+	// the parent's epoch. It must carry a validator descriptor and be finalized.
 	currentEpochSealingBlock := func(finalized bool) *outerBlock {
 		ob := &outerBlock{block: StateMachineBlock{Metadata: StateMachineMetadata{
 			SimplexEpochInfo: SimplexEpochInfo{
@@ -1550,7 +1546,6 @@ func TestBuildBlockCollectingApprovalsDedupsOwnApprovalAcrossRounds(t *testing.T
 			},
 			SimplexEpochInfo: SimplexEpochInfo{
 				PChainReferenceHeight:     100,
-				EpochNumber:               1,
 				NextPChainReferenceHeight: 200,
 				PrevVMBlockSeq:            parentSeq - 1,
 			},
@@ -1622,14 +1617,13 @@ func TestVerifyCollectingApprovalsNotReady(t *testing.T) {
 				},
 				SimplexEpochInfo: SimplexEpochInfo{
 					PChainReferenceHeight:     pChainRefHeight,
-					EpochNumber:               1,
 					NextPChainReferenceHeight: nextPChainRefHeight,
 					PrevVMBlockSeq:            parentSeq - 1,
 				},
 			},
 		}
 		tc.blockStore[parentSeq] = &outerBlock{block: parent}
-		require.Equal(t, stateBuildCollectingApprovals, parent.Metadata.SimplexEpochInfo.NextState())
+		require.Equal(t, stateBuildCollectingApprovals, parent.Metadata.NextState())
 		return sm, tc, parent
 	}
 
@@ -1727,7 +1721,6 @@ func TestCollectingApprovalsAuxInfoGating(t *testing.T) {
 			},
 			SimplexEpochInfo: SimplexEpochInfo{
 				PChainReferenceHeight:     pChainRefHeight,
-				EpochNumber:               1,
 				NextPChainReferenceHeight: nextPChainRefHeight,
 				PrevVMBlockSeq:            parentSeq - 1,
 			},
@@ -1842,7 +1835,6 @@ func TestVerifyCollectingApprovalsRejectsIllegalAuxInfoBatch(t *testing.T) {
 			},
 			SimplexEpochInfo: SimplexEpochInfo{
 				PChainReferenceHeight:     pChainRefHeight,
-				EpochNumber:               1,
 				NextPChainReferenceHeight: nextPChainRefHeight,
 				PrevVMBlockSeq:            parentSeq - 1,
 			},
@@ -1925,7 +1917,6 @@ func TestCollectingApprovalsAuxInfoVersionIDIsBackwardCompatible(t *testing.T) {
 			},
 			SimplexEpochInfo: SimplexEpochInfo{
 				PChainReferenceHeight:     pChainRefHeight,
-				EpochNumber:               1,
 				NextPChainReferenceHeight: nextPChainRefHeight,
 				PrevVMBlockSeq:            parentSeq - 1,
 			},
@@ -2006,7 +1997,6 @@ func TestCollectingApprovalsIncludesMultipleAuxInfoMessages(t *testing.T) {
 			},
 			SimplexEpochInfo: SimplexEpochInfo{
 				PChainReferenceHeight:     pChainRefHeight,
-				EpochNumber:               1,
 				NextPChainReferenceHeight: nextPChainRefHeight,
 				PrevVMBlockSeq:            parentSeq - 1,
 			},
@@ -2082,15 +2072,19 @@ func TestMSMWaitForPendingBlock(t *testing.T) {
 	defaultSet := NodeBLSMappings{{BLSKey: []byte{1}, Weight: 1}, {BLSKey: []byte{2}, Weight: 1}}
 
 	var (
-		normal     = SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 100}
-		collecting = SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 100, NextPChainReferenceHeight: 200}
-		telock     = SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 100, NextPChainReferenceHeight: 200, SealingBlockSeq: 5}
-		sealing    = SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 100, NextPChainReferenceHeight: 200,
+		normal     = SimplexEpochInfo{PChainReferenceHeight: 100}
+		collecting = SimplexEpochInfo{PChainReferenceHeight: 100, NextPChainReferenceHeight: 200}
+		telock     = SimplexEpochInfo{PChainReferenceHeight: 100, NextPChainReferenceHeight: 200, SealingBlockSeq: 5}
+		sealing    = SimplexEpochInfo{PChainReferenceHeight: 100, NextPChainReferenceHeight: 200,
 			BlockValidationDescriptor: &BlockValidationDescriptor{AggregatedMembership: AggregatedMembership{Members: defaultSet}}, PrevSealingBlockHash: [32]byte{0xaa}}
 	)
 
+	// Every parent below belongs to epoch 1.
 	block := func(sei SimplexEpochInfo, finalized bool) *outerBlock {
-		ob := &outerBlock{block: StateMachineBlock{Metadata: StateMachineMetadata{SimplexEpochInfo: sei}}}
+		ob := &outerBlock{block: StateMachineBlock{Metadata: StateMachineMetadata{
+			SimplexProtocolMetadata: common.ProtocolMetadata{Epoch: 1},
+			SimplexEpochInfo:        sei,
+		}}}
 		if finalized {
 			ob.finalization = &common.Finalization{}
 		}
@@ -2101,10 +2095,12 @@ func TestMSMWaitForPendingBlock(t *testing.T) {
 	zeroBlock := func(set NodeBLSMappings) *outerBlock {
 		return &outerBlock{
 			finalization: &common.Finalization{},
-			block: StateMachineBlock{Metadata: StateMachineMetadata{SimplexEpochInfo: SimplexEpochInfo{
-				EpochNumber:               1,
-				BlockValidationDescriptor: &BlockValidationDescriptor{AggregatedMembership: AggregatedMembership{Members: set}},
-			}}},
+			block: StateMachineBlock{Metadata: StateMachineMetadata{
+				SimplexProtocolMetadata: common.ProtocolMetadata{Epoch: 1},
+				SimplexEpochInfo: SimplexEpochInfo{
+					BlockValidationDescriptor: &BlockValidationDescriptor{AggregatedMembership: AggregatedMembership{Members: set}},
+				},
+			}},
 		}
 	}
 
@@ -2209,7 +2205,7 @@ func TestMSMWaitForPendingBlock(t *testing.T) {
 			// zero block (seq 1); the set at the latest P-chain height differs from it.
 			name:            "normal operation, validator set changed",
 			seq:             3,
-			blocks:          blockStore{1: zeroBlock(defaultSet), 2: block(SimplexEpochInfo{EpochNumber: 1, PChainReferenceHeight: 100}, false)},
+			blocks:          blockStore{1: zeroBlock(defaultSet), 2: block(SimplexEpochInfo{PChainReferenceHeight: 100}, false)},
 			pChainHeight:    200,
 			validatorSets:   map[uint64]NodeBLSMappings{200: {{BLSKey: []byte{9}, Weight: 1}}},
 			returnsOnItsOwn: true,
@@ -2393,7 +2389,7 @@ func TestGetCurrentValidatorSet(t *testing.T) {
 		return &outerBlock{
 			finalization: finalization,
 			block: StateMachineBlock{Metadata: StateMachineMetadata{
-				SimplexEpochInfo: SimplexEpochInfo{EpochNumber: 1, BlockValidationDescriptor: bvd},
+				SimplexEpochInfo: SimplexEpochInfo{BlockValidationDescriptor: bvd},
 			}},
 		}
 	}
@@ -2414,14 +2410,15 @@ func TestGetCurrentValidatorSet(t *testing.T) {
 		return &outerBlock{
 			finalization: finalized,
 			block: StateMachineBlock{Metadata: StateMachineMetadata{
-				SimplexProtocolMetadata: common.ProtocolMetadata{Seq: seq},
-				SimplexEpochInfo:        SimplexEpochInfo{EpochNumber: epoch},
+				SimplexProtocolMetadata: common.ProtocolMetadata{Seq: seq, Epoch: epoch},
 			}},
 		}
 	}
 
 	for _, testCase := range []struct {
 		name string
+		// epoch is the epoch of the block whose validator set is looked up.
+		epoch uint64
 		// parent is the epoch info of the block whose epoch's validator set is looked up.
 		parent SimplexEpochInfo
 		blocks blockStore
@@ -2434,68 +2431,71 @@ func TestGetCurrentValidatorSet(t *testing.T) {
 	}{
 		{
 			name:     "normal block in the first epoch reads the zero block",
-			parent:   SimplexEpochInfo{EpochNumber: 1},
+			epoch:    1,
 			blocks:   blockStore{1: zeroBlock(descriptor(validators), finalized)},
 			expected: validators,
 		},
 		{
 			name:     "the zero block is read even before it is finalized",
-			parent:   SimplexEpochInfo{EpochNumber: 1},
+			epoch:    1,
 			blocks:   blockStore{1: zeroBlock(descriptor(validators), nil)},
 			expected: validators,
 		},
 		{
 			name:     "normal block in a later epoch reads the finalized sealing block",
-			parent:   SimplexEpochInfo{EpochNumber: 10},
+			epoch:    10,
 			blocks:   blockStore{10: sealingBlock(10, descriptor(validators), finalized)},
 			expected: validators,
 		},
 		{
 			name:     "transitioning block reads the sealing block of its epoch",
-			parent:   SimplexEpochInfo{EpochNumber: 10, NextPChainReferenceHeight: 300},
+			epoch:    10,
+			parent:   SimplexEpochInfo{NextPChainReferenceHeight: 300},
 			blocks:   blockStore{10: sealingBlock(10, descriptor(validators), finalized)},
 			expected: validators,
 		},
 		{
 			name:        "sealing block that is not finalized is rejected",
-			parent:      SimplexEpochInfo{EpochNumber: 10},
+			epoch:       10,
 			blocks:      blockStore{10: sealingBlock(10, descriptor(validators), nil)},
 			expectedErr: "sealing block 10 is not finalized",
 		},
 		{
 			name:          "missing epoch block",
-			parent:        SimplexEpochInfo{EpochNumber: 10},
+			epoch:         10,
 			blocks:        blockStore{},
 			expectedErrIs: common.ErrBlockNotFound,
 		},
 		{
 			name:        "sealing block without validators",
-			parent:      SimplexEpochInfo{EpochNumber: 10},
+			epoch:       10,
 			blocks:      blockStore{10: sealingBlock(10, descriptor(nil), finalized)},
 			expectedErr: "block 10 has no validators",
 		},
 		{
 			name:        "epoch block that carries no descriptor",
-			parent:      SimplexEpochInfo{EpochNumber: 10},
+			epoch:       10,
 			blocks:      blockStore{10: normalBlock(10, 1)},
 			expectedErr: "block 10 has no validators",
 		},
 		{
 			name:        "sealing block as parent is rejected",
-			parent:      SimplexEpochInfo{EpochNumber: 1, PrevSealingBlockHash: [32]byte{1}, BlockValidationDescriptor: descriptor(validators)},
+			epoch:       1,
+			parent:      SimplexEpochInfo{PrevSealingBlockHash: [32]byte{1}, BlockValidationDescriptor: descriptor(validators)},
 			blocks:      blockStore{1: zeroBlock(descriptor(validators), finalized)},
 			expectedErr: "did not expect block 20 to be a sealing block or a Telock",
 		},
 		{
 			name:        "Telock as parent is rejected",
-			parent:      SimplexEpochInfo{EpochNumber: 1, SealingBlockSeq: 15},
+			epoch:       1,
+			parent:      SimplexEpochInfo{SealingBlockSeq: 15},
 			blocks:      blockStore{1: zeroBlock(descriptor(validators), finalized)},
 			expectedErr: "did not expect block 20 to be a sealing block or a Telock",
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			parent := &StateMachineBlock{Metadata: StateMachineMetadata{
-				SimplexProtocolMetadata: common.ProtocolMetadata{Seq: 20},
+				SimplexProtocolMetadata: common.ProtocolMetadata{Seq: 20, Epoch: testCase.epoch},
 				SimplexEpochInfo:        testCase.parent,
 			}}
 

--- a/msm/util_test.go
+++ b/msm/util_test.go
@@ -289,7 +289,7 @@ func makeZeroBlock(blocks []StateMachineBlock, validatorSet NodeBLSMappings, rou
 			SimplexProtocolMetadata: common.ProtocolMetadata{
 				Round: round,
 				Seq:   seq,
-				Epoch: epochInfo.EpochNumber,
+				Epoch: seq,
 				Prev:  parent.Digest(),
 			},
 			SimplexEpochInfo: epochInfo,
@@ -304,7 +304,7 @@ func makeNormalSimplexBlock(t *testing.T, index int, blocks []StateMachineBlock,
 	require.NoError(t, err)
 
 	parent := blocks[index-1]
-	epoch := parent.Metadata.SimplexEpochInfo.EpochNumber
+	epoch := parent.Metadata.SimplexProtocolMetadata.Epoch
 
 	return StateMachineBlock{
 		InnerBlock: &InnerBlock{
@@ -323,7 +323,6 @@ func makeNormalSimplexBlock(t *testing.T, index int, blocks []StateMachineBlock,
 			SimplexEpochInfo: SimplexEpochInfo{
 				PrevSealingBlockHash:  [32]byte{},
 				PChainReferenceHeight: 100,
-				EpochNumber:           epoch,
 				PrevVMBlockSeq:        computePrevVMBlockSeq(&parent, uint64(index-1)),
 			},
 		},


### PR DESCRIPTION
The value should always be the same as the value in the protocol metadata, so there is no point in having a duplicate field