### PR TITLE
Remove early return in verify block message

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2413,8 +2413,11 @@ func (e *Epoch) verifyBlockMessageVote(from common.NodeID, md common.BlockHeader
 		return fmt.Errorf("received a finalization from an unknown node %s", from)
 	}
 
-	// Ensure the block was voted on by its block producer:
+	if !md.Equals(&vote.Vote.BlockHeader) {
+		return errors.New("vote block header does not match block header")
+	}
 
+	// Ensure the block was voted on by its block producer:
 	// 1) Verify block digest corresponds to the digest voted on
 	if !bytes.Equal(vote.Vote.Digest[:], md.Digest[:]) {
 		e.Logger.Debug("ToBeSignedVote digest mismatches block digest", zap.Stringer("voteDigest", vote.Vote.Digest),

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -1933,7 +1933,7 @@ func (e *Epoch) handleBlockMessage(message *common.BlockMessage, from common.Nod
 	}
 
 	// Check if we have verified this message in the past:
-	if err := e.VerifyBlockMessageVote(from, md, vote); err != nil {
+	if err := e.verifyBlockMessageVote(from, md, vote); err != nil {
 		return nil
 	}
 
@@ -2405,18 +2405,8 @@ func (e *Epoch) createNotarizedBlockVerificationTask(block common.Block, notariz
 	}
 }
 
-// VerifyBlockMessageVote checks if we have the block in the future messages map.
-// If so, it means we have already verified the vote associated with this proposal.
-// If not, it verifies that the vote corresponds to the block proposed, and that the vote is properly signed.
-func (e *Epoch) VerifyBlockMessageVote(from common.NodeID, md common.BlockHeader, vote common.Vote) error {
-	msgsForRound, exists := e.futureMessages[string(from)][md.Round]
-	if exists && msgsForRound.proposal != nil {
-		bh := msgsForRound.proposal.Block.BlockHeader()
-		if bh.Equals(&md) {
-			return nil
-		}
-	}
-
+// verifyBlockMessageVote verifies that the vote corresponds to the block proposed, and that the vote is properly signed.
+func (e *Epoch) verifyBlockMessageVote(from common.NodeID, md common.BlockHeader, vote common.Vote) error {
 	pk, exists := e.validatorsToPKs[string(vote.Signature.Signer)]
 	if !exists {
 		e.Logger.Debug("Received a finalization from an unknown node", zap.Stringer("NodeID", from))

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2413,17 +2413,12 @@ func (e *Epoch) verifyBlockMessageVote(from common.NodeID, md common.BlockHeader
 		return fmt.Errorf("received a finalization from an unknown node %s", from)
 	}
 
+	// Ensure the block was voted on by its block producer:
+	// 1) Verify block header corresponds to the block header voted on
 	if !md.Equals(&vote.Vote.BlockHeader) {
 		return errors.New("vote block header does not match block header")
 	}
 
-	// Ensure the block was voted on by its block producer:
-	// 1) Verify block digest corresponds to the digest voted on
-	if !bytes.Equal(vote.Vote.Digest[:], md.Digest[:]) {
-		e.Logger.Debug("ToBeSignedVote digest mismatches block digest", zap.Stringer("voteDigest", vote.Vote.Digest),
-			zap.Stringer("blockDigest", md.Digest))
-		return errors.New("vote digest mismatches block digest")
-	}
 	// 2) Verify the vote is properly signed
 	if err := vote.Vote.Verify(vote.Signature.Value, e.Verifier, pk); err != nil {
 		e.Logger.Debug("ToBeSignedVote verification failed", zap.Stringer("NodeID", vote.Signature.Signer), zap.Error(err))

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -2307,7 +2307,7 @@ func TestEpochBlockVoteHeaderMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	mismatched := *vote
-	mismatched.Vote.BlockHeader.Round++
+	mismatched.Vote.Round++
 	require.NoError(t, e.HandleMessage(&Message{
 		BlockMessage: &BlockMessage{Vote: mismatched, Block: block},
 	}, nodes[2]))

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -2251,7 +2251,7 @@ func TestEpochBlockSentTwiceKeepsVerifiedVote(t *testing.T) {
 	t.Cleanup(e.Stop)
 	require.NoError(t, e.Start())
 
-	// nodes[2] leads round 2 and sends its proposal early, so it is buffered as a future message.
+	// nodes[2] leads round 2 and sends its proposal early, so it is stored as a future message.
 	md := e.Metadata()
 	md.Round = 2
 	b, ok := bb.BuildBlock(context.Background(), md, emptyBlacklist)
@@ -2265,8 +2265,7 @@ func TestEpochBlockSentTwiceKeepsVerifiedVote(t *testing.T) {
 	}, nodes[2]))
 	require.False(t, verificationFailed)
 
-	// The same block with a vote that does not verify must be rejected by signature
-	// verification, not waved through because a proposal with this header is buffered.
+	// The same block with a vote that does not verify must be rejected by signature verification
 	forgedVote := Vote{Vote: vote.Vote, Signature: Signature{Signer: nodes[2], Value: forged}}
 	require.NoError(t, e.HandleMessage(&Message{
 		BlockMessage: &BlockMessage{Vote: forgedVote, Block: block},

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -2226,6 +2226,54 @@ func TestEpochVoteSentTwiceKeepsVerifiedVote(t *testing.T) {
 	}
 }
 
+// TestEpochBlockSentTwiceKeepsVerifiedVote ensures a leader re-sending a buffered proposal
+// with different vote signature bytes has that vote verified rather than accepted on the
+// strength of the earlier, identical block header.
+func TestEpochBlockSentTwiceKeepsVerifiedVote(t *testing.T) {
+	bb := testutil.NewTestBlockBuilder()
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+
+	forged := []byte("forged signature")
+
+	conf, _, _ := testutil.DefaultTestNodeEpochConfig(t, nodes[1], testutil.NewNoopComm(nodes), bb)
+	conf.Verifier = &rejectingVerifier{rejected: forged}
+
+	var verificationFailed bool
+	conf.Logger.(*testutil.TestLogger).Intercept(func(entry zapcore.Entry) error {
+		if entry.Message == "ToBeSignedVote verification failed" {
+			verificationFailed = true
+		}
+		return nil
+	})
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	// nodes[2] leads round 2 and sends its proposal early, so it is buffered as a future message.
+	md := e.Metadata()
+	md.Round = 2
+	b, ok := bb.BuildBlock(context.Background(), md, emptyBlacklist)
+	require.True(t, ok)
+	block := b.(Block)
+
+	vote, err := testutil.NewTestVote(block, nodes[2])
+	require.NoError(t, err)
+	require.NoError(t, e.HandleMessage(&Message{
+		BlockMessage: &BlockMessage{Vote: *vote, Block: block},
+	}, nodes[2]))
+	require.False(t, verificationFailed)
+
+	// The same block with a vote that does not verify must be rejected by signature
+	// verification, not waved through because a proposal with this header is buffered.
+	forgedVote := Vote{Vote: vote.Vote, Signature: Signature{Signer: nodes[2], Value: forged}}
+	require.NoError(t, e.HandleMessage(&Message{
+		BlockMessage: &BlockMessage{Vote: forgedVote, Block: block},
+	}, nodes[2]))
+	require.True(t, verificationFailed)
+}
+
 // TestNotarizedNotFinalizedTipCausesEmptyBlockProposal verifies that when the leader
 // has a notarized-but-not-finalized tip and no transactions are available, it proposes
 // an empty block instead of stalling.

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -2273,6 +2273,53 @@ func TestEpochBlockSentTwiceKeepsVerifiedVote(t *testing.T) {
 	require.True(t, verificationFailed)
 }
 
+// TestEpochBlockVoteHeaderMismatch ensures a block message whose vote is for a
+// different block header is dropped, so a later matching proposal is still accepted.
+func TestEpochBlockVoteHeaderMismatch(t *testing.T) {
+	bb := testutil.NewTestBlockBuilder()
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+	conf, _, _ := testutil.DefaultTestNodeEpochConfig(t, nodes[1], testutil.NewNoopComm(nodes), bb)
+
+	var storedFutureBlock, alreadyReceived bool
+	conf.Logger.(*testutil.TestLogger).Intercept(func(entry zapcore.Entry) error {
+		switch entry.Message {
+		case "Got block of a future round":
+			storedFutureBlock = true
+		case "Already received a proposal from this node for the round":
+			alreadyReceived = true
+		}
+		return nil
+	})
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	// nodes[2] leads round 2, so its proposal is stored as a future message.
+	md := e.Metadata()
+	md.Round = 2
+	b, ok := bb.BuildBlock(context.Background(), md, emptyBlacklist)
+	require.True(t, ok)
+	block := b.(Block)
+
+	vote, err := testutil.NewTestVote(block, nodes[2])
+	require.NoError(t, err)
+
+	mismatched := *vote
+	mismatched.Vote.BlockHeader.Round++
+	require.NoError(t, e.HandleMessage(&Message{
+		BlockMessage: &BlockMessage{Vote: mismatched, Block: block},
+	}, nodes[2]))
+	require.False(t, storedFutureBlock)
+
+	require.NoError(t, e.HandleMessage(&Message{
+		BlockMessage: &BlockMessage{Vote: *vote, Block: block},
+	}, nodes[2]))
+	require.True(t, storedFutureBlock)
+	require.False(t, alreadyReceived)
+}
+
 // TestNotarizedNotFinalizedTipCausesEmptyBlockProposal verifies that when the leader
 // has a notarized-but-not-finalized tip and no transactions are available, it proposes
 // an empty block instead of stalling.


### PR DESCRIPTION
the previous check was a slight optimization that said "if a proposal was already sent and is in future messages, don't verify the vote". 

This was broken as noted in #546, because an adversary could just send us a invalid vote and override the valid one. 

IMO the check for future messages doesn't save us much, and is not worth the additional complexity. Best case it saves us one signature verification if a malicious node sends us two blocks for the same round.


Closes #546 