### PR TITLE
Re-request rounds/sequences if buffer is full

### DIFF
--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2188,18 +2188,16 @@ func (e *Epoch) processNotarizedBlock(block common.Block, notarization *common.N
 	task := e.createNotarizedBlockVerificationTask(e.oneTimeVerifier.Wrap(block), *notarization)
 	blockDependency, missingRounds := e.blockDependencies(md)
 
+	e.replicationState.CreateDependencyTasks(blockDependency, md.Seq-1, missingRounds)
+
 	err := e.blockVerificationScheduler.ScheduleTaskWithDependencies(task, md.Seq, blockDependency, missingRounds)
 	if errors.Is(err, common.ErrTooManyPendingVerifications) {
 		e.Logger.Debug("Verification queue is full, re-requesting notarized block", zap.Uint64("round", md.Round))
 		e.replicationState.ResendRoundRequest(md.Round, notarization.QC.Signers())
 		return nil
 	}
-	if err != nil {
-		return err
-	}
 
-	e.replicationState.CreateDependencyTasks(blockDependency, md.Seq-1, missingRounds)
-	return nil
+	return err
 }
 
 func (e *Epoch) createBlockVerificationTask(block common.Block, from common.NodeID, vote common.Vote) func() common.Digest {

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2125,10 +2125,9 @@ func (e *Epoch) processFinalizedBlock(block common.Block, finalization *common.F
 	task := e.createFinalizedBlockVerificationTask(e.oneTimeVerifier.Wrap(block), finalization)
 	err := e.blockVerificationScheduler.ScheduleTaskWithDependencies(task, block.BlockHeader().Seq, blockDependency, []uint64{})
 	if errors.Is(err, common.ErrTooManyPendingVerifications) {
-		// The sequence was already removed from the replication state, so re-request it.
-		// This shouldn't happen since processing a finalized block means its the next sequence to commit
-		// so we should be able to schedule it.
-		e.Logger.Warn("Verification queue is full, re-requesting finalized block", zap.Uint64("seq", block.BlockHeader().Seq))
+		// A full scheduler shouldn't fatal
+		e.Logger.Debug("Dropping finalized block, too many pending verifications",
+			zap.Uint64("seq", block.BlockHeader().Seq), zap.Error(err))
 		e.replicationState.ResendFinalizationRequest(block.BlockHeader().Seq, finalization.QC.Signers())
 		return nil
 	}

--- a/simplex/epoch.go
+++ b/simplex/epoch.go
@@ -2123,7 +2123,16 @@ func (e *Epoch) processFinalizedBlock(block common.Block, finalization *common.F
 
 	// Create a task that will verify the block in the future, after its predecessors have also been verified.
 	task := e.createFinalizedBlockVerificationTask(e.oneTimeVerifier.Wrap(block), finalization)
-	return e.blockVerificationScheduler.ScheduleTaskWithDependencies(task, block.BlockHeader().Seq, blockDependency, []uint64{})
+	err := e.blockVerificationScheduler.ScheduleTaskWithDependencies(task, block.BlockHeader().Seq, blockDependency, []uint64{})
+	if errors.Is(err, common.ErrTooManyPendingVerifications) {
+		// The sequence was already removed from the replication state, so re-request it.
+		// This shouldn't happen since processing a finalized block means its the next sequence to commit
+		// so we should be able to schedule it.
+		e.Logger.Warn("Verification queue is full, re-requesting finalized block", zap.Uint64("seq", block.BlockHeader().Seq))
+		e.replicationState.ResendFinalizationRequest(block.BlockHeader().Seq, finalization.QC.Signers())
+		return nil
+	}
+	return err
 }
 
 // processNotarizedBlock processes a block that has a notarization.
@@ -2179,9 +2188,18 @@ func (e *Epoch) processNotarizedBlock(block common.Block, notarization *common.N
 	task := e.createNotarizedBlockVerificationTask(e.oneTimeVerifier.Wrap(block), *notarization)
 	blockDependency, missingRounds := e.blockDependencies(md)
 
-	e.replicationState.CreateDependencyTasks(blockDependency, md.Seq-1, missingRounds)
+	err := e.blockVerificationScheduler.ScheduleTaskWithDependencies(task, md.Seq, blockDependency, missingRounds)
+	if errors.Is(err, common.ErrTooManyPendingVerifications) {
+		e.Logger.Debug("Verification queue is full, re-requesting notarized block", zap.Uint64("round", md.Round))
+		e.replicationState.ResendRoundRequest(md.Round, notarization.QC.Signers())
+		return nil
+	}
+	if err != nil {
+		return err
+	}
 
-	return e.blockVerificationScheduler.ScheduleTaskWithDependencies(task, md.Seq, blockDependency, missingRounds)
+	e.replicationState.CreateDependencyTasks(blockDependency, md.Seq-1, missingRounds)
+	return nil
 }
 
 func (e *Epoch) createBlockVerificationTask(block common.Block, from common.NodeID, vote common.Vote) func() common.Digest {

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -808,7 +808,7 @@ func TestEpochLeaderEquivocationDoesNotFloodBlockVerification(t *testing.T) {
 }
 
 // TestReplicationRerequestsRoundWhenVerificationQueueIsFull asserts that a replicated notarized block whose
-// verification cannot be scheduled is re-requested rather than dropped, mirroring the finalized case.
+// verification cannot be scheduled is re-requested rather than dropped.
 func TestReplicationRerequestsRoundWhenVerificationQueueIsFull(t *testing.T) {
 	nodes := []NodeID{{1}, {2}, {3}, {4}}
 	comm := &recordingComm{Communication: testutil.NewNoopComm(nodes), SentMessages: make(chan *Message, 100)}
@@ -823,10 +823,10 @@ func TestReplicationRerequestsRoundWhenVerificationQueueIsFull(t *testing.T) {
 	// Hold the verification of the notarized block so every redelivery queues another task behind it.
 	blocks := createBlocks(t, nodes, 1)
 	block := blocks[0].VerifiedBlock.(*testutil.TestBlock)
-	gate := make(chan struct{})
-	openGate := sync.OnceFunc(func() { close(gate) })
-	t.Cleanup(openGate)
-	block.VerificationDelay = gate
+	blockVerification := make(chan struct{})
+	allowVerification := sync.OnceFunc(func() { close(blockVerification) })
+	t.Cleanup(allowVerification)
+	block.VerificationDelay = blockVerification
 	notarization, err := testutil.NewNotarization(conf.Logger, &testutil.TestSignatureAggregator{N: len(nodes)}, block, nodes)
 	require.NoError(t, err)
 	notarizedRound := &Message{ReplicationResponse: &ReplicationResponse{
@@ -843,7 +843,7 @@ func TestReplicationRerequestsRoundWhenVerificationQueueIsFull(t *testing.T) {
 	require.Contains(t, request.Rounds, uint64(0))
 
 	// Once the queue drains the node advances past the notarized round and still commits it.
-	openGate()
+	allowVerification()
 	require.Eventually(t, func() bool { return e.Metadata().Round == 1 }, 5*time.Second, 10*time.Millisecond)
 	require.NoError(t, e.HandleMessage(replicateSeq(blocks[0]), nodes[0]))
 	storage.WaitForBlockCommit(0)

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -814,8 +814,6 @@ func TestReplicationRerequestsRoundWhenVerificationQueueIsFull(t *testing.T) {
 	comm := &recordingComm{Communication: testutil.NewNoopComm(nodes), SentMessages: make(chan *Message, 100)}
 	conf, _, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[2], comm, testutil.NewTestBlockBuilder())
 	conf.ReplicationEnabled = true
-	// Filling the verification queue logs a WARN, which CI treats as a failure.
-	conf.Logger.(*testutil.TestLogger).Silence()
 
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -814,6 +814,8 @@ func TestReplicationRerequestsRoundWhenVerificationQueueIsFull(t *testing.T) {
 	comm := &recordingComm{Communication: testutil.NewNoopComm(nodes), SentMessages: make(chan *Message, 100)}
 	conf, _, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[2], comm, testutil.NewTestBlockBuilder())
 	conf.ReplicationEnabled = true
+	// Filling the verification queue logs a WARN, which CI treats as a failure.
+	conf.Logger.(*testutil.TestLogger).Silence()
 
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -807,6 +807,48 @@ func TestEpochLeaderEquivocationDoesNotFloodBlockVerification(t *testing.T) {
 		"a leader must not get more than one proposal verified for the same round")
 }
 
+// TestReplicationRerequestsRoundWhenVerificationQueueIsFull asserts that a replicated notarized block whose
+// verification cannot be scheduled is re-requested rather than dropped, mirroring the finalized case.
+func TestReplicationRerequestsRoundWhenVerificationQueueIsFull(t *testing.T) {
+	nodes := []NodeID{{1}, {2}, {3}, {4}}
+	comm := &recordingComm{Communication: testutil.NewNoopComm(nodes), SentMessages: make(chan *Message, 100)}
+	conf, _, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[2], comm, testutil.NewTestBlockBuilder())
+	conf.ReplicationEnabled = true
+
+	e, err := NewEpoch(conf)
+	require.NoError(t, err)
+	t.Cleanup(e.Stop)
+	require.NoError(t, e.Start())
+
+	// Hold the verification of the notarized block so every redelivery queues another task behind it.
+	blocks := createBlocks(t, nodes, 1)
+	block := blocks[0].VerifiedBlock.(*testutil.TestBlock)
+	gate := make(chan struct{})
+	openGate := sync.OnceFunc(func() { close(gate) })
+	t.Cleanup(openGate)
+	block.VerificationDelay = gate
+	notarization, err := testutil.NewNotarization(conf.Logger, &testutil.TestSignatureAggregator{N: len(nodes)}, block, nodes)
+	require.NoError(t, err)
+	notarizedRound := &Message{ReplicationResponse: &ReplicationResponse{
+		Data: []QuorumRound{{Block: block, Notarization: &notarization}},
+	}}
+
+	// Redeliver until the queue is full and the node re-requests the round instead of scheduling it.
+	for i := 0; len(comm.SentMessages) == 0; i++ {
+		require.Less(t, i, DefaultProcessingBlocks+2)
+		require.NoError(t, e.HandleMessage(notarizedRound, nodes[0]))
+	}
+	request := (<-comm.SentMessages).ReplicationRequest
+	require.NotNil(t, request)
+	require.Contains(t, request.Rounds, uint64(0))
+
+	// Once the queue drains the node advances past the notarized round and still commits it.
+	openGate()
+	require.Eventually(t, func() bool { return e.Metadata().Round == 1 }, 5*time.Second, 10*time.Millisecond)
+	require.NoError(t, e.HandleMessage(replicateSeq(blocks[0]), nodes[0]))
+	storage.WaitForBlockCommit(0)
+}
+
 // TestEpochIncreasesRoundAfterFinalization ensures that the epochs round is incremented
 // if we receive a finalization for the current round(even if it is not the next seq to commit)
 func TestEpochIncreasesRoundAfterFinalization(t *testing.T) {

--- a/simplex/epoch_test.go
+++ b/simplex/epoch_test.go
@@ -814,6 +814,8 @@ func TestReplicationRerequestsRoundWhenVerificationQueueIsFull(t *testing.T) {
 	comm := &recordingComm{Communication: testutil.NewNoopComm(nodes), SentMessages: make(chan *Message, 100)}
 	conf, _, storage := testutil.DefaultTestNodeEpochConfig(t, nodes[2], comm, testutil.NewTestBlockBuilder())
 	conf.ReplicationEnabled = true
+	// Filling the queue logs a WARN, which fails CI.
+	conf.Logger.(*testutil.TestLogger).Silence()
 
 	e, err := NewEpoch(conf)
 	require.NoError(t, err)

--- a/simplex/replication_state.go
+++ b/simplex/replication_state.go
@@ -238,6 +238,20 @@ func (r *ReplicationState) ResendFinalizationRequest(seq uint64, signers []commo
 	r.finalizationRequestor.sendRequestToNode([]uint64{seq}, signers[index])
 }
 
+// ResendRoundRequest notifies the replication state that `round` should be re-requested.
+func (r *ReplicationState) ResendRoundRequest(round uint64, signers []common.NodeID) {
+	if !r.enabled {
+		return
+	}
+
+	signers = common.NodeIDs(signers).Remove(r.myNodeID)
+	numSigners := int64(len(signers))
+	index := r.rand.Int64N(numSigners)
+
+	r.DeleteRound(round)
+	r.roundRequestor.sendRequestToNode([]uint64{round}, signers[index])
+}
+
 // CreateDependencyTasks creates tasks to refetch the given parent digest and empty rounds. If there are no
 // dependencies, no tasks are created.
 func (r *ReplicationState) CreateDependencyTasks(parent *common.Digest, parentSeq uint64, emptyRounds []uint64) {


### PR DESCRIPTION
Shouldn't happen for finalized blocks which is why I used a warning log, but more probable for notarized blocks. 

Closes #542 
