### PR TITLE
Ensure chain doesn't halt when processing Telocks 

### DIFF
--- a/nonvalidator/non_validator.go
+++ b/nonvalidator/non_validator.go
@@ -378,19 +378,32 @@ func (n *NonValidator) handleFinalization(finalization *common.Finalization, fro
 
 	// Duplicate finalization received.
 	if incomplete.finalization != nil {
+		stored := incomplete.finalization.Finalization
+		// We can have two different finalizations for the same sequence.
+		// A telock for a lower epoch, and a finalization in the next epoch.
+		switch {
+		// finalizations are the same
+		case bytes.Equal(stored.Bytes(), finalization.Finalization.Bytes()):
+			return nil
 		// sanity check: should never happen.
-		if !bytes.Equal(incomplete.finalization.Finalization.Bytes(), finalization.Finalization.Bytes()) {
+		case stored.Epoch == bh.Epoch:
 			n.Logger.Warn(
 				"Mismatching finalizations",
 				zap.Uint64("Incoming Sequence", finalization.Finalization.Seq),
-				zap.Uint64("Stored sequence", incomplete.finalization.Finalization.Seq),
+				zap.Uint64("Stored sequence", stored.Seq),
 			)
 			errConflictingFinalizations := fmt.Errorf("conflicting finalizations. seq: %d", bh.Seq)
 			n.haltedError = errConflictingFinalizations
 			return errConflictingFinalizations
+		// the finalization we received was for a telock
+		case bh.Epoch < stored.Epoch:
+			n.Logger.Debug("Received a Telock finalization", zap.Uint64("Epoch", bh.Epoch), zap.Uint64("Seq", bh.Seq), zap.Stringer("From", from))
+			return nil
 		}
-
-		return nil
+		// The current finalization in incompleteSequences belongs to a Telock
+		n.Logger.Debug("Dropping stored Telock sequence", zap.Stringer("Sequence", incomplete))
+		incomplete.block = nil
+		n.sequenceReplicator.ReceivedFutureFinalization(finalization, n.nextSeqToCommit())
 	}
 
 	incomplete.finalization = finalization
@@ -409,6 +422,7 @@ func (n *NonValidator) handleFinalization(finalization *common.Finalization, fro
 			zap.Stringer("From", from),
 		)
 
+		incomplete.block = nil
 		n.sequenceReplicator.ReceivedFutureFinalization(finalization, n.nextSeqToCommit())
 		return nil
 	}
@@ -535,6 +549,20 @@ func (n *NonValidator) storeQuorumRound(qr *common.QuorumRound) {
 		n.Logger.Debug("Received a quorum round from a sequence too far ahead", zap.Uint64("Next Seq To Commit", nextSeqToCommit), zap.Uint64("Block Sequence", seq))
 		n.sequenceReplicator.ReceivedFutureFinalization(qr.Finalization, nextSeqToCommit)
 		return
+	}
+
+	// A Telock and the first block of the next epoch share a seq. The lower epoch is the Telock.
+	if _, stored, exists := n.sequenceReplicator.GetFinalizedBlockForSequence(seq); exists {
+		storedEpoch := stored.Finalization.Epoch
+		epoch := qr.Finalization.Finalization.Epoch
+		if epoch < storedEpoch {
+			n.Logger.Debug("Received a Telock quorum round", zap.Uint64("Epoch", epoch), zap.Uint64("Seq", seq))
+			return
+		}
+		if epoch > storedEpoch {
+			n.Logger.Debug("Dropping stored Telock quorum round", zap.Uint64("Epoch", storedEpoch), zap.Uint64("Seq", seq))
+			n.sequenceReplicator.DeleteSeq(seq)
+		}
 	}
 
 	n.sequenceReplicator.StoreQuorumRound(qr)

--- a/nonvalidator/non_validator_test.go
+++ b/nonvalidator/non_validator_test.go
@@ -227,6 +227,87 @@ func TestHandleMessages(t *testing.T) {
 			},
 			expectedHeight: 8,
 		},
+		{
+			name: "telock finalization after the sealing block is dropped",
+			setup: func(t *testing.T) (*testChain, []*messageInfo) {
+				tc := newSeededChain(t, testNodes, 2)
+				epoch3Nodes := common.Nodes{
+					{Id: common.NodeID{1}, Weight: 1},
+					{Id: common.NodeID{2}, Weight: 1},
+					{Id: common.NodeID{3}, Weight: 1},
+					{Id: common.NodeID{4}, Weight: 1},
+					{Id: common.NodeID{5}, Weight: 1},
+				}
+
+				b3 := tc.appendSealing(epoch3Nodes)
+				// The Telock extends epoch 1 past the sealing block and shares seq 4 with the first block of epoch 3.
+				telock := newBlock(4, 1, b3.Digest)
+				b4 := tc.appendBlock()
+
+				return tc, []*messageInfo{
+					blockMsg(t, b3, testNodes),
+					finalizationMsg(t, b3, testNodes),
+					finalizationMsg(t, telock, testNodes),
+					finalizationMsg(t, b4, epoch3Nodes),
+					blockMsg(t, b4, epoch3Nodes),
+				}
+			},
+			expectedHeight: 5,
+		},
+		{
+			name: "telock finalization before the sealing block is dropped",
+			setup: func(t *testing.T) (*testChain, []*messageInfo) {
+				tc := newSeededChain(t, testNodes, 2)
+				epoch3Nodes := common.Nodes{
+					{Id: common.NodeID{1}, Weight: 1},
+					{Id: common.NodeID{2}, Weight: 1},
+					{Id: common.NodeID{3}, Weight: 1},
+					{Id: common.NodeID{4}, Weight: 1},
+					{Id: common.NodeID{5}, Weight: 1},
+				}
+
+				b3 := tc.appendSealing(epoch3Nodes)
+				telock := newBlock(4, 1, b3.Digest)
+				b4 := tc.appendBlock()
+
+				// The Telock finalization is stored before epoch 3 is known and must be purged once it is.
+				return tc, []*messageInfo{
+					finalizationMsg(t, telock, testNodes),
+					blockMsg(t, b3, testNodes),
+					finalizationMsg(t, b3, testNodes),
+					finalizationMsg(t, b4, epoch3Nodes),
+					blockMsg(t, b4, epoch3Nodes),
+				}
+			},
+			expectedHeight: 5,
+		},
+		{
+			name: "telock block before the sealing block is dropped",
+			setup: func(t *testing.T) (*testChain, []*messageInfo) {
+				tc := newSeededChain(t, testNodes, 2)
+				epoch3Nodes := common.Nodes{
+					{Id: common.NodeID{1}, Weight: 1},
+					{Id: common.NodeID{2}, Weight: 1},
+					{Id: common.NodeID{3}, Weight: 1},
+					{Id: common.NodeID{4}, Weight: 1},
+					{Id: common.NodeID{5}, Weight: 1},
+				}
+
+				b3 := tc.appendSealing(epoch3Nodes)
+				telock := newBlock(4, 1, b3.Digest)
+				b4 := tc.appendBlock()
+
+				// A stored Telock block would otherwise make the epoch 3 block at seq 4 look like a duplicate.
+				return tc, []*messageInfo{
+					blockMsg(t, telock, testNodes),
+					blockMsg(t, b3, testNodes),
+					finalizationMsg(t, b3, testNodes),
+					finalizationMsg(t, b4, epoch3Nodes),
+					blockMsg(t, b4, epoch3Nodes),
+				}
+			},
+			expectedHeight: 5,
+		},
 	}
 
 	for _, tt := range tests {
@@ -252,6 +333,63 @@ func TestHandleMessages(t *testing.T) {
 
 			tc.WaitForBlockCommit(tt.expectedHeight - 1)
 			require.Equal(t, tt.expectedHeight, nv.Storage.NumBlocks())
+		})
+	}
+}
+
+// TestNonValidatorDropsTelockQuorumRound replicates a Telock and the next epoch's block
+// for the same seq in both orders and asserts the next epoch's block is the one indexed.
+func TestNonValidatorDropsTelockQuorumRound(t *testing.T) {
+	tests := []struct {
+		name        string
+		telockFirst bool
+	}{
+		{name: "telock quorum round first", telockFirst: true},
+		{name: "telock quorum round last", telockFirst: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := newSeededChain(t, testNodes, 2)
+			epoch3Nodes := common.Nodes{
+				{Id: common.NodeID{1}, Weight: 1},
+				{Id: common.NodeID{2}, Weight: 1},
+				{Id: common.NodeID{3}, Weight: 1},
+				{Id: common.NodeID{4}, Weight: 1},
+				{Id: common.NodeID{5}, Weight: 1},
+			}
+
+			b3 := tc.appendSealing(epoch3Nodes)
+			telock := newBlock(4, 1, b3.Digest)
+			b4 := tc.appendBlock()
+			f3, fTelock, f4 := tc.newFinalization(b3), tc.newFinalization(telock), tc.newFinalization(b4)
+
+			nv, err := NewNonValidator(Config{
+				Storage:                    tc,
+				Comm:                       testutil.NewNoopComm(tc.nodes().NodeIDs()),
+				Logger:                     testutil.MakeLogger(t, 1),
+				SignatureAggregatorCreator: tc.signatureAggregatorCreator,
+				MaxSequenceWindow:          simplex.DefaultMaxRoundWindow,
+				ID:                         testNodes[0].Id,
+			})
+			require.NoError(t, err)
+			defer nv.Stop()
+
+			telockQR := common.QuorumRound{Block: telock, Finalization: &fTelock}
+			b4QR := common.QuorumRound{Block: b4, Finalization: &f4}
+			data := []common.QuorumRound{{Block: b3, Finalization: &f3}, telockQR, b4QR}
+			if !tt.telockFirst {
+				data = []common.QuorumRound{{Block: b3, Finalization: &f3}, b4QR, telockQR}
+			}
+
+			require.NoError(t, nv.HandleMessage(
+				&common.Message{ReplicationResponse: &common.ReplicationResponse{Data: data}},
+				testNodes.NodeIDs()[1],
+			))
+
+			indexed := tc.WaitForBlockCommit(4)
+			require.Equal(t, b4.BlockHeader().Digest, indexed.BlockHeader().Digest)
+			require.Equal(t, uint64(5), tc.NumBlocks())
 		})
 	}
 }


### PR DESCRIPTION
The non-validator is not aware of Telocks. It only knows about the `VerifiedBlock` & `Block` apis defined in `common` package. The non-validator was running of the assumption that the same sequence could not have two different finalizations. It would halt the non-validator as a defensive check if it ever noticed that.

This PR ensures that the non-validator does not halt the chain if the two finalizations are different and one of them is a telock. Instead, it drops the telock and requests the actual finalization which will always be for the higher epoch.

Closes #545 